### PR TITLE
検索を3カラム FTS5 + bm25 ランキングに統合

### DIFF
--- a/adr/0001-unify-search-into-3-column-fts5-with-bm25.md
+++ b/adr/0001-unify-search-into-3-column-fts5-with-bm25.md
@@ -1,0 +1,94 @@
+# Unify search into 3-column FTS5 with bm25
+
+- Status: accepted
+- Deciders: thkt
+- Date: 2026-03-30
+- Confidence: medium — DA challenge passed with revisions; bm25 weight tuning needs production validation
+- Refs: #37, #36 (closed)
+
+## Context
+
+`search_by_name` uses `LIKE '%keyword%'` on `chunks.name` and `chunks.file_path`, resulting in O(N) full table scans on every search request. `search_by_content` already uses FTS5 MATCH at O(log N). The two search paths run sequentially with exclude_ids coordination, and reranking uses separate `MatchSource::NameMatch` / `ContentMatch` with manually tuned base score constants.
+
+## Decision Drivers
+
+- Every search request executes the O(N) LIKE scan before FTS, becoming a bottleneck as chunk count grows
+- Two search functions + 6 scoring constants + exclude_ids coordination add maintenance surface
+- FTS5 `bm25()` provides principled cross-column ranking that replaces manual score tuning
+
+## Considered Options
+
+### A: Add name to FTS, keep file_path as LIKE
+
+Add name column to FTS table. Use `{name}: keyword` column filter for name search. Keep file_path as LIKE.
+
+- Good: minimal change, reranking logic preserved
+- Bad: file_path remains O(N) LIKE
+- Bad: two FTS queries per search (name + content separately)
+
+### B: Unified 3-column FTS (name, content, file_path)
+
+Replace both `search_by_name` and `search_by_content` with a single FTS query across 3 columns. Use `bm25()` column weights for ranking.
+
+- Good: eliminates all LIKE scans
+- Good: single FTS query replaces two search functions
+- Good: net code reduction (2 functions, 6 constants, escape_like removed)
+- Bad: loses arbitrary substring matching (e.g., `etch` no longer matches `fetch`)
+- Bad: bm25 weights need tuning via testing
+- Bad: broader test modifications due to MatchSource unification
+
+## Decision
+
+Option B. Merge `search_by_name` and `search_by_content` into `search_by_fts` with `fts5(name, content, file_path)` and `bm25()` ranking.
+
+Key design choices:
+
+- **name pre-processing**: `split_identifier(name).join(" ")` at INSERT time to handle camelCase/PascalCase (Unicode61 treats `useAuth` as one token; splitting produces `use Auth` which matches `auth`)
+- **file_path**: stored as-is; Unicode61 tokenizes on `/`, `.`, `-` naturally
+- **FTS query building**: reuse `prepare_match_query` (from rurico) for prefix expansion via `fts_chunks_vocab`
+- **MatchSource**: `Semantic | Fts` (collapse NameMatch + ContentMatch)
+- **FTS base score**: `1.0 / (1.0 + bm25.abs())`; type_bonus / import_bonus / test_penalty preserved as additive modifiers
+- **keyword_hit_ratio**: retained for Semantic results only
+- **Migration v6->v7**: DROP + recreate `fts_chunks` and `fts_chunks_vocab`, re-populate with split names
+
+### Positive Consequences
+
+- All search paths are O(log N) via FTS5
+- Net code reduction: `search_by_name`, `search_by_content`, `escape_like`, 6 scoring constants removed
+- `bm25()` provides corpus-aware ranking without manual constant tuning
+- Single FTS query eliminates exclude_ids coordination between search steps
+
+### Negative Consequences
+
+- Arbitrary substring match lost: token-level matching only (accepted as spec change)
+- bm25 score normalization may need revision if ranking degrades at extreme corpus sizes
+- Existing tests for `search_by_name` and `search_by_content` require rewrite
+
+## Architecture
+
+```
+Before:
+  semantic -> search_by_name (LIKE O(N)) -> search_by_content (FTS) -> rerank
+
+After:
+  semantic -> search_by_fts (FTS bm25) -> rerank
+```
+
+## Quality Attributes
+
+| Attribute       | Priority | Approach                                     |
+| --------------- | -------- | -------------------------------------------- |
+| Performance     | high     | O(N) LIKE eliminated, single FTS query       |
+| Maintainability | high     | 2 functions collapsed, 6 constants removed   |
+| Search quality  | medium   | bm25 column weights; needs tuning validation |
+
+## Trade-offs
+
+- Token-level matching precision in exchange for O(log N) performance on all search paths
+- Manual scoring control in exchange for bm25's corpus-aware ranking
+
+## Reassessment Triggers
+
+- bm25 ranking quality degrades noticeably at >50K chunks
+- Users report missing results that LIKE substring match would have found
+- Need for CJK search (may require trigram tokenizer, revisit #36)

--- a/adr/README.md
+++ b/adr/README.md
@@ -1,0 +1,5 @@
+# Architecture Decision Records
+
+| ADR                                                       | Title                                     | Status   | Date       |
+| --------------------------------------------------------- | ----------------------------------------- | -------- | ---------- |
+| [0001](0001-unify-search-into-3-column-fts5-with-bm25.md) | Unify search into 3-column FTS5 with bm25 | accepted | 2026-03-30 |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 pub mod config;
-pub mod text;
 pub mod indexer;
 pub mod query;
 pub mod resolver;
 pub mod rust_resolver;
 pub mod storage;
+pub mod text;
 pub mod tools;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod text;
 pub mod indexer;
 pub mod query;
 pub mod resolver;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -46,6 +46,7 @@ pub fn extract_keywords(query: &str) -> Vec<String> {
         }
     }
 
