### PR TITLE
検索ランキングから recency boost を削除

### DIFF
--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -318,8 +318,7 @@ pub fn rerank(
             0.0
         };
 
-        result.score =
-            base + name_bonus + overlap_bonus + type_bonus + import_bonus - test_penalty;
+        result.score = base + name_bonus + overlap_bonus + type_bonus + import_bonus - test_penalty;
     }
 
     results.sort_by(|a, b| {

--- a/src/query/tests.rs
+++ b/src/query/tests.rs
@@ -335,11 +335,7 @@ fn rerank_semantic_base_score() {
         0.5,
         storage::MatchSource::Semantic,
     )];
-    rerank(
-        &mut results,
-        &RerankContext::default(),
-        &HashMap::new(),
-    );
+    rerank(&mut results, &RerankContext::default(), &HashMap::new());
     let expected = 1.0 / (1.0 + 0.5);
     assert!(
         (results[0].score - expected).abs() < 1e-6,
@@ -392,11 +388,7 @@ fn rerank_sorts_by_score_descending() {
             storage::MatchSource::Semantic,
         ),
     ];
-    rerank(
-        &mut results,
-        &RerankContext::default(),
-        &HashMap::new(),
-    );
+    rerank(&mut results, &RerankContext::default(), &HashMap::new());
     assert!(
         results[0].score >= results[1].score,
         "expected descending: {} >= {}",
@@ -460,11 +452,7 @@ fn rerank_import_rank_bonus() {
         ("src/popular.tsx".to_string(), 10u32),
         ("src/unpopular.tsx".to_string(), 1u32),
     ]);
-    rerank(
-        &mut results,
-        &RerankContext::default(),
-        &import_counts,
-    );
+    rerank(&mut results, &RerankContext::default(), &import_counts);
 
     let popular = results
         .iter()


### PR DESCRIPTION
## 概要

- 検索ランキングから recency boost（加算方式 `score + 0.03 * decay`）を削除。コード検索においてファイル更新時刻はクエリ関連度と相関がないため
- `RECENCY_BONUS`, `RECENCY_HALF_LIFE_DAYS`, `now_epoch`, `file_mtimes` パラメータを `rerank()` と `search_pipeline()` から削除
- recency テスト2件を削除し、残りの `rerank()` 呼び出しを新しい3引数シグネチャに更新

Closes #38

## テスト計画

- [ ] `cargo test` が recency 関連の失敗なく通る
- [ ] 検索結果がセマンティック関連度でランキングされる（name, overlap, type, import ボーナスは維持）
- [ ] `src/query/` 内に `RECENCY_BONUS`, `now_epoch`, `file_mtimes` への参照が残っていない