### PR TITLE
feat(chunker): 宣言チャンクへのコメント付与と Rust use 宣言パース

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "yomu"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "clap",
  "ignore",

--- a/src/indexer/chunker/mod.rs
+++ b/src/indexer/chunker/mod.rs
@@ -64,7 +64,7 @@ pub fn chunk_file(source: &str, extension: &str) -> FileChunks {
     match extension {
         "tsx" | "jsx" => ts::chunk_tsx(source),
         "ts" | "js" | "mjs" => ts::chunk_ts(source),
-        "rs" => FileChunks::chunks_only(rust::chunk_rust(source)),
+        "rs" => rust::chunk_rust(source),
         "css" => FileChunks::chunks_only(css_html::chunk_css(source)),
         "html" => FileChunks::chunks_only(css_html::chunk_html(source)),
         "md" => FileChunks::chunks_only(markdown::chunk_markdown(source)),
@@ -144,6 +144,24 @@ fn chunk_fallback(source: &str) -> Vec<RawChunk> {
     }
 
     chunks
+}
+
+pub(super) fn attach_pending_comments(
+    chunk: &mut RawChunk,
+    pending_comments: &mut Vec<tree_sitter::Node>,
+    source: &str,
+) {
+    if pending_comments.is_empty() {
+        return;
+    }
+    let comment_text: String = pending_comments
+        .iter()
+        .map(|c| &source[c.byte_range()])
+        .collect::<Vec<_>>()
+        .join("\n");
+    chunk.start_line = pending_comments[0].start_position().row as u32 + 1;
+    chunk.content = format!("{comment_text}\n{}", chunk.content);
+    pending_comments.clear();
 }
 
 fn other_or_skip(source: &str, node: &tree_sitter::Node) -> Option<RawChunk> {

--- a/src/indexer/chunker/rust.rs
+++ b/src/indexer/chunker/rust.rs
@@ -1,12 +1,54 @@
 use crate::storage::ChunkType;
 
-use super::{chunk_fallback, chunk_with_ast, extract_name, make_chunk, make_parser, other_or_skip, RawChunk};
+use super::{
+    attach_pending_comments, chunk_fallback, extract_name, make_chunk, make_parser, other_or_skip,
+    FileChunks, ImportKind, ImportSpecifier, ParsedImport, RawChunk,
+};
 
-pub(super) fn chunk_rust(source: &str) -> Vec<RawChunk> {
+pub(super) fn chunk_rust(source: &str) -> FileChunks {
     let Some(mut parser) = make_parser(&tree_sitter_rust::LANGUAGE.into()) else {
-        return chunk_fallback(source);
+        return FileChunks::chunks_only(chunk_fallback(source));
     };
-    chunk_with_ast(source, &mut parser, classify_rust_node)
+    let Some(tree) = parser.parse(source, None) else {
+        tracing::warn!("AST parse failed, using fallback chunker");
+        return FileChunks::chunks_only(chunk_fallback(source));
+    };
+    let root = tree.root_node();
+    let mut imports = Vec::new();
+    let mut parsed_imports = Vec::new();
+    let mut chunks = Vec::new();
+    let mut pending_comments: Vec<tree_sitter::Node> = Vec::new();
+    let mut cursor = root.walk();
+    for node in root.children(&mut cursor) {
+        match node.kind() {
+            "use_declaration" => {
+                imports.push(source[node.byte_range()].to_string());
+                if let Some(pi) = parse_rust_use(&node, source) {
+                    parsed_imports.push(pi);
+                }
+                pending_comments.clear();
+            }
+            "line_comment" | "block_comment" => {
+                pending_comments.push(node);
+            }
+            _ => {
+                if let Some(mut chunk) = classify_rust_node(&node, source) {
+                    attach_pending_comments(&mut chunk, &mut pending_comments, source);
+                    chunks.push(chunk);
+                } else {
+                    pending_comments.clear();
+                }
+            }
+        }
+    }
+    if chunks.is_empty() {
+        chunks = chunk_fallback(source);
+    }
+    FileChunks {
+        imports,
+        parsed_imports,
+        chunks,
+    }
 }
 
 fn classify_rust_node(node: &tree_sitter::Node, source: &str) -> Option<RawChunk> {
@@ -19,11 +61,139 @@ fn classify_rust_node(node: &tree_sitter::Node, source: &str) -> Option<RawChunk
             let name = extract_rust_impl_name(node, source);
             return Some(make_chunk(source, node, ChunkType::RustImpl, name));
         }
-        "use_declaration" | "line_comment" | "block_comment" => return None,
         _ => return other_or_skip(source, node),
     };
     let name = extract_name(node, source);
     Some(make_chunk(source, node, chunk_type, name))
+}
+
+fn parse_rust_use(node: &tree_sitter::Node, source: &str) -> Option<ParsedImport> {
+    let argument = node.child_by_field_name("argument")?;
+    match argument.kind() {
+        "scoped_identifier" => parse_scoped_identifier(&argument, source),
+        "scoped_use_list" => parse_scoped_use_list(&argument, source),
+        "use_wildcard" => parse_use_wildcard(&argument, source),
+        "use_as_clause" => parse_use_as_clause(&argument, source),
+        _ => None,
+    }
+}
+
+fn parse_scoped_identifier(node: &tree_sitter::Node, source: &str) -> Option<ParsedImport> {
+    let path_node = node.child_by_field_name("path")?;
+    let name_node = node.child_by_field_name("name")?;
+    let path = &source[path_node.byte_range()];
+    if !is_internal_path(path) {
+        return None;
+    }
+    Some(ParsedImport {
+        source: path.to_string(),
+        specifiers: vec![ImportSpecifier {
+            name: source[name_node.byte_range()].to_string(),
+            alias: None,
+            kind: ImportKind::Named,
+        }],
+    })
+}
+
+fn parse_scoped_use_list(node: &tree_sitter::Node, source: &str) -> Option<ParsedImport> {
+    let path_node = node.child_by_field_name("path")?;
+    let list_node = node.child_by_field_name("list")?;
+    let path = &source[path_node.byte_range()];
+    if !is_internal_path(path) {
+        return None;
+    }
+    let specifiers = collect_use_list_specifiers(&list_node, source);
+    Some(ParsedImport {
+        source: path.to_string(),
+        specifiers,
+    })
+}
+
+fn parse_use_wildcard(node: &tree_sitter::Node, source: &str) -> Option<ParsedImport> {
+    let mut cursor = node.walk();
+    let path_node = node.children(&mut cursor).find(|c| c.is_named())?;
+    let path = &source[path_node.byte_range()];
+    if !is_internal_path(path) {
+        return None;
+    }
+    Some(ParsedImport {
+        source: path.to_string(),
+        specifiers: vec![ImportSpecifier {
+            name: "*".to_string(),
+            alias: None,
+            kind: ImportKind::Namespace,
+        }],
+    })
+}
+
+fn parse_use_as_clause(node: &tree_sitter::Node, source: &str) -> Option<ParsedImport> {
+    let path_node = node.child_by_field_name("path")?;
+    let alias_node = node.child_by_field_name("alias")?;
+    if path_node.kind() == "scoped_identifier" {
+        let inner_path = path_node.child_by_field_name("path")?;
+        let inner_name = path_node.child_by_field_name("name")?;
+        let path = &source[inner_path.byte_range()];
+        if !is_internal_path(path) {
+            return None;
+        }
+        Some(ParsedImport {
+            source: path.to_string(),
+            specifiers: vec![ImportSpecifier {
+                name: source[inner_name.byte_range()].to_string(),
+                alias: Some(source[alias_node.byte_range()].to_string()),
+                kind: ImportKind::Named,
+            }],
+        })
+    } else {
+        None
+    }
+}
+
+fn collect_use_list_specifiers(
+    list: &tree_sitter::Node,
+    source: &str,
+) -> Vec<ImportSpecifier> {
+    let mut specifiers = Vec::new();
+    let mut cursor = list.walk();
+    for child in list.children(&mut cursor) {
+        match child.kind() {
+            "identifier" => {
+                specifiers.push(ImportSpecifier {
+                    name: source[child.byte_range()].to_string(),
+                    alias: None,
+                    kind: ImportKind::Named,
+                });
+            }
+            "scoped_identifier" => {
+                if let Some(name_node) = child.child_by_field_name("name") {
+                    specifiers.push(ImportSpecifier {
+                        name: source[name_node.byte_range()].to_string(),
+                        alias: None,
+                        kind: ImportKind::Named,
+                    });
+                }
+            }
+            "scoped_use_list" => {
+                if let Some(inner_list) = child.child_by_field_name("list") {
+                    specifiers.extend(collect_use_list_specifiers(&inner_list, source));
+                }
+            }
+            "use_wildcard" => {
+                specifiers.push(ImportSpecifier {
+                    name: "*".to_string(),
+                    alias: None,
+                    kind: ImportKind::Namespace,
+                });
+            }
+            _ => {}
+        }
+    }
+    specifiers
+}
+
+fn is_internal_path(path: &str) -> bool {
+    let prefix = path.split("::").next().unwrap_or("");
+    matches!(prefix, "crate" | "super" | "self")
 }
 
 fn extract_rust_impl_name(node: &tree_sitter::Node, source: &str) -> Option<String> {

--- a/src/indexer/chunker/tests.rs
+++ b/src/indexer/chunker/tests.rs
@@ -378,12 +378,18 @@ fn parse_aliased_named_import() {
 }
 
 #[test]
-fn chunk_rust_function() {
-    let source = "fn hello() { println!(\"hello\"); }";
-    let result = chunk_file(source, "rs");
-    assert_eq!(result.chunks.len(), 1);
-    assert_eq!(result.chunks[0].chunk_type, ChunkType::RustFn);
-    assert_eq!(result.chunks[0].name.as_deref(), Some("hello"));
+fn chunk_rust_function_variants() {
+    let cases = [
+        ("fn hello() { println!(\"hello\"); }", "hello"),
+        ("pub fn greet() { println!(\"hi\"); }", "greet"),
+        ("async fn fetch() { todo!() }", "fetch"),
+    ];
+    for (source, expected_name) in cases {
+        let result = chunk_file(source, "rs");
+        assert_eq!(result.chunks.len(), 1, "source: {source}");
+        assert_eq!(result.chunks[0].chunk_type, ChunkType::RustFn, "source: {source}");
+        assert_eq!(result.chunks[0].name.as_deref(), Some(expected_name), "source: {source}");
+    }
 }
 
 #[test]
@@ -433,7 +439,7 @@ fn chunk_rust_impl_trait() {
 }
 
 #[test]
-fn chunk_rust_skips_use_and_comments() {
+fn chunk_rust_use_and_comment_do_not_produce_separate_chunks() {
     let source = r#"
 use std::fmt::Display;
 // A helper function
@@ -460,24 +466,6 @@ fn baz() {}
 }
 
 #[test]
-fn chunk_rust_pub_fn() {
-    let source = "pub fn greet() { println!(\"hi\"); }";
-    let result = chunk_file(source, "rs");
-    assert_eq!(result.chunks.len(), 1);
-    assert_eq!(result.chunks[0].chunk_type, ChunkType::RustFn);
-    assert_eq!(result.chunks[0].name.as_deref(), Some("greet"));
-}
-
-#[test]
-fn chunk_rust_async_fn() {
-    let source = "async fn fetch() { todo!() }";
-    let result = chunk_file(source, "rs");
-    assert_eq!(result.chunks.len(), 1);
-    assert_eq!(result.chunks[0].chunk_type, ChunkType::RustFn);
-    assert_eq!(result.chunks[0].name.as_deref(), Some("fetch"));
-}
-
-#[test]
 fn chunk_rust_impl_generic() {
     let source = "impl<T> From<T> for Wrapper<T> { fn from(val: T) -> Self { Wrapper(val) } }";
     let result = chunk_file(source, "rs");
@@ -489,7 +477,7 @@ fn chunk_rust_impl_generic() {
 }
 
 #[test]
-fn chunk_rust_skips_block_comment() {
+fn chunk_rust_block_comment_does_not_produce_separate_chunk() {
     let source = r#"
 /* This is a block comment */
 fn only_fn() {}
@@ -646,6 +634,263 @@ fn chunk_markdown_empty_title_produces_nameless_section() {
     assert_eq!(result.chunks.len(), 1);
     assert_eq!(result.chunks[0].chunk_type, ChunkType::MdSection);
     assert_eq!(result.chunks[0].name, None);
+}
+
+#[test]
+fn chunk_tsx_jsdoc_attached_to_function() {
+    let source = r#"/** Manages authentication state */
+export function useAuth() { return { user: null }; }"#;
+    let result = chunk_file(source, "tsx");
+    assert_eq!(result.chunks.len(), 1);
+    assert!(
+        result.chunks[0].content.contains("/** Manages authentication state */"),
+        "JSDoc should be attached to the chunk"
+    );
+    assert_eq!(result.chunks[0].start_line, 1);
+}
+
+#[test]
+fn chunk_tsx_line_comment_attached_to_function() {
+    let source = r#"// Helper to format dates
+function formatDate() { return '2024-01-01'; }"#;
+    let result = chunk_file(source, "tsx");
+    assert_eq!(result.chunks.len(), 1);
+    assert!(
+        result.chunks[0].content.contains("// Helper to format dates"),
+        "Line comment should be attached to the chunk"
+    );
+}
+
+#[test]
+fn chunk_tsx_consecutive_comments_attached() {
+    let source = r#"// Line 1
+// Line 2
+function helper() { return 42; }"#;
+    let result = chunk_file(source, "tsx");
+    assert_eq!(result.chunks.len(), 1);
+    assert!(
+        result.chunks[0].content.contains("// Line 1"),
+        "First comment should be attached"
+    );
+    assert!(
+        result.chunks[0].content.contains("// Line 2"),
+        "Second comment should be attached"
+    );
+}
+
+#[test]
+fn chunk_tsx_standalone_comment_discarded() {
+    let source = r#"// Standalone comment
+import { useState } from 'react';
+function App() { return <div/>; }"#;
+    let result = chunk_file(source, "tsx");
+    assert_eq!(result.chunks.len(), 1);
+    assert!(
+        !result.chunks[0].content.contains("Standalone"),
+        "Comment before import should not attach to later declaration"
+    );
+}
+
+#[test]
+fn chunk_tsx_comment_between_declarations() {
+    let source = r#"function first() { return 1; }
+/** Second function docs */
+function second() { return 2; }"#;
+    let result = chunk_file(source, "tsx");
+    assert_eq!(result.chunks.len(), 2);
+    assert!(
+        !result.chunks[0].content.contains("Second function docs"),
+        "Comment should not attach to preceding declaration"
+    );
+    assert!(
+        result.chunks[1].content.contains("/** Second function docs */"),
+        "Comment should attach to following declaration"
+    );
+}
+
+#[test]
+fn chunk_rust_doc_comment_attached_to_fn() {
+    let source = "/// Docs for helper\nfn helper() {}";
+    let result = chunk_file(source, "rs");
+    assert_eq!(result.chunks.len(), 1);
+    assert!(
+        result.chunks[0].content.contains("/// Docs for helper"),
+        "doc comment should be attached"
+    );
+    assert_eq!(result.chunks[0].start_line, 1);
+}
+
+#[test]
+fn chunk_rust_block_comment_attached_to_struct() {
+    let source = "/* Info about Config */\nstruct Config { x: i32 }";
+    let result = chunk_file(source, "rs");
+    assert_eq!(result.chunks.len(), 1);
+    assert!(
+        result.chunks[0].content.contains("/* Info about Config */"),
+        "block comment should be attached"
+    );
+}
+
+#[test]
+fn chunk_rust_comment_before_use_not_attached_to_fn() {
+    let source = "// docs for use\nuse crate::foo::Bar;\nfn bar() {}";
+    let result = chunk_file(source, "rs");
+    assert_eq!(result.chunks.len(), 1);
+    assert!(
+        !result.chunks[0].content.contains("docs for use"),
+        "comment before use should not attach to following fn"
+    );
+}
+
+#[test]
+fn chunk_rust_parses_internal_use_prefixes() {
+    let cases = [
+        ("use crate::foo::Bar;\nfn main() {}", "crate::foo", "Bar"),
+        ("use super::utils::helper;\nfn run() {}", "super::utils", "helper"),
+        ("use self::inner::Thing;\nfn run() {}", "self::inner", "Thing"),
+    ];
+    for (source, expected_source, expected_name) in cases {
+        let result = chunk_file(source, "rs");
+        assert_eq!(result.parsed_imports.len(), 1, "source: {source}");
+        assert_eq!(result.parsed_imports[0].source, expected_source, "source: {source}");
+        assert_eq!(result.parsed_imports[0].specifiers[0].name, expected_name, "source: {source}");
+        assert_eq!(result.parsed_imports[0].specifiers[0].kind, ImportKind::Named, "source: {source}");
+    }
+}
+
+#[test]
+fn chunk_rust_parses_grouped_use() {
+    let source = "use crate::models::{User, Post};\nfn run() {}";
+    let result = chunk_file(source, "rs");
+    assert_eq!(result.parsed_imports.len(), 1);
+    assert_eq!(result.parsed_imports[0].source, "crate::models");
+    assert_eq!(result.parsed_imports[0].specifiers.len(), 2);
+    assert_eq!(result.parsed_imports[0].specifiers[0].name, "User");
+    assert_eq!(result.parsed_imports[0].specifiers[1].name, "Post");
+}
+
+#[test]
+fn chunk_rust_parses_glob_use() {
+    let source = "use crate::prelude::*;\nfn run() {}";
+    let result = chunk_file(source, "rs");
+    assert_eq!(result.parsed_imports.len(), 1);
+    assert_eq!(result.parsed_imports[0].source, "crate::prelude");
+    assert_eq!(result.parsed_imports[0].specifiers.len(), 1);
+    assert_eq!(result.parsed_imports[0].specifiers[0].name, "*");
+    assert_eq!(result.parsed_imports[0].specifiers[0].kind, ImportKind::Namespace);
+}
+
+#[test]
+fn chunk_rust_skips_external_crate_use() {
+    let source = "use std::fmt::Display;\nuse serde::Serialize;\nfn run() {}";
+    let result = chunk_file(source, "rs");
+    assert!(result.parsed_imports.is_empty());
+}
+
+#[test]
+fn chunk_rust_stores_all_use_as_import_text() {
+    let source = "use std::fmt::Display;\nuse crate::foo::Bar;\nfn run() {}";
+    let result = chunk_file(source, "rs");
+    assert_eq!(result.imports.len(), 2, "all use declarations stored as text");
+    assert!(result.imports[0].contains("std::fmt::Display"));
+    assert!(result.imports[1].contains("crate::foo::Bar"));
+    assert_eq!(result.parsed_imports.len(), 1, "only internal parsed");
+}
+
+#[test]
+fn chunk_rust_parses_nested_grouped_use() {
+    let source = "use crate::foo::{bar::Baz, Quux};\nfn run() {}";
+    let result = chunk_file(source, "rs");
+    assert_eq!(result.parsed_imports.len(), 1);
+    assert_eq!(result.parsed_imports[0].source, "crate::foo");
+    let names: Vec<&str> = result.parsed_imports[0]
+        .specifiers
+        .iter()
+        .map(|s| s.name.as_str())
+        .collect();
+    assert!(names.contains(&"Baz"));
+    assert!(names.contains(&"Quux"));
+}
+
+#[test]
+fn chunk_rust_parses_use_as_clause() {
+    let source = "use crate::foo::Bar as Baz;\nfn run() {}";
+    let result = chunk_file(source, "rs");
+    assert_eq!(result.parsed_imports.len(), 1);
+    assert_eq!(result.parsed_imports[0].source, "crate::foo");
+    assert_eq!(result.parsed_imports[0].specifiers[0].name, "Bar");
+    assert_eq!(
+        result.parsed_imports[0].specifiers[0].alias,
+        Some("Baz".to_string())
+    );
+}
+
+#[test]
+fn chunk_rust_parses_wildcard_in_group() {
+    let source = "use crate::prelude::{self, *};\nfn run() {}";
+    let result = chunk_file(source, "rs");
+    assert_eq!(result.parsed_imports.len(), 1);
+    let has_wildcard = result.parsed_imports[0]
+        .specifiers
+        .iter()
+        .any(|s| s.name == "*");
+    assert!(has_wildcard, "should parse wildcard within use group");
+}
+
+#[test]
+fn chunk_rust_skips_crate_name_prefix_collision() {
+    let source = "use self_cell::SelfCell;\nuse superstruct::Foo;\nfn run() {}";
+    let result = chunk_file(source, "rs");
+    assert!(
+        result.parsed_imports.is_empty(),
+        "crate names starting with self/super should not be treated as internal"
+    );
+}
+
+#[test]
+fn chunk_rust_skips_external_use_as_clause() {
+    let source = "use std::io::Read as R;\nfn run() {}";
+    let result = chunk_file(source, "rs");
+    assert!(
+        result.parsed_imports.is_empty(),
+        "external use-as should not produce a parsed import"
+    );
+    assert_eq!(result.imports.len(), 1, "raw import text should still be stored");
+}
+
+#[test]
+fn chunk_tsx_exported_interface() {
+    let source = "export interface Props { label: string; }";
+    let result = chunk_file(source, "tsx");
+    assert_eq!(result.chunks.len(), 1);
+    assert_eq!(result.chunks[0].chunk_type, ChunkType::TypeDef);
+    assert_eq!(result.chunks[0].name.as_deref(), Some("Props"));
+}
+
+#[test]
+fn chunk_tsx_exported_type_alias() {
+    let source = "export type Theme = 'light' | 'dark';";
+    let result = chunk_file(source, "tsx");
+    assert_eq!(result.chunks.len(), 1);
+    assert_eq!(result.chunks[0].chunk_type, ChunkType::TypeDef);
+    assert_eq!(result.chunks[0].name.as_deref(), Some("Theme"));
+}
+
+#[test]
+fn chunk_tsx_exported_const_non_arrow() {
+    let source = "export const API_URL = 'https://api.example.com';";
+    let result = chunk_file(source, "tsx");
+    assert_eq!(result.chunks.len(), 1);
+    assert_eq!(result.chunks[0].chunk_type, ChunkType::Other);
+    assert_eq!(result.chunks[0].name.as_deref(), Some("API_URL"));
+}
+
+#[test]
+fn chunk_tsx_bare_expression_statement() {
+    let source = "console.log('init');";
+    let result = chunk_file(source, "tsx");
+    assert_eq!(result.chunks.len(), 1);
+    assert_eq!(result.chunks[0].chunk_type, ChunkType::Other);
 }
 
 #[test]

--- a/src/indexer/chunker/ts.rs
+++ b/src/indexer/chunker/ts.rs
@@ -1,8 +1,9 @@
 use crate::storage::ChunkType;
 
 use super::{
-    chunk_fallback, classify_function, extract_name, find_child_by_kind, make_chunk, make_parser,
-    other_or_skip, FileChunks, ImportKind, ImportSpecifier, ParsedImport, RawChunk, ReExport,
+    attach_pending_comments, chunk_fallback, classify_function, extract_name, find_child_by_kind,
+    make_chunk, make_parser, other_or_skip, FileChunks, ImportKind, ImportSpecifier, ParsedImport,
+    RawChunk, ReExport,
 };
 
 pub(super) fn chunk_tsx(source: &str) -> FileChunks {
@@ -28,6 +29,7 @@ fn chunk_js_like_with_imports(source: &str, parser: &mut tree_sitter::Parser) ->
     let mut imports = Vec::new();
     let mut parsed_imports = Vec::new();
     let mut chunks = Vec::new();
+    let mut pending_comments: Vec<tree_sitter::Node> = Vec::new();
     let mut cursor = root.walk();
     for node in root.children(&mut cursor) {
         if node.kind() == "import_statement" {
@@ -35,8 +37,14 @@ fn chunk_js_like_with_imports(source: &str, parser: &mut tree_sitter::Parser) ->
             if let Some(pi) = parse_single_import(&node, source) {
                 parsed_imports.push(pi);
             }
-        } else if let Some(chunk) = classify_js_node(&node, source) {
+            pending_comments.clear();
+        } else if node.kind() == "comment" {
+            pending_comments.push(node);
+        } else if let Some(mut chunk) = classify_js_node(&node, source) {
+            attach_pending_comments(&mut chunk, &mut pending_comments, source);
             chunks.push(chunk);
+        } else {
+            pending_comments.clear();
         }
     }
     if chunks.is_empty() {


### PR DESCRIPTION
## 概要

- chunker の検索精度向上: JSDoc/コメントを宣言チャンクに付与 (Issue #4)
- Rust use 宣言を `ParsedImport` にパースして import graph に反映 (Issue #1)
- audit で発見された `is_internal_path` の prefix match バグを修正

Closes #4, closes #1

## 変更内容

### コメント付与 (#4)
- declaration 直前のコメント/JSDoc をチャンクの content 先頭に付与
- TS/JS と Rust の両方に対応
- `attach_pending_comments` 共通ヘルパーを `mod.rs` に抽出

### Rust use パース (#1)
- `use crate::/super::/self::` を `ParsedImport` にパース
- scoped_identifier, scoped_use_list, use_wildcard, use_as_clause, nested groups に対応
- 外部クレートはスキップ（内部パスのみ）
- `chunk_file("rs")` が `FileChunks`（imports/parsed_imports 付き）を返すように変更

### バグ修正
- `is_internal_path` が `self_cell`, `superstruct` 等を誤判定していたのを修正
- `split("::") + matches!` で最初のセグメントを正確に一致判定

## テスト計画

- [x] 302 tests passing (`cargo test --lib`)
- [x] clippy clean
- [x] TS/JS コメント付与: JSDoc, 行コメント, 連続, standalone 破棄, declaration 間
- [x] Rust コメント付与: doc comment, block comment, use 前 clearing
- [x] Rust use パース: crate/super/self, grouped, glob, nested, use_as_clause, wildcard-in-group
- [x] エッジケース: external skip, prefix collision, external use-as
- [x] TS classify 分岐: export interface/type, non-arrow const, bare expression