### PR TITLE
tools/mod.rs からエンベダーライフサイクルを embedder.rs に分離

### DIFF
--- a/src/tools/embedder.rs
+++ b/src/tools/embedder.rs
@@ -83,7 +83,7 @@ pub(super) fn parse_budget_value(value: Option<&str>) -> u32 {
 }
 
 fn try_load_embedder(disabled: bool) -> Result<Arc<dyn Embed>, DegradedReason> {
-    use rurico::embed::{model_paths_if_cached, ProbeStatus};
+    use rurico::embed::{ProbeStatus, model_paths_if_cached};
 
     fn probe_failed(e: &dyn std::fmt::Display) -> DegradedReason {
         record_embedder_warning(DegradedReason::ProbeFailed, &e.to_string());

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -14,9 +14,9 @@ use crate::indexer;
 use crate::query;
 use crate::storage;
 
-use embedder::{DegradedReason, parse_embed_budget};
 #[cfg(any(test, feature = "test-support"))]
 use embedder::DEFAULT_EMBED_BUDGET;
+use embedder::{DegradedReason, parse_embed_budget};
 use format::{
     EnrichmentContext, format_coverage, format_coverage_note, format_impact_all,
     format_impact_results, format_no_results_message, format_results_grouped, format_results_json,

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -1,7 +1,7 @@
-use super::*;
 use super::embedder::{
-    get_recorded_warnings, parse_budget_value, record_embedder_warning, RECORDED_WARNINGS,
+    RECORDED_WARNINGS, get_recorded_warnings, parse_budget_value, record_embedder_warning,
 };
+use super::*;
 use std::collections::HashMap;
 
 use rurico::embed::FailingEmbedder;


### PR DESCRIPTION
## 概要

`tools/mod.rs` のエンベダーサブシステムを `tools/embedder.rs` に分離。`mod.rs` が642行に膨らみ400行閾値を超過していたため、独立した状態管理を持つエンベダーコードを抽出した。

## 変更内容

- `src/tools/embedder.rs`（新規、170行）: `DegradedReason`, `NoOpEmbedder`, `try_load_embedder`, `get_embedder`, `degraded_reason`, `embedding_available`, budget パース、`record_embedder_warning`、テストヘルパー
- `src/tools/mod.rs`: 移動済みコード削除、`mod embedder` + re-export 追加。642 → 488行
- `src/tools/tests.rs`: embedder サブモジュールからの import 追加

## スコープ

- **対象外**: 振る舞いの変更。純粋な構造リファクタ。

## 設計判断

- 同モジュール内の既存 `format.rs` 分割パターンに準拠。
- `mod.rs` はエンベダーサブシステムと `get_embedder()` / `degraded_reason()` のみで接続しており、分離境界が明確。

## テスト方法

1. `cargo test` — 既存400テスト全パス
2. `wc -l src/tools/mod.rs` で500行未満を確認
3. `src/tools/embedder.rs` に移動対象シンボルが存在することを確認

## 関連

- Closes #29