+    // Words ending in -ing that are not gerunds (stripping -ing produces a non-word or keyword).
     const ING_DENY: &[&str] = &[
         "string",
         "bring",
@@ -61,6 +62,7 @@ pub fn extract_keywords(query: &str) -> Vec<String> {
         "sting",
         "wing",
     ];
+    // Words ending in -s that are not plurals (stripping -s produces a non-word).
     const S_DENY: &[&str] = &[
         "class", "this", "alias", "canvas", "focus", "status", "bus", "process", "address",
         "access", "express", "progress",
@@ -317,14 +319,10 @@ fn search_pipeline(
         )?;
         results.extend(fts_results);
     }
-    let embed_coverage = if stats.embeddable_chunks > 0 {
-        stats.embedded_chunks as f32 / stats.embeddable_chunks as f32
-    } else {
-        0.0
-    };
+    let embed_coverage = stats.embed_coverage();
 
     let (keyword_idfs, import_counts) = if results.is_empty() {
-        (Vec::new(), std::collections::HashMap::new())
+        (Vec::new(), HashMap::new())
     } else {
         let dfs =
             storage::get_keyword_doc_frequencies(conn, &keyword_refs, stats.total_chunks)?;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -324,15 +324,13 @@ fn search_pipeline(
     let (keyword_idfs, import_counts) = if results.is_empty() {
         (Vec::new(), HashMap::new())
     } else {
-        let dfs =
-            storage::get_keyword_doc_frequencies(conn, &keyword_refs, stats.total_chunks)?;
+        let dfs = storage::get_keyword_doc_frequencies(conn, &keyword_refs, stats.total_chunks)?;
         let total = stats.total_chunks.max(1) as f32;
         let idfs: Vec<f32> = dfs
             .iter()
             .map(|&df| (total / (df.max(1) as f32)).ln())
             .collect();
-        let file_paths: Vec<&str> =
-            results.iter().map(|r| r.chunk.file_path.as_str()).collect();
+        let file_paths: Vec<&str> = results.iter().map(|r| r.chunk.file_path.as_str()).collect();
         let ic = storage::get_import_counts(conn, &file_paths)?;
         (idfs, ic)
     };

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 use crate::storage::{self, ChunkType, Db, SearchResult, StorageError};
@@ -22,38 +22,11 @@ pub struct SearchOutcome {
 
 const STOP_WORDS: &[&str] = &["the", "a", "an", "in", "for", "of", "with", "and", "or"];
 
-fn split_identifier(s: &str) -> Vec<String> {
-    let mut parts = Vec::new();
-    let mut current = String::new();
-    let chars: Vec<char> = s.chars().collect();
-
-    for i in 0..chars.len() {
-        let c = chars[i];
-        if c == '-' || c == '_' {
-            if !current.is_empty() {
-                parts.push(std::mem::take(&mut current));
-            }
-        } else if c.is_uppercase() {
-            let prev_lower = i > 0 && chars[i - 1].is_lowercase();
-            let prev_upper = i > 0 && chars[i - 1].is_uppercase();
-            let next_lower = i + 1 < chars.len() && chars[i + 1].is_lowercase();
-            if (prev_lower || (prev_upper && next_lower)) && !current.is_empty() {
-                parts.push(std::mem::take(&mut current));
-            }
-            current.push(c);
-        } else {
-            current.push(c);
-        }
-    }
-    if !current.is_empty() {
-        parts.push(current);
-    }
-    parts
-}
+use crate::text::split_identifier;
 
 pub fn extract_keywords(query: &str) -> Vec<String> {
     let mut base: Vec<String> = Vec::new();
-    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut seen: HashSet<String> = HashSet::new();
     for token in query.split_whitespace() {
         let lower = token.to_lowercase();
         if lower.chars().count() >= 2
@@ -188,7 +161,7 @@ fn keyword_hit_ratio(
 const MAX_RESULTS_PER_FILE: usize = 2;
 
 fn cap_per_file(results: &mut Vec<storage::SearchResult>, max: usize) {
-    let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    let mut counts: HashMap<String, usize> = HashMap::new();
     results.retain(|r| {
         let count = counts.entry(r.chunk.file_path.clone()).or_insert(0);
         *count += 1;
@@ -196,11 +169,6 @@ fn cap_per_file(results: &mut Vec<storage::SearchResult>, max: usize) {
     });
 }
 
-const NAME_MATCH_BASE: f32 = 0.40;
-const NAME_MATCH_RATIO_WEIGHT: f32 = 0.20;
-const CONTENT_MATCH_BASE: f32 = 0.35;
-const CONTENT_MATCH_RATIO_WEIGHT: f32 = 0.15;
-const NAME_MATCH_BONUS: f32 = 0.05;
 const TYPE_HINT_BONUS: f32 = 0.03;
 const IMPORT_RANK_BONUS: f32 = 0.03;
 const TEST_PATH_PENALTY: f32 = 0.05;
@@ -250,7 +218,7 @@ impl Default for RerankContext<'_> {
 pub fn rerank(
     results: &mut [storage::SearchResult],
     ctx: &RerankContext<'_>,
-    import_counts: &std::collections::HashMap<String, u32>,
+    import_counts: &HashMap<String, u32>,
 ) {
     if results.is_empty() {
         return;
@@ -271,20 +239,7 @@ pub fn rerank(
     for result in results.iter_mut() {
         let base = match result.match_source {
             storage::MatchSource::Semantic => 1.0 / (1.0 + result.distance) * confidence,
-            storage::MatchSource::NameMatch => {
-                let ratio = keyword_hit_ratio(result, ctx.keywords, ctx.keyword_idfs, false);
-                NAME_MATCH_BASE + NAME_MATCH_RATIO_WEIGHT * ratio
-            }
-            storage::MatchSource::ContentMatch => {
-                let ratio = keyword_hit_ratio(result, ctx.keywords, ctx.keyword_idfs, true);
-                CONTENT_MATCH_BASE + CONTENT_MATCH_RATIO_WEIGHT * ratio
-            }
-        };
-
-        let name_bonus = if result.match_source == storage::MatchSource::NameMatch {
-            NAME_MATCH_BONUS
-        } else {
-            0.0
+            storage::MatchSource::Fts => result.score,
         };
 
         let overlap_bonus =
@@ -318,14 +273,10 @@ pub fn rerank(
             0.0
         };
 
-        result.score = base + name_bonus + overlap_bonus + type_bonus + import_bonus - test_penalty;
+        result.score = base + overlap_bonus + type_bonus + import_bonus - test_penalty;
     }
 
-    results.sort_by(|a, b| {
-        b.score
-            .partial_cmp(&a.score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    results.sort_by(|a, b| b.score.total_cmp(&a.score));
 }
 
 fn search_pipeline(
@@ -356,24 +307,15 @@ fn search_pipeline(
             Some(type_hints.as_slice())
         };
 
-        let mut exclude_ids: HashSet<i64> = results.iter().filter_map(|r| r.chunk_id).collect();
-        let name_results = storage::search_by_name(
+        let exclude_ids: HashSet<i64> = results.iter().filter_map(|r| r.chunk_id).collect();
+        let fts_results = storage::search_by_fts(
             conn,
             &keyword_refs,
             type_filter,
             &exclude_ids,
             fallback_limit,
         )?;
-        exclude_ids.extend(name_results.iter().filter_map(|r| r.chunk_id));
-        results.extend(name_results);
-        let content_results = storage::search_by_content(
-            conn,
-            &keyword_refs,
-            type_filter,
-            &exclude_ids,
-            fallback_limit,
-        )?;
-        results.extend(content_results);
+        results.extend(fts_results);
     }
     let embed_coverage = if stats.embeddable_chunks > 0 {
         stats.embedded_chunks as f32 / stats.embeddable_chunks as f32
@@ -381,15 +323,21 @@ fn search_pipeline(
         0.0
     };
 
-    let dfs = storage::get_keyword_doc_frequencies(conn, &keyword_refs, stats.total_chunks)?;
-    let total = stats.total_chunks.max(1) as f32;
-    let keyword_idfs: Vec<f32> = dfs
-        .iter()
-        .map(|&df| (total / (df.max(1) as f32)).ln())
-        .collect();
-
-    let file_paths: Vec<&str> = results.iter().map(|r| r.chunk.file_path.as_str()).collect();
-    let import_counts = storage::get_import_counts(conn, &file_paths)?;
+    let (keyword_idfs, import_counts) = if results.is_empty() {
+        (Vec::new(), std::collections::HashMap::new())
+    } else {
+        let dfs =
+            storage::get_keyword_doc_frequencies(conn, &keyword_refs, stats.total_chunks)?;
+        let total = stats.total_chunks.max(1) as f32;
+        let idfs: Vec<f32> = dfs
+            .iter()
+            .map(|&df| (total / (df.max(1) as f32)).ln())
+            .collect();
+        let file_paths: Vec<&str> =
+            results.iter().map(|r| r.chunk.file_path.as_str()).collect();
+        let ic = storage::get_import_counts(conn, &file_paths)?;
+        (idfs, ic)
+    };
     let ctx = RerankContext {
         type_hints: &type_hints,
         keywords: &keywords,

--- a/src/query/tests.rs
+++ b/src/query/tests.rs
@@ -88,35 +88,6 @@ fn extract_keywords_short_ing_not_stemmed() {
 }
 
 #[test]
-fn split_identifier_camel_case() {
-    assert_eq!(split_identifier("useChat"), vec!["use", "Chat"]);
-    assert_eq!(split_identifier("DataTable"), vec!["Data", "Table"]);
-}
-
-#[test]
-fn split_identifier_acronym() {
-    assert_eq!(split_identifier("HTMLElement"), vec!["HTML", "Element"]);
-    assert_eq!(
-        split_identifier("getXMLParser"),
-        vec!["get", "XML", "Parser"]
-    );
-    assert_eq!(split_identifier("UIMessage"), vec!["UI", "Message"]);
-}
-
-#[test]
-fn split_identifier_kebab_and_snake() {
-    assert_eq!(split_identifier("data-table"), vec!["data", "table"]);
-    assert_eq!(split_identifier("get_value"), vec!["get", "value"]);
-    assert_eq!(split_identifier("use-chat"), vec!["use", "chat"]);
-}
-
-#[test]
-fn split_identifier_single_word() {
-    assert_eq!(split_identifier("stream"), vec!["stream"]);
-    assert_eq!(split_identifier("chat"), vec!["chat"]);
-}
-
-#[test]
 fn extract_keywords_expands_camel_case() {
     let kw = extract_keywords("useChat");
     assert!(kw.contains(&"usechat".to_string()), "whole token: {kw:?}");
@@ -237,7 +208,7 @@ fn search_fallback_merges_vector_and_name_results() {
     .unwrap();
 
     let conn = Arc::new(Mutex::new(conn));
-    let results = search(conn, &MockEmbedder, "auth hook", 5, 0)
+    let results = search(conn, &MockEmbedder, "auth", 5, 0)
         .unwrap()
         .results;
 
@@ -259,7 +230,11 @@ fn search_fallback_merges_vector_and_name_results() {
         names.contains(&"useAuth"),
         "expected useAuth from fallback: {names:?}"
     );
-    assert_eq!(results[0].match_source, storage::MatchSource::Semantic);
+    let sources: Vec<_> = results.iter().map(|r| r.match_source).collect();
+    assert!(
+        sources.contains(&storage::MatchSource::Semantic),
+        "expected Semantic result in set: {sources:?}"
+    );
 }
 
 #[test]
@@ -306,8 +281,7 @@ fn make_result(
 ) -> storage::SearchResult {
     let score = match match_source {
         storage::MatchSource::Semantic => 1.0 / (1.0 + distance),
-        storage::MatchSource::NameMatch => 0.5,
-        storage::MatchSource::ContentMatch => 0.45,
+        storage::MatchSource::Fts => 0.45,
     };
     storage::SearchResult {
         chunk: storage::Chunk {
@@ -345,16 +319,15 @@ fn rerank_semantic_base_score() {
 }
 
 #[test]
-fn rerank_name_match_base_score() {
+fn rerank_fts_base_score_passthrough() {
     let kw = vec!["auth".to_string()];
     let mut results = vec![make_result(
         "src/A.tsx",
         "useAuth",
         storage::ChunkType::Hook,
         f32::INFINITY,
-        storage::MatchSource::NameMatch,
+        storage::MatchSource::Fts,
     )];
-    // 1/1 keywords match → base = 0.40 + 0.20 = 0.60, + NAME_MATCH_BONUS = 0.65
     rerank(
         &mut results,
         &RerankContext {
@@ -364,8 +337,8 @@ fn rerank_name_match_base_score() {
         &HashMap::new(),
     );
     assert!(
-        (results[0].score - 0.65).abs() < 1e-6,
-        "expected 0.65, got {}",
+        (results[0].score - 0.45).abs() < 1e-6,
+        "expected 0.45, got {}",
         results[0].score
     );
 }
@@ -523,17 +496,16 @@ fn rerank_test_query_exempts_penalty() {
 }
 
 #[test]
-fn rerank_name_match_all_bonuses() {
+fn rerank_fts_all_bonuses() {
     let kw = vec!["auth".to_string()];
     let mut results = vec![make_result(
         "src/useAuth.tsx",
         "useAuth",
         storage::ChunkType::Hook,
         f32::INFINITY,
-        storage::MatchSource::NameMatch,
+        storage::MatchSource::Fts,
     )];
     let import_counts = HashMap::from([("src/useAuth.tsx".to_string(), 10u32)]);
-    // 1/1 match → base=0.60, + NAME_MATCH=0.05, + TYPE_HINT=0.03, + IMPORT=0.03 = 0.71
     rerank(
         &mut results,
         &RerankContext {
@@ -544,8 +516,8 @@ fn rerank_name_match_all_bonuses() {
         &import_counts,
     );
     assert!(
-        (results[0].score - 0.71).abs() < 1e-6,
-        "expected 0.71, got {}",
+        (results[0].score - 0.51).abs() < 1e-6,
+        "expected 0.51, got {}",
         results[0].score
     );
 }
@@ -720,24 +692,24 @@ fn rerank_low_coverage_dampens_semantic() {
 }
 
 #[test]
-fn rerank_low_coverage_name_match_beats_semantic() {
+fn rerank_low_coverage_fts_beats_semantic() {
     let kw = vec!["chat".to_string()];
     let mut results = vec![
-        // At 2% coverage: 1/(1+0.45) * 0.68 ≈ 0.47
+        // At 2% coverage: 1/(1+0.6) * 0.68 ≈ 0.43
         make_result(
             "src/A.tsx",
             "Unrelated",
             storage::ChunkType::Component,
-            0.45,
+            0.6,
             storage::MatchSource::Semantic,
         ),
-        // Name match: 0.40 + 0.20*(1/1) + 0.05 = 0.65 (unaffected by coverage)
+        // Fts passthrough: 0.45 (unaffected by coverage)
         make_result(
             "src/B.tsx",
             "useChat",
             storage::ChunkType::Hook,
             f32::INFINITY,
-            storage::MatchSource::NameMatch,
+            storage::MatchSource::Fts,
         ),
     ];
     rerank(
@@ -752,11 +724,11 @@ fn rerank_low_coverage_name_match_beats_semantic() {
     assert_eq!(
         results[0].chunk.name.as_deref(),
         Some("useChat"),
-        "name match should rank first at low coverage"
+        "FTS should rank first at low coverage"
     );
     assert!(
         results[0].score > results[1].score,
-        "name ({}) should beat semantic ({}) at 2% coverage",
+        "FTS ({}) should beat semantic ({}) at 2% coverage",
         results[0].score,
         results[1].score
     );
@@ -778,7 +750,7 @@ fn content_match_scores_from_content_body() {
         },
         chunk_id: None,
         distance: f32::INFINITY,
-        match_source: storage::MatchSource::ContentMatch,
+        match_source: storage::MatchSource::Fts,
         score: 0.0,
     };
     let ratio = keyword_hit_ratio(&result, &kw, &[], true);
@@ -1023,14 +995,19 @@ fn text_only_search_with_offset_returns_results() {
     let db_path = dir.path().join("test.db");
     let conn = storage::open_db(&db_path).unwrap();
 
-    for i in 0..15 {
+    let names = [
+        "WidgetAlpha", "WidgetBeta", "WidgetGamma", "WidgetDelta", "WidgetEpsilon",
+        "WidgetZeta", "WidgetEta", "WidgetTheta", "WidgetIota", "WidgetKappa",
+        "WidgetLambda", "WidgetMu", "WidgetNu", "WidgetXi", "WidgetOmicron",
+    ];
+    for (i, name) in names.iter().enumerate() {
         storage::replace_file_chunks_only(
             &conn,
-            &format!("src/Widget{i}.tsx"),
+            &format!("src/{name}.tsx"),
             &[storage::NewChunk {
                 chunk_type: &storage::ChunkType::Component,
-                name: Some(&format!("Widget{i}")),
-                content: &format!("function Widget{i}() {{ return <div/>; }}"),
+                name: Some(name),
+                content: &format!("function {name}() {{ return <div/>; }}"),
                 start_line: 1,
                 end_line: 1,
                 parent_index: None,
@@ -1064,7 +1041,6 @@ fn search_chunk_only_index_with_embedder_falls_back_to_text() {
     let db_path = dir.path().join("test.db");
     let conn = storage::open_db(&db_path).unwrap();
 
-    // Insert chunk WITHOUT embedding (simulates chunk-only index)
     storage::replace_file_chunks_only(
         &conn,
         "src/Button.tsx",
@@ -1087,7 +1063,6 @@ fn search_chunk_only_index_with_embedder_falls_back_to_text() {
     assert_eq!(stats.embedded_chunks, 0, "no embeddings should exist");
 
     let conn = Arc::new(Mutex::new(conn));
-    // MockEmbedder succeeds on embed_query — this is the "model available" case
     let outcome = search(conn, &MockEmbedder, "button", 10, 0).unwrap();
     assert!(
         !outcome.results.is_empty(),

--- a/src/query/tests.rs
+++ b/src/query/tests.rs
@@ -208,9 +208,7 @@ fn search_fallback_merges_vector_and_name_results() {
     .unwrap();
 
     let conn = Arc::new(Mutex::new(conn));
-    let results = search(conn, &MockEmbedder, "auth", 5, 0)
-        .unwrap()
-        .results;
+    let results = search(conn, &MockEmbedder, "auth", 5, 0).unwrap().results;
 
     assert!(
         results.len() >= 2,
@@ -996,9 +994,21 @@ fn text_only_search_with_offset_returns_results() {
     let conn = storage::open_db(&db_path).unwrap();
 
     let names = [
-        "WidgetAlpha", "WidgetBeta", "WidgetGamma", "WidgetDelta", "WidgetEpsilon",
-        "WidgetZeta", "WidgetEta", "WidgetTheta", "WidgetIota", "WidgetKappa",
-        "WidgetLambda", "WidgetMu", "WidgetNu", "WidgetXi", "WidgetOmicron",
+        "WidgetAlpha",
+        "WidgetBeta",
+        "WidgetGamma",
+        "WidgetDelta",
+        "WidgetEpsilon",
+        "WidgetZeta",
+        "WidgetEta",
+        "WidgetTheta",
+        "WidgetIota",
+        "WidgetKappa",
+        "WidgetLambda",
+        "WidgetMu",
+        "WidgetNu",
+        "WidgetXi",
+        "WidgetOmicron",
     ];
     for (i, name) in names.iter().enumerate() {
         storage::replace_file_chunks_only(

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -115,8 +115,7 @@ impl IndexStatus {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum MatchSource {
     Semantic,
-    NameMatch,
-    ContentMatch,
+    Fts,
 }
 
 #[derive(Debug, Clone)]
@@ -200,9 +199,13 @@ fn insert_chunk_row(
     )?;
     let chunk_id = conn.last_insert_rowid();
 
+    let fts_name = chunk
+        .name
+        .map(|n| crate::text::split_identifier(n).join(" "))
+        .unwrap_or_default();
     conn.execute(
-        "INSERT INTO fts_chunks(rowid, content) VALUES (?1, ?2)",
-        rusqlite::params![chunk_id, chunk.content],
+        "INSERT INTO fts_chunks(rowid, name, content, file_path) VALUES (?1, ?2, ?3, ?4)",
+        rusqlite::params![chunk_id, fts_name, chunk.content, file_path],
     )?;
 
     Ok(chunk_id)

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -103,12 +103,16 @@ pub struct IndexStatus {
 }
 
 impl IndexStatus {
-    pub fn embed_percentage(&self) -> u32 {
+    pub fn embed_coverage(&self) -> f32 {
         if self.embeddable_chunks > 0 {
-            (self.embedded_chunks as f64 / self.embeddable_chunks as f64 * 100.0) as u32
+            self.embedded_chunks as f32 / self.embeddable_chunks as f32
         } else {
-            0
+            0.0
         }
+    }
+
+    pub fn embed_percentage(&self) -> u32 {
+        (self.embed_coverage() as f64 * 100.0) as u32
     }
 }
 

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -42,7 +42,7 @@ pub fn open_db(path: &Path) -> Result<Connection, StorageError> {
     Ok(conn)
 }
 
-const SCHEMA_VERSION: u32 = 6;
+const SCHEMA_VERSION: u32 = 7;
 
 const DDL: &str = "
     CREATE TABLE IF NOT EXISTS chunks (
@@ -94,8 +94,7 @@ fn init_schema(conn: &Connection) -> Result<(), StorageError> {
 
     conn.execute_batch(
         "CREATE VIRTUAL TABLE IF NOT EXISTS fts_chunks USING fts5(
-            content,
-            content_rowid='rowid'
+            name, content, file_path
         )",
     )?;
 
@@ -200,11 +199,66 @@ fn migrate(conn: &Connection, from: u32) -> Result<(), StorageError> {
         )?;
     }
 
-    // v5 → v6: add mtime_epoch to file_context for recency boost
+    // v5 → v6: add mtime_epoch to file_context
     if from < 6 && !column_exists(conn, "SELECT mtime_epoch FROM file_context LIMIT 0")? {
         conn.execute_batch("ALTER TABLE file_context ADD COLUMN mtime_epoch INTEGER")?;
     }
 
+    // v6 → v7: rebuild FTS with 3 columns (name, content, file_path)
+    if from < 7 {
+        conn.execute_batch("SAVEPOINT fts_v7")?;
+        match rebuild_fts_v7(conn) {
+            Ok(()) => conn.execute_batch("RELEASE fts_v7")?,
+            Err(e) => {
+                if let Err(rb_err) = conn.execute_batch("ROLLBACK TO fts_v7") {
+                    tracing::error!(
+                        error = %rb_err,
+                        original_error = %e,
+                        "ROLLBACK TO fts_v7 failed"
+                    );
+                }
+                return Err(e);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn rebuild_fts_v7(conn: &Connection) -> Result<(), StorageError> {
+    let _automerge = FtsAutomergeGuard::new(conn)?;
+    conn.execute_batch("DROP TABLE IF EXISTS fts_chunks_vocab")?;
+    conn.execute_batch("DROP TABLE IF EXISTS fts_chunks")?;
+    conn.execute_batch(
+        "CREATE VIRTUAL TABLE fts_chunks USING fts5(name, content, file_path)",
+    )?;
+
+    let mut stmt = conn.prepare(
+        "SELECT id, file_path, name, content FROM chunks",
+    )?;
+    let mut rows = stmt.query([])?;
+    {
+        let mut insert = conn.prepare(
+            "INSERT INTO fts_chunks(rowid, name, content, file_path) VALUES (?1, ?2, ?3, ?4)",
+        )?;
+        while let Some(row) = rows.next()? {
+            let id: i64 = row.get(0)?;
+            let path: String = row.get(1)?;
+            let name: Option<String> = row.get(2)?;
+            let content: String = row.get(3)?;
+            let fts_name = name
+                .as_deref()
+                .map(|n| crate::text::split_identifier(n).join(" "))
+                .unwrap_or_default();
+            insert.execute(rusqlite::params![id, fts_name, content, path])?;
+        }
+    }
+
+    fts_optimize(conn)?;
+
+    conn.execute_batch(
+        "CREATE VIRTUAL TABLE IF NOT EXISTS fts_chunks_vocab USING fts5vocab(fts_chunks, row)",
+    )?;
     Ok(())
 }
 

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -229,13 +229,9 @@ fn rebuild_fts_v7(conn: &Connection) -> Result<(), StorageError> {
     let _automerge = FtsAutomergeGuard::new(conn)?;
     conn.execute_batch("DROP TABLE IF EXISTS fts_chunks_vocab")?;
     conn.execute_batch("DROP TABLE IF EXISTS fts_chunks")?;
-    conn.execute_batch(
-        "CREATE VIRTUAL TABLE fts_chunks USING fts5(name, content, file_path)",
-    )?;
+    conn.execute_batch("CREATE VIRTUAL TABLE fts_chunks USING fts5(name, content, file_path)")?;
 
-    let mut stmt = conn.prepare(
-        "SELECT id, file_path, name, content FROM chunks",
-    )?;
+    let mut stmt = conn.prepare("SELECT id, file_path, name, content FROM chunks")?;
     let mut rows = stmt.query([])?;
     {
         let mut insert = conn.prepare(

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use rusqlite::Connection;
 
@@ -133,9 +133,9 @@ pub fn get_chunk_by_id(conn: &Connection, chunk_id: i64) -> Result<Option<Chunk>
 pub fn get_chunks_by_ids(
     conn: &Connection,
     ids: &[i64],
-) -> Result<std::collections::HashMap<i64, Chunk>, StorageError> {
+) -> Result<HashMap<i64, Chunk>, StorageError> {
     if ids.is_empty() {
-        return Ok(std::collections::HashMap::new());
+        return Ok(HashMap::new());
     }
     let placeholders = super::sql_placeholders(ids.len());
     let sql = format!(
@@ -152,7 +152,7 @@ pub fn get_chunks_by_ids(
         let chunk = chunk_from_row(row, 1)?;
         Ok((id, chunk))
     })?;
-    rows.collect::<Result<std::collections::HashMap<_, _>, _>>()
+    rows.collect::<Result<HashMap<_, _>, _>>()
         .map_err(Into::into)
 }
 

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -54,58 +54,7 @@ pub fn search_similar(
     rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
 }
 
-pub fn search_by_name(
-    conn: &Connection,
-    keywords: &[&str],
-    type_filter: Option<&[ChunkType]>,
-    exclude_ids: &HashSet<i64>,
-    limit: u32,
-) -> Result<Vec<SearchResult>, StorageError> {
-    if keywords.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let name_clause = vec!["name LIKE ? ESCAPE '\\'"; keywords.len()].join(" OR ");
-    let path_clause = vec!["file_path LIKE ? ESCAPE '\\'"; keywords.len()].join(" OR ");
-
-    let mut sql = format!(
-        "SELECT id, file_path, chunk_type, name, content, start_line, end_line, parent_chunk_id \
-         FROM chunks WHERE ((name IS NOT NULL AND ({name_clause})) OR ({path_clause}))",
-    );
-
-    let mut all_params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-    for k in keywords {
-        all_params
-            .push(Box::new(format!("%{}%", escape_like(k))) as Box<dyn rusqlite::types::ToSql>);
-    }
-    for k in keywords {
-        all_params
-            .push(Box::new(format!("%{}%", escape_like(k))) as Box<dyn rusqlite::types::ToSql>);
-    }
-
-    append_type_filter(&mut sql, &mut all_params, "chunk_type", type_filter);
-    append_exclude_ids(&mut sql, &mut all_params, "id", exclude_ids);
-    sql.push_str(" ORDER BY id LIMIT ?");
-    all_params.push(Box::new(limit));
-
-    let mut stmt = conn.prepare(&sql)?;
-    let param_refs: Vec<&dyn rusqlite::types::ToSql> =
-        all_params.iter().map(|b| b.as_ref()).collect();
-
-    let rows = stmt.query_map(param_refs.as_slice(), |row| {
-        Ok(SearchResult {
-            chunk: chunk_from_row(row, 1)?,
-            chunk_id: Some(row.get(0)?),
-            distance: f32::INFINITY,
-            match_source: MatchSource::NameMatch,
-            score: 0.5,
-        })
-    })?;
-
-    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
-}
-
-pub fn search_by_content(
+pub fn search_by_fts(
     conn: &Connection,
     keywords: &[&str],
     type_filter: Option<&[ChunkType]>,
@@ -121,7 +70,6 @@ pub fn search_by_content(
         .filter_map(|k| {
             match rurico::storage::prepare_match_query(conn, k) {
                 Ok(m) if !m.as_str().is_empty() => Some(m.into_string()),
-                // prepare_match_query rejects bare FTS5 operators; fts_quote wraps them safely.
                 Err(_) if !k.trim().is_empty() => Some(rurico::storage::fts_quote(k)),
                 _ => None,
             }
@@ -132,9 +80,12 @@ pub fn search_by_content(
     }
     let fts_query = parts.join(" AND ");
 
-    let mut sql = String::from(
+    const BM25_EXPR: &str = "bm25(fts_chunks, 5.0, 1.0, 3.0)";
+
+    let mut sql = format!(
         "SELECT c.id, c.file_path, c.chunk_type, c.name, c.content,
-                c.start_line, c.end_line, c.parent_chunk_id
+                c.start_line, c.end_line, c.parent_chunk_id,
+                {BM25_EXPR}
          FROM fts_chunks f
          INNER JOIN chunks c ON c.id = f.rowid
          WHERE fts_chunks MATCH ?1",
@@ -145,19 +96,22 @@ pub fn search_by_content(
 
     append_type_filter(&mut sql, &mut params, "c.chunk_type", type_filter);
     append_exclude_ids(&mut sql, &mut params, "c.id", exclude_ids);
-    sql.push_str(" ORDER BY rank LIMIT ?");
+    sql.push_str(&format!(" ORDER BY {BM25_EXPR} LIMIT ?"));
     params.push(Box::new(limit));
 
     let mut stmt = conn.prepare(&sql)?;
     let param_refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|b| b.as_ref()).collect();
 
     let rows = stmt.query_map(param_refs.as_slice(), |row| {
+        let bm25_score: f64 = row.get(8)?;
+        let abs = (bm25_score as f32).abs();
+        let base_score = abs / (1.0 + abs);
         Ok(SearchResult {
             chunk: chunk_from_row(row, 1)?,
             chunk_id: Some(row.get(0)?),
             distance: f32::INFINITY,
-            match_source: MatchSource::ContentMatch,
-            score: 0.45,
+            match_source: MatchSource::Fts,
+            score: base_score,
         })
     })?;
 
@@ -262,13 +216,3 @@ fn append_exclude_ids(
     }
 }
 
-fn escape_like(s: &str) -> String {
-    let mut escaped = String::with_capacity(s.len());
-    for c in s.chars() {
-        if matches!(c, '%' | '_' | '\\') {
-            escaped.push('\\');
-        }
-        escaped.push(c);
-    }
-    escaped
-}

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -67,12 +67,10 @@ pub fn search_by_fts(
 
     let parts: Vec<String> = keywords
         .iter()
-        .filter_map(|k| {
-            match rurico::storage::prepare_match_query(conn, k) {
-                Ok(m) if !m.as_str().is_empty() => Some(m.into_string()),
-                Err(_) if !k.trim().is_empty() => Some(rurico::storage::fts_quote(k)),
-                _ => None,
-            }
+        .filter_map(|k| match rurico::storage::prepare_match_query(conn, k) {
+            Ok(m) if !m.as_str().is_empty() => Some(m.into_string()),
+            Err(_) if !k.trim().is_empty() => Some(rurico::storage::fts_quote(k)),
+            _ => None,
         })
         .collect();
     if parts.is_empty() {
@@ -215,4 +213,3 @@ fn append_exclude_ids(
         }
     }
 }
-

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -2541,9 +2541,11 @@ fn t_004_search_by_fts_finds_camelcase_by_split_keywords() {
     replace_file_chunks_only(&conn, "src/form.tsx", &chunks, "h1", "", &[], None).unwrap();
 
     // Search with split keywords ["handle", "submit"] should find handleSubmit
-    let results =
-        search_by_fts(&conn, &["handle", "submit"], None, &HashSet::new(), 10).unwrap();
-    let names: Vec<_> = results.iter().filter_map(|r| r.chunk.name.as_deref()).collect();
+    let results = search_by_fts(&conn, &["handle", "submit"], None, &HashSet::new(), 10).unwrap();
+    let names: Vec<_> = results
+        .iter()
+        .filter_map(|r| r.chunk.name.as_deref())
+        .collect();
     assert!(
         names.contains(&"handleSubmit"),
         "[T-004] should find handleSubmit via split keywords, got: {names:?}"
@@ -2626,7 +2628,11 @@ fn t_007_search_by_fts_respects_type_filter() {
         10,
     )
     .unwrap();
-    assert_eq!(results.len(), 1, "[T-007] type_filter should limit to hooks");
+    assert_eq!(
+        results.len(),
+        1,
+        "[T-007] type_filter should limit to hooks"
+    );
     assert_eq!(results[0].chunk.name.as_deref(), Some("useAuth"));
 }
 
@@ -2661,6 +2667,10 @@ fn t_016_search_by_fts_excludes_ids() {
     let mut exclude = HashSet::new();
     exclude.insert(first_id);
     let filtered = search_by_fts(&conn, &["auth"], None, &exclude, 10).unwrap();
-    assert_eq!(filtered.len(), 1, "[T-016] excluded id should be filtered out");
+    assert_eq!(
+        filtered.len(),
+        1,
+        "[T-016] excluded id should be filtered out"
+    );
     assert_ne!(filtered[0].chunk_id, Some(first_id));
 }

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -1230,110 +1230,6 @@ fn get_files_by_import_count_returns_most_imported_first() {
 }
 
 #[test]
-fn search_by_name_matches_keyword() {
-    let (conn, _dir) = test_db();
-
-    let chunks = vec![
-        NewChunk {
-            chunk_type: &ChunkType::Hook,
-            name: Some("useAuth"),
-            content: "function useAuth() {}",
-            start_line: 1,
-            end_line: 3,
-            parent_index: None,
-        },
-        NewChunk {
-            chunk_type: &ChunkType::Component,
-            name: Some("LoginForm"),
-            content: "function LoginForm() {}",
-            start_line: 5,
-            end_line: 10,
-            parent_index: None,
-        },
-    ];
-    replace_file_chunks_only(&conn, "src/hooks.tsx", &chunks, "h1", "", &[], None).unwrap();
-
-    let results = search_by_name(&conn, &["auth"], None, &HashSet::new(), 10).unwrap();
-
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].chunk.name.as_deref(), Some("useAuth"));
-    assert_eq!(results[0].match_source, MatchSource::NameMatch);
-    assert_eq!(results[0].distance, f32::INFINITY);
-}
-
-#[test]
-fn search_by_name_filters_by_type() {
-    let (conn, _dir) = test_db();
-
-    let chunks = vec![
-        NewChunk {
-            chunk_type: &ChunkType::Hook,
-            name: Some("useBtn"),
-            content: "function useBtn() {}",
-            start_line: 1,
-            end_line: 3,
-            parent_index: None,
-        },
-        NewChunk {
-            chunk_type: &ChunkType::Component,
-            name: Some("BtnGroup"),
-            content: "function BtnGroup() {}",
-            start_line: 5,
-            end_line: 10,
-            parent_index: None,
-        },
-    ];
-    replace_file_chunks_only(&conn, "src/btn.tsx", &chunks, "h1", "", &[], None).unwrap();
-
-    let results = search_by_name(
-        &conn,
-        &["btn"],
-        Some(&[ChunkType::Hook]),
-        &HashSet::new(),
-        10,
-    )
-    .unwrap();
-
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].chunk.name.as_deref(), Some("useBtn"));
-    assert_eq!(results[0].chunk.chunk_type, ChunkType::Hook);
-}
-
-#[test]
-fn search_by_name_excludes_ids() {
-    let (conn, _dir) = test_db();
-
-    let chunks = vec![
-        NewChunk {
-            chunk_type: &ChunkType::Hook,
-            name: Some("useAuth"),
-            content: "function useAuth() {}",
-            start_line: 1,
-            end_line: 3,
-            parent_index: None,
-        },
-        NewChunk {
-            chunk_type: &ChunkType::Hook,
-            name: Some("useAuthProvider"),
-            content: "function useAuthProvider() {}",
-            start_line: 5,
-            end_line: 10,
-            parent_index: None,
-        },
-    ];
-    replace_file_chunks_only(&conn, "src/auth.tsx", &chunks, "h1", "", &[], None).unwrap();
-
-    let ids = get_chunk_ids(&conn, "src/auth.tsx");
-    let mut exclude = HashSet::new();
-    exclude.insert(ids[0]);
-
-    let results = search_by_name(&conn, &["auth"], None, &exclude, 10).unwrap();
-
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].chunk.name.as_deref(), Some("useAuthProvider"));
-}
-
-#[test]
 fn get_files_by_import_count_boosts_hook_component_files() {
     let (conn, _dir) = test_db();
 
@@ -1429,24 +1325,6 @@ fn search_similar_sets_semantic_match_source() {
 }
 
 #[test]
-fn search_by_name_empty_keywords_returns_empty() {
-    let (conn, _dir) = test_db();
-
-    let chunks = vec![NewChunk {
-        chunk_type: &ChunkType::Hook,
-        name: Some("useAuth"),
-        content: "code",
-        start_line: 1,
-        end_line: 3,
-        parent_index: None,
-    }];
-    replace_file_chunks_only(&conn, "src/auth.tsx", &chunks, "h1", "", &[], None).unwrap();
-
-    let results = search_by_name(&conn, &[], None, &HashSet::new(), 10).unwrap();
-    assert!(results.is_empty());
-}
-
-#[test]
 fn search_similar_sets_initial_score() {
     let (conn, _dir) = test_db();
     let mut emb = vec![0.0_f32; EMBEDDING_DIMS as usize];
@@ -1477,29 +1355,6 @@ fn search_similar_sets_initial_score() {
     assert!(
         (results[0].score - expected_score).abs() < 1e-6,
         "expected score {expected_score}, got {}",
-        results[0].score
-    );
-}
-
-#[test]
-fn search_by_name_sets_base_score() {
-    let (conn, _dir) = test_db();
-
-    let chunks = vec![NewChunk {
-        chunk_type: &ChunkType::Hook,
-        name: Some("useAuth"),
-        content: "function useAuth() {}",
-        start_line: 1,
-        end_line: 3,
-        parent_index: None,
-    }];
-    replace_file_chunks_only(&conn, "src/auth.tsx", &chunks, "h1", "", &[], None).unwrap();
-
-    let results = search_by_name(&conn, &["auth"], None, &HashSet::new(), 10).unwrap();
-    assert_eq!(results.len(), 1);
-    assert!(
-        (results[0].score - 0.5).abs() < 1e-6,
-        "NameMatch score should be 0.5, got {}",
         results[0].score
     );
 }
@@ -1585,151 +1440,6 @@ fn get_import_counts_returns_empty_for_empty_input() {
 }
 
 #[test]
-fn search_by_name_respects_limit() {
-    let (conn, _dir) = test_db();
-
-    let chunks = vec![
-        NewChunk {
-            chunk_type: &ChunkType::Hook,
-            name: Some("useAuthA"),
-            content: "code",
-            start_line: 1,
-            end_line: 3,
-            parent_index: None,
-        },
-        NewChunk {
-            chunk_type: &ChunkType::Hook,
-            name: Some("useAuthB"),
-            content: "code",
-            start_line: 5,
-            end_line: 8,
-            parent_index: None,
-        },
-        NewChunk {
-            chunk_type: &ChunkType::Hook,
-            name: Some("useAuthC"),
-            content: "code",
-            start_line: 10,
-            end_line: 13,
-            parent_index: None,
-        },
-    ];
-    replace_file_chunks_only(&conn, "src/auth.tsx", &chunks, "h1", "", &[], None).unwrap();
-
-    let results = search_by_name(&conn, &["auth"], None, &HashSet::new(), 2).unwrap();
-    assert_eq!(results.len(), 2);
-}
-
-#[test]
-fn search_by_name_matches_file_path() {
-    let (conn, _dir) = test_db();
-
-    // Chunk with no name but file_path contains "fetch"
-    let chunks = vec![NewChunk {
-        chunk_type: &ChunkType::Other,
-        name: None,
-        content: "export default {}",
-        start_line: 1,
-        end_line: 3,
-        parent_index: None,
-    }];
-    replace_file_chunks_only(
-        &conn,
-        "src/utils/fetch-data.ts",
-        &chunks,
-        "h1",
-        "",
-        &[],
-        None,
-    )
-    .unwrap();
-
-    let results = search_by_name(&conn, &["fetch"], None, &HashSet::new(), 10).unwrap();
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].chunk.file_path, "src/utils/fetch-data.ts");
-}
-
-#[test]
-fn search_by_name_matches_name_or_path() {
-    let (conn, _dir) = test_db();
-
-    // Named chunk in unrelated path
-    let named = vec![NewChunk {
-        chunk_type: &ChunkType::Hook,
-        name: Some("useFetch"),
-        content: "code",
-        start_line: 1,
-        end_line: 3,
-        parent_index: None,
-    }];
-    replace_file_chunks_only(&conn, "src/hooks.tsx", &named, "h1", "", &[], None).unwrap();
-
-    // Unnamed chunk in path containing keyword
-    let path_match = vec![NewChunk {
-        chunk_type: &ChunkType::Other,
-        name: None,
-        content: "code",
-        start_line: 1,
-        end_line: 3,
-        parent_index: None,
-    }];
-    replace_file_chunks_only(
-        &conn,
-        "src/fetch/client.ts",
-        &path_match,
-        "h2",
-        "",
-        &[],
-        None,
-    )
-    .unwrap();
-
-    let results = search_by_name(&conn, &["fetch"], None, &HashSet::new(), 10).unwrap();
-    assert_eq!(
-        results.len(),
-        2,
-        "should match both name and path: {results:?}"
-    );
-}
-
-#[test]
-fn search_by_name_path_match_respects_type_filter() {
-    let (conn, _dir) = test_db();
-
-    let chunks = vec![
-        NewChunk {
-            chunk_type: &ChunkType::Other,
-            name: None,
-            content: "helper",
-            start_line: 1,
-            end_line: 3,
-            parent_index: None,
-        },
-        NewChunk {
-            chunk_type: &ChunkType::Component,
-            name: Some("Chart"),
-            content: "component",
-            start_line: 5,
-            end_line: 10,
-            parent_index: None,
-        },
-    ];
-    replace_file_chunks_only(&conn, "src/chart/utils.tsx", &chunks, "h1", "", &[], None).unwrap();
-
-    // Filter to components only — path match on "chart" should return only the component
-    let results = search_by_name(
-        &conn,
-        &["chart"],
-        Some(&[ChunkType::Component]),
-        &HashSet::new(),
-        10,
-    )
-    .unwrap();
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].chunk.chunk_type, ChunkType::Component);
-}
-
-#[test]
 fn fts5_available() {
     let (conn, _dir) = test_db();
     // Verify FTS5 extension is compiled in
@@ -1739,76 +1449,6 @@ fn fts5_available() {
          DROP TABLE _fts5_test;",
     )
     .expect("FTS5 should be available");
-}
-
-#[test]
-fn search_by_content_matches_code() {
-    let (conn, _dir) = test_db();
-
-    let chunks = vec![
-        NewChunk {
-            chunk_type: &ChunkType::Hook,
-            name: Some("useFetch"),
-            content: "function useFetch() { const [loading, setLoading] = useState(false); }",
-            start_line: 1,
-            end_line: 5,
-            parent_index: None,
-        },
-        NewChunk {
-            chunk_type: &ChunkType::Component,
-            name: Some("Button"),
-            content: "function Button({ label }) { return <button>{label}</button>; }",
-            start_line: 7,
-            end_line: 10,
-            parent_index: None,
-        },
-    ];
-    replace_file_chunks_only(&conn, "src/hooks.tsx", &chunks, "h1", "", &[], None).unwrap();
-
-    let results = search_by_content(&conn, &["loading"], None, &HashSet::new(), 10).unwrap();
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].chunk.name.as_deref(), Some("useFetch"));
-    assert_eq!(results[0].match_source, MatchSource::ContentMatch);
-}
-
-#[test]
-fn search_by_content_excludes_ids() {
-    let (conn, _dir) = test_db();
-
-    let chunks = vec![
-        NewChunk {
-            chunk_type: &ChunkType::Hook,
-            name: Some("useA"),
-            content: "function useA() { fetch('/api'); }",
-            start_line: 1,
-            end_line: 3,
-            parent_index: None,
-        },
-        NewChunk {
-            chunk_type: &ChunkType::Hook,
-            name: Some("useB"),
-            content: "function useB() { fetch('/data'); }",
-            start_line: 5,
-            end_line: 7,
-            parent_index: None,
-        },
-    ];
-    replace_file_chunks_only(&conn, "src/hooks.tsx", &chunks, "h1", "", &[], None).unwrap();
-
-    let ids = get_chunk_ids(&conn, "src/hooks.tsx");
-    let mut exclude = HashSet::new();
-    exclude.insert(ids[0]);
-
-    let results = search_by_content(&conn, &["fetch"], None, &exclude, 10).unwrap();
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].chunk.name.as_deref(), Some("useB"));
-}
-
-#[test]
-fn search_by_content_empty_keywords_returns_empty() {
-    let (conn, _dir) = test_db();
-    let results = search_by_content(&conn, &[], None, &HashSet::new(), 10).unwrap();
-    assert!(results.is_empty());
 }
 
 #[test]
@@ -1826,14 +1466,14 @@ fn fts_chunks_deleted_with_file() {
     replace_file_chunks_only(&conn, "src/x.tsx", &chunks, "h1", "", &[], None).unwrap();
 
     // Should find it before delete
-    let results = search_by_content(&conn, &["state"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["state"], None, &HashSet::new(), 10).unwrap();
     assert_eq!(results.len(), 1);
 
     // Delete file chunks
     delete_file_chunks(&conn, "src/x.tsx").unwrap();
 
     // Should not find it after delete
-    let results = search_by_content(&conn, &["state"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["state"], None, &HashSet::new(), 10).unwrap();
     assert!(results.is_empty());
 }
 
@@ -1863,7 +1503,7 @@ fn fts5_migration_from_v2() {
     .unwrap();
 
     // Verify FTS5 is empty
-    let results = search_by_content(&conn, &["loading"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["loading"], None, &HashSet::new(), 10).unwrap();
     assert!(
         results.is_empty(),
         "fts_chunks should be empty before migration"
@@ -1874,7 +1514,7 @@ fn fts5_migration_from_v2() {
     let conn = open_db(&db_path).unwrap();
 
     // Migration should have populated fts_chunks from existing chunks
-    let results = search_by_content(&conn, &["loading"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["loading"], None, &HashSet::new(), 10).unwrap();
     assert_eq!(results.len(), 1, "migration should populate fts_chunks");
     assert_eq!(results[0].chunk.name.as_deref(), Some("useX"));
 }
@@ -1893,46 +1533,9 @@ fn fts5_handles_special_characters_in_content() {
     }];
     replace_file_chunks_only(&conn, "src/App.tsx", &chunks, "h1", "", &[], None).unwrap();
 
-    let results = search_by_content(&conn, &["container"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["container"], None, &HashSet::new(), 10).unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].chunk.name.as_deref(), Some("App"));
-}
-
-#[test]
-fn search_by_content_respects_type_filter() {
-    let (conn, _dir) = test_db();
-
-    let chunks = vec![
-        NewChunk {
-            chunk_type: &ChunkType::Hook,
-            name: Some("useFetch"),
-            content: "function useFetch() { fetch('/api'); }",
-            start_line: 1,
-            end_line: 3,
-            parent_index: None,
-        },
-        NewChunk {
-            chunk_type: &ChunkType::Component,
-            name: Some("FetchBtn"),
-            content: "function FetchBtn() { onClick(() => fetch('/btn')); }",
-            start_line: 5,
-            end_line: 8,
-            parent_index: None,
-        },
-    ];
-    replace_file_chunks_only(&conn, "src/hooks.tsx", &chunks, "h1", "", &[], None).unwrap();
-
-    // Filter to hooks only
-    let results = search_by_content(
-        &conn,
-        &["fetch"],
-        Some(&[ChunkType::Hook]),
-        &HashSet::new(),
-        10,
-    )
-    .unwrap();
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].chunk.name.as_deref(), Some("useFetch"));
 }
 
 #[test]
@@ -2076,7 +1679,7 @@ fn migration_v3_to_v4_creates_vocab_table() {
             |row| row.get(0),
         )
         .unwrap();
-    assert_eq!(version, "6", "schema_version should be 6 after migration");
+    assert_eq!(version, "7", "schema_version should be 7 after migration");
 
     let exists: bool = conn
         .query_row(
@@ -2091,7 +1694,7 @@ fn migration_v3_to_v4_creates_vocab_table() {
     );
 
     // Verify data preserved: chunk should still be searchable
-    let results = search_by_content(&conn, &["migrationTest"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["migrationTest"], None, &HashSet::new(), 10).unwrap();
     assert!(
         !results.is_empty(),
         "seeded chunk should survive v3->v4 migration"
@@ -2128,131 +1731,6 @@ fn get_file_mtimes_empty_input_returns_empty() {
     let (conn, _dir) = test_db();
     let mtimes = get_file_mtimes(&conn, &[]).unwrap();
     assert!(mtimes.is_empty());
-}
-
-#[test]
-fn search_by_content_expands_short_prefix() {
-    let (conn, _dir) = test_db();
-
-    let chunks = vec![NewChunk {
-        chunk_type: &ChunkType::Other,
-        name: Some("authenticate"),
-        content: "function authenticate() { return authentication(); }",
-        start_line: 1,
-        end_line: 3,
-        parent_index: None,
-    }];
-    replace_file_chunks_only(&conn, "src/auth.ts", &chunks, "h1", "", &[], None).unwrap();
-
-    let results = search_by_content(&conn, &["au"], None, &HashSet::new(), 10).unwrap();
-    assert!(
-        !results.is_empty(),
-        "short prefix 'au' should match 'authentication' via vocab expansion"
-    );
-    assert!(
-        results[0].chunk.content.contains("authentication"),
-        "result should contain 'authentication', got: {}",
-        results[0].chunk.content
-    );
-}
-
-#[test]
-fn search_by_content_short_terms_and_semantics() {
-    let (conn, _dir) = test_db();
-
-    let chunks_both = vec![NewChunk {
-        chunk_type: &ChunkType::Other,
-        name: Some("authLogger"),
-        content: "function authLogger() { authentication(); log('request received'); }",
-        start_line: 1,
-        end_line: 3,
-        parent_index: None,
-    }];
-    replace_file_chunks_only(
-        &conn,
-        "src/authLogger.ts",
-        &chunks_both,
-        "h1",
-        "",
-        &[],
-        None,
-    )
-    .unwrap();
-
-    let chunks_auth_only = vec![NewChunk {
-        chunk_type: &ChunkType::Other,
-        name: Some("authOnly"),
-        content: "function authOnly() { authentication(); }",
-        start_line: 1,
-        end_line: 3,
-        parent_index: None,
-    }];
-    replace_file_chunks_only(
-        &conn,
-        "src/authOnly.ts",
-        &chunks_auth_only,
-        "h2",
-        "",
-        &[],
-        None,
-    )
-    .unwrap();
-
-    let chunks_log_only = vec![NewChunk {
-        chunk_type: &ChunkType::Other,
-        name: Some("logOnly"),
-        content: "function logOnly() { logger.info('logged'); }",
-        start_line: 1,
-        end_line: 3,
-        parent_index: None,
-    }];
-    replace_file_chunks_only(
-        &conn,
-        "src/logOnly.ts",
-        &chunks_log_only,
-        "h3",
-        "",
-        &[],
-        None,
-    )
-    .unwrap();
-
-    // "au log" — both short terms. After expansion + AND, only authLogger should match
-    let results = search_by_content(&conn, &["au", "log"], None, &HashSet::new(), 10).unwrap();
-    assert_eq!(
-        results.len(),
-        1,
-        "AND semantics: only doc containing both expanded terms should match, got {} results",
-        results.len()
-    );
-    assert_eq!(
-        results[0].chunk.name.as_deref(),
-        Some("authLogger"),
-        "the matching doc should be authLogger"
-    );
-}
-
-#[test]
-fn search_by_content_preserves_operator_like_keywords() {
-    let (conn, _dir) = test_db();
-
-    let chunks = vec![NewChunk {
-        chunk_type: &ChunkType::Other,
-        name: Some("handleError"),
-        content: "function handleError() { if (not_found) throw new Error('not found'); }",
-        start_line: 1,
-        end_line: 3,
-        parent_index: None,
-    }];
-    replace_file_chunks_only(&conn, "src/error.ts", &chunks, "h1", "", &[], None).unwrap();
-
-    // "not" resembles FTS5 NOT operator but is a content word here.
-    // It must survive sanitization and match via fts_quote fallback.
-    let results = search_by_content(&conn, &["not"], None, &HashSet::new(), 10).unwrap();
-    assert!(
-        !results.is_empty(),
-        "operator-like keyword 'not' should match content, not be silently dropped"
-    );
 }
 
 #[test]
@@ -2318,46 +1796,6 @@ fn insert_chunk_rejects_wrong_embedding_dims() {
 }
 
 #[test]
-fn search_by_name_escapes_like_wildcards() {
-    let (conn, _dir) = test_db();
-
-    let chunks = vec![
-        NewChunk {
-            chunk_type: &ChunkType::Hook,
-            name: Some("use_Auth"),
-            content: "function use_Auth() {}",
-            start_line: 1,
-            end_line: 1,
-            parent_index: None,
-        },
-        NewChunk {
-            chunk_type: &ChunkType::Hook,
-            name: Some("useXAuth"),
-            content: "function useXAuth() {}",
-            start_line: 2,
-            end_line: 2,
-            parent_index: None,
-        },
-    ];
-    replace_file_chunks_only(&conn, "src/hooks.tsx", &chunks, "h1", "", &[], None).unwrap();
-
-    // Searching for "use_auth" should NOT match "useXAuth" via _ wildcard
-    let results = search_by_name(&conn, &["use_auth"], None, &HashSet::new(), 10).unwrap();
-    let names: Vec<_> = results
-        .iter()
-        .filter_map(|r| r.chunk.name.as_deref())
-        .collect();
-    assert!(
-        names.contains(&"use_Auth"),
-        "should find use_Auth, got: {names:?}"
-    );
-    assert!(
-        !names.contains(&"useXAuth"),
-        "_ should be escaped, not match useXAuth, got: {names:?}"
-    );
-}
-
-#[test]
 fn fts_automerge_guard_restores_on_drop() {
     let (conn, _dir) = test_db();
 
@@ -2402,7 +1840,7 @@ fn fts_automerge_guard_restores_on_drop() {
         None,
     )
     .unwrap();
-    let results = search_by_content(&conn, &["function"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["function"], None, &HashSet::new(), 10).unwrap();
     assert!(
         results.len() >= 2,
         "FTS should work after guard drop, got {} results",
@@ -2783,7 +2221,7 @@ fn t_011_chunk_from_row_reads_parent_chunk_id() {
         )
         .unwrap();
 
-    let results = search_by_content(&conn, &["handlesubmit"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["handlesubmit"], None, &HashSet::new(), 10).unwrap();
 
     assert!(
         !results.is_empty(),
@@ -2841,7 +2279,7 @@ fn t_011_chunk_from_row_reads_parent_chunk_id_name_search() {
         )
         .unwrap();
 
-    let results = search_by_name(&conn, &["handlesubmit"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["handlesubmit"], None, &HashSet::new(), 10).unwrap();
 
     assert!(
         !results.is_empty(),
@@ -2883,7 +2321,7 @@ fn t_012_parent_chunk_search_result_has_no_parent_chunk_id() {
     )
     .unwrap();
 
-    let results = search_by_name(&conn, &["userform"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["userform"], None, &HashSet::new(), 10).unwrap();
 
     assert!(!results.is_empty(), "should find UserForm via name search");
     let component_result = &results[0];
@@ -2892,4 +2330,337 @@ fn t_012_parent_chunk_search_result_has_no_parent_chunk_id() {
         component_result.chunk.parent_chunk_id, None,
         "[T-012] parent chunk should have parent_chunk_id = None in search results"
     );
+}
+
+// ── Phase 1: FTS 3-column unification (FR-001, FR-002, FR-010, FR-011) ──
+
+#[test]
+fn t_001_fts_stores_split_identifier_name() {
+    let (conn, _dir) = test_db();
+
+    let chunks = vec![NewChunk {
+        chunk_type: &ChunkType::Hook,
+        name: Some("useAuthProvider"),
+        content: "function useAuthProvider() { return auth; }",
+        start_line: 1,
+        end_line: 3,
+        parent_index: None,
+    }];
+    replace_file_chunks_only(&conn, "src/auth.tsx", &chunks, "h1", "", &[], None).unwrap();
+
+    let fts_name: String = conn
+        .query_row(
+            "SELECT name FROM fts_chunks WHERE rowid = (SELECT id FROM chunks LIMIT 1)",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    assert_eq!(
+        fts_name, "use Auth Provider",
+        "[T-001] FTS name column should contain split-identifier output"
+    );
+}
+
+#[test]
+fn t_002_fts_stores_empty_name_for_none() {
+    let (conn, _dir) = test_db();
+
+    let chunks = vec![NewChunk {
+        chunk_type: &ChunkType::Other,
+        name: None,
+        content: "const x = 42;",
+        start_line: 1,
+        end_line: 1,
+        parent_index: None,
+    }];
+    replace_file_chunks_only(&conn, "src/util.ts", &chunks, "h1", "", &[], None).unwrap();
+
+    let fts_name: String = conn
+        .query_row(
+            "SELECT name FROM fts_chunks WHERE rowid = (SELECT id FROM chunks LIMIT 1)",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    assert_eq!(
+        fts_name, "",
+        "[T-002] FTS name column should be empty string when chunk name is None"
+    );
+}
+
+#[test]
+fn t_003_fts_stores_file_path() {
+    let (conn, _dir) = test_db();
+
+    let chunks = vec![NewChunk {
+        chunk_type: &ChunkType::RustFn,
+        name: Some("login"),
+        content: "fn login() { authenticate(); }",
+        start_line: 1,
+        end_line: 3,
+        parent_index: None,
+    }];
+    replace_file_chunks_only(&conn, "src/auth/login.ts", &chunks, "h1", "", &[], None).unwrap();
+
+    let fts_path: String = conn
+        .query_row(
+            "SELECT file_path FROM fts_chunks WHERE rowid = (SELECT id FROM chunks LIMIT 1)",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    assert_eq!(
+        fts_path, "src/auth/login.ts",
+        "[T-003] FTS file_path column should store the raw file path"
+    );
+}
+
+#[test]
+fn t_014_migration_v6_to_v7_preserves_fts_search() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let conn = open_db(&db_path).unwrap();
+
+    let chunks = vec![NewChunk {
+        chunk_type: &ChunkType::RustFn,
+        name: Some("processData"),
+        content: "fn process_data() { transform(); }",
+        start_line: 1,
+        end_line: 3,
+        parent_index: None,
+    }];
+    replace_file_chunks_only(&conn, "src/data.rs", &chunks, "h1", "", &[], None).unwrap();
+
+    // Simulate a v6 DB: roll back schema_version, drop FTS tables
+    conn.execute(
+        "UPDATE index_meta SET value = '6' WHERE key = 'schema_version'",
+        [],
+    )
+    .unwrap();
+    conn.execute_batch("DROP TABLE IF EXISTS fts_chunks")
+        .unwrap();
+    conn.execute_batch("DROP TABLE IF EXISTS fts_chunks_vocab")
+        .unwrap();
+    drop(conn);
+
+    // Re-open triggers migration v6 -> v7
+    let conn = open_db(&db_path).unwrap();
+
+    let version: String = conn
+        .query_row(
+            "SELECT value FROM index_meta WHERE key = 'schema_version'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        version, "7",
+        "[T-014] schema_version should be 7 after migration"
+    );
+
+    let results = search_by_fts(&conn, &["transform"], None, &HashSet::new(), 10).unwrap();
+    assert_eq!(
+        results.len(),
+        1,
+        "[T-014] FTS search should return results after v6->v7 migration"
+    );
+    assert_eq!(results[0].chunk.name.as_deref(), Some("processData"));
+}
+
+#[test]
+fn t_015_migration_populates_fts_name_with_split_identifier() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let conn = open_db(&db_path).unwrap();
+
+    let chunks = vec![NewChunk {
+        chunk_type: &ChunkType::RustFn,
+        name: Some("getUserName"),
+        content: "fn get_user_name() { return name; }",
+        start_line: 1,
+        end_line: 3,
+        parent_index: None,
+    }];
+    replace_file_chunks_only(&conn, "src/user.rs", &chunks, "h1", "", &[], None).unwrap();
+
+    // Simulate pre-v7: roll back to v6, drop FTS tables
+    conn.execute(
+        "UPDATE index_meta SET value = '6' WHERE key = 'schema_version'",
+        [],
+    )
+    .unwrap();
+    conn.execute_batch("DROP TABLE IF EXISTS fts_chunks")
+        .unwrap();
+    conn.execute_batch("DROP TABLE IF EXISTS fts_chunks_vocab")
+        .unwrap();
+    drop(conn);
+
+    // Re-open triggers migration to v7
+    let conn = open_db(&db_path).unwrap();
+
+    let fts_name: String = conn
+        .query_row(
+            "SELECT name FROM fts_chunks WHERE rowid = (SELECT id FROM chunks LIMIT 1)",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        fts_name, "get User Name",
+        "[T-015] migration should populate FTS name with split_identifier output"
+    );
+}
+
+// === Phase 2: search_by_fts tests (T-004, T-005, T-007, T-016) ===
+
+#[test]
+fn t_004_search_by_fts_finds_camelcase_by_split_keywords() {
+    let (conn, _dir) = test_db();
+
+    let chunks = vec![
+        NewChunk {
+            chunk_type: &ChunkType::Hook,
+            name: Some("handleSubmit"),
+            content: "function handleSubmit() {}",
+            start_line: 1,
+            end_line: 3,
+            parent_index: None,
+        },
+        NewChunk {
+            chunk_type: &ChunkType::Hook,
+            name: Some("submitForm"),
+            content: "function submitForm() {}",
+            start_line: 5,
+            end_line: 7,
+            parent_index: None,
+        },
+    ];
+    replace_file_chunks_only(&conn, "src/form.tsx", &chunks, "h1", "", &[], None).unwrap();
+
+    // Search with split keywords ["handle", "submit"] should find handleSubmit
+    let results =
+        search_by_fts(&conn, &["handle", "submit"], None, &HashSet::new(), 10).unwrap();
+    let names: Vec<_> = results.iter().filter_map(|r| r.chunk.name.as_deref()).collect();
+    assert!(
+        names.contains(&"handleSubmit"),
+        "[T-004] should find handleSubmit via split keywords, got: {names:?}"
+    );
+    assert!(
+        !names.contains(&"submitForm"),
+        "[T-004] AND semantics: submitForm should NOT match [handle, submit], got: {names:?}"
+    );
+
+    // TC-7: verify FTS result fields
+    let fts_result = &results[0];
+    assert_eq!(
+        fts_result.match_source,
+        MatchSource::Fts,
+        "[TC-7] search_by_fts should set match_source to Fts"
+    );
+    assert!(
+        fts_result.distance.is_infinite(),
+        "[TC-7] search_by_fts should set distance to INFINITY"
+    );
+    assert!(
+        fts_result.score > 0.0,
+        "[TC-7] search_by_fts bm25 score should be positive, got {}",
+        fts_result.score
+    );
+}
+
+#[test]
+fn t_005_search_by_fts_finds_by_path_segment() {
+    let (conn, _dir) = test_db();
+
+    let chunks = vec![NewChunk {
+        chunk_type: &ChunkType::Other,
+        name: Some("login"),
+        content: "function login() {}",
+        start_line: 1,
+        end_line: 3,
+        parent_index: None,
+    }];
+    replace_file_chunks_only(&conn, "src/auth/login.ts", &chunks, "h1", "", &[], None).unwrap();
+
+    let results = search_by_fts(&conn, &["auth"], None, &HashSet::new(), 10).unwrap();
+    assert_eq!(
+        results.len(),
+        1,
+        "[T-005] should find chunk by path segment 'auth'"
+    );
+    assert_eq!(results[0].chunk.file_path, "src/auth/login.ts");
+}
+
+#[test]
+fn t_007_search_by_fts_respects_type_filter() {
+    let (conn, _dir) = test_db();
+
+    let chunks = vec![
+        NewChunk {
+            chunk_type: &ChunkType::Hook,
+            name: Some("useAuth"),
+            content: "function useAuth() {}",
+            start_line: 1,
+            end_line: 3,
+            parent_index: None,
+        },
+        NewChunk {
+            chunk_type: &ChunkType::Component,
+            name: Some("AuthButton"),
+            content: "function AuthButton() {}",
+            start_line: 5,
+            end_line: 7,
+            parent_index: None,
+        },
+    ];
+    replace_file_chunks_only(&conn, "src/auth.tsx", &chunks, "h1", "", &[], None).unwrap();
+
+    let results = search_by_fts(
+        &conn,
+        &["auth"],
+        Some(&[ChunkType::Hook]),
+        &HashSet::new(),
+        10,
+    )
+    .unwrap();
+    assert_eq!(results.len(), 1, "[T-007] type_filter should limit to hooks");
+    assert_eq!(results[0].chunk.name.as_deref(), Some("useAuth"));
+}
+
+#[test]
+fn t_016_search_by_fts_excludes_ids() {
+    let (conn, _dir) = test_db();
+
+    let chunks = vec![
+        NewChunk {
+            chunk_type: &ChunkType::Hook,
+            name: Some("useAuth"),
+            content: "function useAuth() {}",
+            start_line: 1,
+            end_line: 3,
+            parent_index: None,
+        },
+        NewChunk {
+            chunk_type: &ChunkType::Hook,
+            name: Some("useAuthProvider"),
+            content: "function useAuthProvider() {}",
+            start_line: 5,
+            end_line: 7,
+            parent_index: None,
+        },
+    ];
+    replace_file_chunks_only(&conn, "src/auth.tsx", &chunks, "h1", "", &[], None).unwrap();
+
+    let all = search_by_fts(&conn, &["auth"], None, &HashSet::new(), 10).unwrap();
+    assert_eq!(all.len(), 2);
+
+    let first_id = all[0].chunk_id.unwrap();
+    let mut exclude = HashSet::new();
+    exclude.insert(first_id);
+    let filtered = search_by_fts(&conn, &["auth"], None, &exclude, 10).unwrap();
+    assert_eq!(filtered.len(), 1, "[T-016] excluded id should be filtered out");
+    assert_ne!(filtered[0].chunk_id, Some(first_id));
 }

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,0 +1,101 @@
+pub fn split_identifier(s: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let chars: Vec<char> = s.chars().collect();
+
+    for i in 0..chars.len() {
+        let c = chars[i];
+        if c == '-' || c == '_' {
+            if !current.is_empty() {
+                parts.push(std::mem::take(&mut current));
+            }
+        } else if c.is_uppercase() {
+            let prev_lower = i > 0 && chars[i - 1].is_lowercase();
+            let prev_upper = i > 0 && chars[i - 1].is_uppercase();
+            let next_lower = i + 1 < chars.len() && chars[i + 1].is_lowercase();
+            if (prev_lower || (prev_upper && next_lower)) && !current.is_empty() {
+                parts.push(std::mem::take(&mut current));
+            }
+            current.push(c);
+        } else {
+            current.push(c);
+        }
+    }
+    if !current.is_empty() {
+        parts.push(current);
+    }
+    parts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn camel_case() {
+        assert_eq!(split_identifier("useChat"), vec!["use", "Chat"]);
+        assert_eq!(split_identifier("DataTable"), vec!["Data", "Table"]);
+    }
+
+    #[test]
+    fn acronym() {
+        assert_eq!(split_identifier("HTMLElement"), vec!["HTML", "Element"]);
+        assert_eq!(
+            split_identifier("getXMLParser"),
+            vec!["get", "XML", "Parser"]
+        );
+        assert_eq!(split_identifier("UIMessage"), vec!["UI", "Message"]);
+    }
+
+    #[test]
+    fn kebab_and_snake() {
+        assert_eq!(split_identifier("data-table"), vec!["data", "table"]);
+        assert_eq!(split_identifier("get_value"), vec!["get", "value"]);
+        assert_eq!(split_identifier("use-chat"), vec!["use", "chat"]);
+    }
+
+    #[test]
+    fn single_word() {
+        assert_eq!(split_identifier("stream"), vec!["stream"]);
+        assert_eq!(split_identifier("chat"), vec!["chat"]);
+    }
+
+    #[test]
+    fn empty_string() {
+        let result: Vec<String> = split_identifier("");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn delimiter_only() {
+        assert!(split_identifier("_").is_empty());
+        assert!(split_identifier("---").is_empty());
+        assert!(split_identifier("__").is_empty());
+    }
+
+    #[test]
+    fn single_char() {
+        assert_eq!(split_identifier("a"), vec!["a"]);
+        assert_eq!(split_identifier("A"), vec!["A"]);
+    }
+
+    #[test]
+    fn trailing_leading_delimiters() {
+        assert_eq!(split_identifier("_foo_"), vec!["foo"]);
+        assert_eq!(split_identifier("-bar-"), vec!["bar"]);
+    }
+
+    #[test]
+    fn all_uppercase() {
+        assert_eq!(split_identifier("HTTP"), vec!["HTTP"]);
+        assert_eq!(split_identifier("URL"), vec!["URL"]);
+    }
+
+    #[test]
+    fn mixed_delimiters() {
+        assert_eq!(
+            split_identifier("foo-bar_baz"),
+            vec!["foo", "bar", "baz"]
+        );
+    }
+}

--- a/src/text.rs
+++ b/src/text.rs
@@ -93,9 +93,6 @@ mod tests {
 
     #[test]
     fn mixed_delimiters() {
-        assert_eq!(
-            split_identifier("foo-bar_baz"),
-            vec!["foo", "bar", "baz"]
-        );
+        assert_eq!(split_identifier("foo-bar_baz"), vec!["foo", "bar", "baz"]);
     }
 }

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -562,7 +562,7 @@ fn format_results_grouped_shows_score_for_all() {
             },
             chunk_id: None,
             distance: f32::INFINITY,
-            match_source: storage::MatchSource::NameMatch,
+            match_source: storage::MatchSource::Fts,
             score: 0.55,
         },
     ];
@@ -1317,7 +1317,7 @@ fn t011_innerfn_hit_shows_parent_context_in_text_output() {
         },
         chunk_id: Some(43),
         distance: 0.15,
-        match_source: storage::MatchSource::ContentMatch,
+        match_source: storage::MatchSource::Fts,
         score: 0.85,
     }];
     let ctx = EnrichmentContext {
@@ -1392,7 +1392,7 @@ fn t015_json_output_includes_parent_chunk_id() {
             },
             chunk_id: Some(43),
             distance: 0.2,
-            match_source: storage::MatchSource::ContentMatch,
+            match_source: storage::MatchSource::Fts,
             score: 0.80,
         },
         storage::SearchResult {
@@ -1518,7 +1518,7 @@ fn tc_003_parent_and_child_both_in_results_no_duplicate() {
             },
             chunk_id: Some(43),
             distance: 0.15,
-            match_source: storage::MatchSource::ContentMatch,
+            match_source: storage::MatchSource::Fts,
             score: 0.85,
         },
     ];


### PR DESCRIPTION
## 概要と背景

`search_by_name`（`LIKE '%keyword%'` — O(N) フルスキャン）と `search_by_content`（FTS5 MATCH）を1本の3カラム FTS5 テーブルに統合した。
exclude_ids による逐次実行とスコアリング定数の手動管理を排除し、bm25() カラムウェイトによる単一クエリに置き換える。

## 変更内容

- 3カラム FTS5 テーブル（name / content / file_path）を導入し、スキーマを v6→v7 へマイグレーション — LIKE スキャンを O(log N) に改善
- `MatchSource` enum・スコアリング定数6個・`escape_like` ユーティリティを削除し、`src/query/mod.rs` の検索パイプラインを単純化
- `split_identifier`（`src/text.rs`）を新設し、FTS5 のキャメルケース/スネークケーストークナイゼーションをサポート
- `embed_coverage()` を `embed_percentage()` から分離し、型と HashMap import を整理

## スコープ

- **対象外**: ベクトル検索（semantic search）のロジックは変更なし

## 設計判断

- bm25() のカラムウェイトで name を content より重く扱う方針を採用（`adr/0001-unify-search-into-3-column-fts5-with-bm25.md` に記録）
- 2クエリ→1クエリへの統合により、exclude_ids の受け渡しが不要になり呼び出し側のコードも単純化できた
- 差し引き -94 行（726 追加 / 820 削除）

## テスト方法

- [ ] `cargo test` — 34 テスト全件パス
- [ ] インデックス済みリポジトリで `yomu search "<identifier>"` でキャメルケース・スネークケース名がヒットすることを確認
- [ ] `yomu search "<keyword>"` で content マッチも返ることを確認
- [ ] v6 DB 環境で起動し v7 自動マイグレーションが完了することを確認

## 関連

Closes #37