### PR TITLE
rurico API rev 5569a30 へのマイグレーション

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,12 +2039,13 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=dd1ad45#dd1ad45c6007c3e1114034a435eef8424f977e48"
+source = "git+https://github.com/thkt/rurico?rev=5569a30#5569a30cc9a6509b5ce2b8220e95dc0257a35d2c"
 dependencies = [
  "bytemuck",
  "hf-hub",
  "log",
  "mlx-rs",
+ "mlx-sys",
  "rusqlite",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ test-support = ["rurico/test-support"]
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
-rurico = { git = "https://github.com/thkt/rurico", rev = "dd1ad45" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "5569a30" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -27,7 +27,7 @@ tree-sitter-rust = "0.24"
 tree-sitter-typescript = "0.23"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "dd1ad45", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "5569a30", features = ["test-support"] }
 tempfile = "3"
 
 [profile.release]

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -112,7 +112,7 @@ fn open_db(root: &Path) -> Arc<Mutex<yomu::storage::Db>> {
 }
 
 fn load_embedder() -> Option<rurico::embed::Embedder> {
-    let paths = rurico::embed::download_model().ok()?;
+    let paths = rurico::embed::download_model(rurico::embed::ModelId::default()).ok()?;
     rurico::embed::Embedder::new(&paths).ok()
 }
 

--- a/src/indexer/embed.rs
+++ b/src/indexer/embed.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use rurico::embed::{Embed, EmbedError};
+use rurico::embed::{ChunkedEmbedding, Embed, EmbedError};
 
 use crate::resolver::Resolver;
 use crate::rust_resolver::RustResolver;
@@ -25,6 +25,8 @@ pub(super) struct EmbedStoreResult {
 
 enum EmbedFailure {
     Abort(EmbedError),
+    /// rurico returned an empty `ChunkedEmbedding.chunks`, violating its documented contract.
+    Contract,
     Skip,
 }
 
@@ -64,6 +66,33 @@ fn classify_embed_error(
         EmbedFailure::Abort(e)
     } else {
         EmbedFailure::Skip
+    }
+}
+
+/// yomu stores one embedding per source chunk (1:1 schema). When rurico
+/// produces multiple overlapping chunks for long texts, only the first is kept.
+///
+/// Returns `Err(())` if rurico violates its contract by returning empty chunks.
+fn first_chunk(emb: ChunkedEmbedding) -> Result<Vec<f32>, ()> {
+    emb.chunks.into_iter().next().ok_or(())
+}
+
+fn run_embed_batch(
+    embedder: &(impl Embed + ?Sized),
+    texts: &[String],
+    consecutive_errors: &mut u32,
+    file_path: &str,
+) -> Result<Vec<Vec<f32>>, EmbedFailure> {
+    let texts_ref: Vec<&str> = texts.iter().map(String::as_str).collect();
+    match embedder.embed_documents_batch(&texts_ref) {
+        Ok(embs) => {
+            *consecutive_errors = 0;
+            embs.into_iter()
+                .map(first_chunk)
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|()| EmbedFailure::Contract)
+        }
+        Err(e) => Err(classify_embed_error(e, consecutive_errors, file_path)),
     }
 }
 
@@ -113,24 +142,19 @@ pub(super) fn embed_and_store(
             })
             .collect();
 
-        let texts_ref: Vec<&str> = texts.iter().map(String::as_str).collect();
-        let embeddings = match embedder.embed_documents_batch(&texts_ref) {
-            Ok(embs) => {
-                consecutive_errors = 0;
-                embs
+        let embeddings = match run_embed_batch(embedder, &texts, &mut consecutive_errors, &pf.rel_path) {
+            Ok(embs) => embs,
+            Err(EmbedFailure::Abort(e)) => return Err(IndexError::Embed(e)),
+            Err(EmbedFailure::Contract) => return Err(IndexError::Internal(
+                "rurico returned empty ChunkedEmbedding.chunks (contract violation)".into(),
+            )),
+            Err(EmbedFailure::Skip) => {
+                files_errored += 1;
+                continue;
             }
-            Err(e) => match classify_embed_error(e, &mut consecutive_errors, &pf.rel_path) {
-                EmbedFailure::Abort(e) => {
-                    return Err(IndexError::Embed(e));
-                }
-                EmbedFailure::Skip => {
-                    files_errored += 1;
-                    continue;
-                }
-            },
         };
 
-        let n = pf.raw_chunks.len() as u32;
+        let n = embeddings.len() as u32;
         let refs = if pf.rel_path.ends_with(".rs") {
             build_references(&pf.parsed_imports, &pf.rel_path, rust_resolver)
         } else {
@@ -211,16 +235,13 @@ fn embed_file_chunks(
     texts: Vec<String>,
     consecutive_errors: &mut u32,
 ) -> Result<Option<u32>, IndexError> {
-    let texts_ref: Vec<&str> = texts.iter().map(String::as_str).collect();
-    let embeddings = match embedder.embed_documents_batch(&texts_ref) {
-        Ok(embs) => {
-            *consecutive_errors = 0;
-            embs
-        }
-        Err(e) => match classify_embed_error(e, consecutive_errors, file_path) {
-            EmbedFailure::Abort(e) => return Err(IndexError::Embed(e)),
-            EmbedFailure::Skip => return Ok(None),
-        },
+    let embeddings = match run_embed_batch(embedder, &texts, consecutive_errors, file_path) {
+        Ok(embs) => embs,
+        Err(EmbedFailure::Abort(e)) => return Err(IndexError::Embed(e)),
+        Err(EmbedFailure::Contract) => return Err(IndexError::Internal(
+            "rurico returned empty ChunkedEmbedding.chunks (contract violation)".into(),
+        )),
+        Err(EmbedFailure::Skip) => return Ok(None),
     };
 
     if embeddings.len() != chunk_ids.len() {
@@ -322,4 +343,25 @@ pub fn run_incremental_embed(
         files_completed,
         budget_exhausted,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_chunk_returns_err_on_empty_chunks() {
+        assert!(first_chunk(ChunkedEmbedding { chunks: vec![] }).is_err());
+    }
+
+    #[test]
+    fn first_chunk_takes_first_only() {
+        let v1 = vec![1.0_f32; 3];
+        let v2 = vec![2.0_f32; 3];
+        let result = first_chunk(ChunkedEmbedding {
+            chunks: vec![v1.clone(), v2],
+        })
+        .unwrap();
+        assert_eq!(result, v1);
+    }
 }

--- a/src/indexer/embed.rs
+++ b/src/indexer/embed.rs
@@ -142,17 +142,20 @@ pub(super) fn embed_and_store(
             })
             .collect();
 
-        let embeddings = match run_embed_batch(embedder, &texts, &mut consecutive_errors, &pf.rel_path) {
-            Ok(embs) => embs,
-            Err(EmbedFailure::Abort(e)) => return Err(IndexError::Embed(e)),
-            Err(EmbedFailure::Contract) => return Err(IndexError::Internal(
-                "rurico returned empty ChunkedEmbedding.chunks (contract violation)".into(),
-            )),
-            Err(EmbedFailure::Skip) => {
-                files_errored += 1;
-                continue;
-            }
-        };
+        let embeddings =
+            match run_embed_batch(embedder, &texts, &mut consecutive_errors, &pf.rel_path) {
+                Ok(embs) => embs,
+                Err(EmbedFailure::Abort(e)) => return Err(IndexError::Embed(e)),
+                Err(EmbedFailure::Contract) => {
+                    return Err(IndexError::Internal(
+                        "rurico returned empty ChunkedEmbedding.chunks (contract violation)".into(),
+                    ));
+                }
+                Err(EmbedFailure::Skip) => {
+                    files_errored += 1;
+                    continue;
+                }
+            };
 
         let n = embeddings.len() as u32;
         let refs = if pf.rel_path.ends_with(".rs") {
@@ -238,9 +241,11 @@ fn embed_file_chunks(
     let embeddings = match run_embed_batch(embedder, &texts, consecutive_errors, file_path) {
         Ok(embs) => embs,
         Err(EmbedFailure::Abort(e)) => return Err(IndexError::Embed(e)),
-        Err(EmbedFailure::Contract) => return Err(IndexError::Internal(
-            "rurico returned empty ChunkedEmbedding.chunks (contract violation)".into(),
-        )),
+        Err(EmbedFailure::Contract) => {
+            return Err(IndexError::Internal(
+                "rurico returned empty ChunkedEmbedding.chunks (contract violation)".into(),
+            ));
+        }
         Err(EmbedFailure::Skip) => return Ok(None),
     };
 

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -208,15 +208,15 @@ fn process_file(
     } else {
         build_references(&pf.parsed_imports, &pf.rel_path, resolver)
     };
-    storage::replace_file_chunks_only(
-        conn,
-        &pf.rel_path,
-        &new_chunks,
-        &pf.hash,
-        &pf.imports_text,
-        &refs,
-        pf.mtime_epoch,
-    )?;
+    let data = storage::FileData {
+        file_path: &pf.rel_path,
+        chunks: &new_chunks,
+        file_hash: &pf.hash,
+        imports_text: &pf.imports_text,
+        refs: &refs,
+        mtime_epoch: pf.mtime_epoch,
+    };
+    storage::replace_file_data(conn, &data, None)?;
     Ok(FileOutcome::Processed(n))
 }
 

--- a/src/indexer/tests.rs
+++ b/src/indexer/tests.rs
@@ -1,6 +1,8 @@
 use super::*;
 
-use rurico::embed::{AlternatingEmbedder, FailingEmbedder, MismatchEmbedder, MockEmbedder};
+use rurico::embed::{
+    AlternatingEmbedder, FailingEmbedder, MismatchEmbedder, MockChunkedEmbedder, MockEmbedder,
+};
 
 #[test]
 fn file_hash_is_deterministic() {
@@ -98,7 +100,13 @@ fn run_index_with_mock_embedder() {
     let conn = storage::open_db(&db_path).unwrap();
     let conn = Arc::new(Mutex::new(conn));
 
-    let result = run_index(Arc::clone(&conn), dir.path(), &MockEmbedder, false).unwrap();
+    let result = run_index(
+        Arc::clone(&conn),
+        dir.path(),
+        &MockEmbedder::default(),
+        false,
+    )
+    .unwrap();
 
     assert_eq!(result.files_processed, 2);
     assert!(result.chunks_created >= 2);
@@ -107,6 +115,39 @@ fn run_index_with_mock_embedder() {
     let stats = storage::get_stats(&conn.lock().unwrap()).unwrap();
     assert_eq!(stats.total_files, 2);
     assert!(stats.total_chunks >= 2);
+}
+
+#[test]
+fn run_index_with_multi_chunk_embedder_keeps_first_only() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let src_dir = dir.path().join("src");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::write(
+        src_dir.join("App.tsx"),
+        "function App() { return <main/>; }",
+    )
+    .unwrap();
+
+    let db_path = dir.path().join(".yomu").join("index.db");
+    let conn = storage::open_db(&db_path).unwrap();
+    let conn = Arc::new(Mutex::new(conn));
+
+    // MockChunkedEmbedder returns 3 chunks per document; first_chunk keeps only the first.
+    let result = run_index(
+        Arc::clone(&conn),
+        dir.path(),
+        &MockChunkedEmbedder::new(3),
+        false,
+    )
+    .unwrap();
+
+    assert_eq!(result.files_processed, 1);
+    assert_eq!(result.files_errored, 0);
+
+    let stats = storage::get_stats(&conn.lock().unwrap()).unwrap();
+    // Embedding count must equal embeddable chunk count (1:1), NOT chunk_count * 3.
+    assert_eq!(stats.embedded_chunks, stats.embeddable_chunks);
 }
 
 #[test]
@@ -121,11 +162,23 @@ fn run_index_skips_unchanged_files() {
     let conn = Arc::new(Mutex::new(conn));
 
     // First run: processes file
-    let r1 = run_index(Arc::clone(&conn), dir.path(), &MockEmbedder, false).unwrap();
+    let r1 = run_index(
+        Arc::clone(&conn),
+        dir.path(),
+        &MockEmbedder::default(),
+        false,
+    )
+    .unwrap();
     assert_eq!(r1.files_processed, 1);
 
     // Second run: skips unchanged file
-    let r2 = run_index(Arc::clone(&conn), dir.path(), &MockEmbedder, false).unwrap();
+    let r2 = run_index(
+        Arc::clone(&conn),
+        dir.path(),
+        &MockEmbedder::default(),
+        false,
+    )
+    .unwrap();
     assert_eq!(r2.files_processed, 0);
     assert_eq!(r2.files_skipped, 1);
 }
@@ -141,9 +194,21 @@ fn run_index_force_reindexes() {
     let conn = storage::open_db(&db_path).unwrap();
     let conn = Arc::new(Mutex::new(conn));
 
-    run_index(Arc::clone(&conn), dir.path(), &MockEmbedder, false).unwrap();
+    run_index(
+        Arc::clone(&conn),
+        dir.path(),
+        &MockEmbedder::default(),
+        false,
+    )
+    .unwrap();
 
-    let r2 = run_index(Arc::clone(&conn), dir.path(), &MockEmbedder, true).unwrap();
+    let r2 = run_index(
+        Arc::clone(&conn),
+        dir.path(),
+        &MockEmbedder::default(),
+        true,
+    )
+    .unwrap();
     assert_eq!(r2.files_processed, 1);
     assert_eq!(r2.files_skipped, 0);
 }
@@ -161,7 +226,13 @@ fn run_index_removes_deleted_file_chunks() {
     let conn = Arc::new(Mutex::new(conn));
 
     // Index both files
-    let r1 = run_index(Arc::clone(&conn), dir.path(), &MockEmbedder, false).unwrap();
+    let r1 = run_index(
+        Arc::clone(&conn),
+        dir.path(),
+        &MockEmbedder::default(),
+        false,
+    )
+    .unwrap();
     assert_eq!(r1.files_processed, 2);
     assert_eq!(
         storage::get_stats(&conn.lock().unwrap())
@@ -174,7 +245,13 @@ fn run_index_removes_deleted_file_chunks() {
     std::fs::remove_file(src_dir.join("B.tsx")).unwrap();
 
     // Re-index: should remove orphaned B.tsx chunks
-    run_index(Arc::clone(&conn), dir.path(), &MockEmbedder, false).unwrap();
+    run_index(
+        Arc::clone(&conn),
+        dir.path(),
+        &MockEmbedder::default(),
+        false,
+    )
+    .unwrap();
     let stats = storage::get_stats(&conn.lock().unwrap()).unwrap();
     assert_eq!(stats.total_files, 1, "orphaned file should be removed");
 }
@@ -278,7 +355,13 @@ fn run_index_stores_imports_in_file_context() {
     let conn = storage::open_db(&db_path).unwrap();
     let conn = Arc::new(Mutex::new(conn));
 
-    run_index(Arc::clone(&conn), dir.path(), &MockEmbedder, false).unwrap();
+    run_index(
+        Arc::clone(&conn),
+        dir.path(),
+        &MockEmbedder::default(),
+        false,
+    )
+    .unwrap();
 
     let contexts = storage::get_file_contexts(&conn.lock().unwrap(), &["src/App.tsx"]).unwrap();
     assert_eq!(contexts.len(), 1);
@@ -338,7 +421,8 @@ fn run_incremental_embed_empty_db_returns_zero() {
     let conn = storage::open_db(&db_path).unwrap();
     let conn = Arc::new(Mutex::new(conn));
 
-    let result = run_incremental_embed(Arc::clone(&conn), &MockEmbedder, 50, None).unwrap();
+    let result =
+        run_incremental_embed(Arc::clone(&conn), &MockEmbedder::default(), 50, None).unwrap();
 
     assert_eq!(result.chunks_embedded, 0);
     assert_eq!(result.files_completed, 0);
@@ -366,7 +450,8 @@ fn run_incremental_embed_within_budget() {
     let stats_before = storage::get_stats(&conn.lock().unwrap()).unwrap();
     assert_eq!(stats_before.embedded_chunks, 0);
 
-    let result = run_incremental_embed(Arc::clone(&conn), &MockEmbedder, 50, None).unwrap();
+    let result =
+        run_incremental_embed(Arc::clone(&conn), &MockEmbedder::default(), 50, None).unwrap();
 
     assert!(result.chunks_embedded >= 3);
     assert_eq!(result.files_completed, 3);
@@ -395,7 +480,8 @@ fn run_incremental_embed_exhausts_budget() {
 
     run_chunk_only_index(Arc::clone(&conn), dir.path()).unwrap();
 
-    let result = run_incremental_embed(Arc::clone(&conn), &MockEmbedder, 2, None).unwrap();
+    let result =
+        run_incremental_embed(Arc::clone(&conn), &MockEmbedder::default(), 2, None).unwrap();
 
     assert!(result.budget_exhausted);
     assert!(result.chunks_embedded <= 2);
@@ -450,7 +536,7 @@ fn run_incremental_embed_prioritizes_type_hints() {
 
     let result = run_incremental_embed(
         Arc::clone(&conn),
-        &MockEmbedder,
+        &MockEmbedder::default(),
         1,
         Some(&[storage::ChunkType::Hook]),
     )
@@ -521,7 +607,8 @@ fn run_incremental_embed_none_hints_preserves_order() {
 
     let conn = Arc::new(Mutex::new(conn));
 
-    let result = run_incremental_embed(Arc::clone(&conn), &MockEmbedder, 50, None).unwrap();
+    let result =
+        run_incremental_embed(Arc::clone(&conn), &MockEmbedder::default(), 50, None).unwrap();
 
     assert_eq!(result.files_completed, 2);
     assert!(result.chunks_embedded >= 2);
@@ -938,7 +1025,13 @@ fn run_index_counts_unreadable_files_as_errors() {
     let conn = storage::open_db(&db_path).unwrap();
     let conn = Arc::new(Mutex::new(conn));
 
-    let result = run_index(Arc::clone(&conn), dir.path(), &MockEmbedder, false).unwrap();
+    let result = run_index(
+        Arc::clone(&conn),
+        dir.path(),
+        &MockEmbedder::default(),
+        false,
+    )
+    .unwrap();
 
     // Restore permissions for cleanup
     std::fs::set_permissions(&bad_path, std::fs::Permissions::from_mode(0o644)).unwrap();

--- a/src/query/tests.rs
+++ b/src/query/tests.rs
@@ -7,7 +7,7 @@ use super::*;
 use crate::storage;
 
 fn test_embedding() -> Vec<f32> {
-    let mut emb = vec![0.0_f32; storage::EMBEDDING_DIMS as usize];
+    let mut emb = vec![0.0_f32; storage::EMBEDDING_DIMS];
     emb[0] = 1.0;
     emb
 }
@@ -37,7 +37,7 @@ fn search_with_mock_embedder() {
     .unwrap();
 
     let conn = Arc::new(Mutex::new(conn));
-    let outcome = search(conn, &MockEmbedder, "button", 10, 0).unwrap();
+    let outcome = search(conn, &MockEmbedder::default(), "button", 10, 0).unwrap();
     assert!(!outcome.degraded);
     assert_eq!(outcome.results.len(), 1);
     assert_eq!(outcome.results[0].chunk.name.as_deref(), Some("Button"));
@@ -208,7 +208,9 @@ fn search_fallback_merges_vector_and_name_results() {
     .unwrap();
 
     let conn = Arc::new(Mutex::new(conn));
-    let results = search(conn, &MockEmbedder, "auth", 5, 0).unwrap().results;
+    let results = search(conn, &MockEmbedder::default(), "auth", 5, 0)
+        .unwrap()
+        .results;
 
     assert!(
         results.len() >= 2,
@@ -260,7 +262,9 @@ fn search_deduplicates_vector_and_name_results() {
     .unwrap();
 
     let conn = Arc::new(Mutex::new(conn));
-    let results = search(conn, &MockEmbedder, "auth", 5, 0).unwrap().results;
+    let results = search(conn, &MockEmbedder::default(), "auth", 5, 0)
+        .unwrap()
+        .results;
 
     let auth_count = results
         .iter()
@@ -623,7 +627,7 @@ fn search_returns_results_sorted_by_score() {
     .unwrap();
 
     let conn = Arc::new(Mutex::new(conn));
-    let results = search(conn, &MockEmbedder, "auth hook", 5, 0)
+    let results = search(conn, &MockEmbedder::default(), "auth hook", 5, 0)
         .unwrap()
         .results;
 
@@ -867,7 +871,7 @@ fn search_degrades_on_model_not_available() {
 #[ignore = "requires model download"]
 fn search_returns_results() {
     use rurico::embed::download_model;
-    let paths = download_model().expect("download model");
+    let paths = download_model(rurico::embed::ModelId::default()).expect("download model");
     let embedder = Embedder::new(&paths).expect("load model");
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("test.db");
@@ -1073,7 +1077,7 @@ fn search_chunk_only_index_with_embedder_falls_back_to_text() {
     assert_eq!(stats.embedded_chunks, 0, "no embeddings should exist");
 
     let conn = Arc::new(Mutex::new(conn));
-    let outcome = search(conn, &MockEmbedder, "button", 10, 0).unwrap();
+    let outcome = search(conn, &MockEmbedder::default(), "button", 10, 0).unwrap();
     assert!(
         !outcome.results.is_empty(),
         "should return text/name fallback results even with zero embeddings"

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2,11 +2,13 @@ mod embed;
 mod graph;
 mod schema;
 mod search;
+mod types;
 
 pub use embed::*;
 pub use graph::*;
 pub use schema::*;
 pub use search::*;
+pub use types::*;
 
 use std::collections::HashSet;
 
@@ -17,161 +19,10 @@ pub type Db = Connection;
 pub use rurico::embed::EMBEDDING_DIMS;
 pub use rurico::storage::f32_as_bytes;
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum ChunkType {
-    Component,
-    Hook,
-    TypeDef,
-    CssRule,
-    HtmlElement,
-    TestCase,
-    RustFn,
-    RustStruct,
-    RustEnum,
-    RustTrait,
-    RustImpl,
-    MdSection,
-    Other,
-    InnerFn,
-}
-
-impl ChunkType {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Component => "component",
-            Self::Hook => "hook",
-            Self::TypeDef => "type_def",
-            Self::CssRule => "css_rule",
-            Self::HtmlElement => "html_element",
-            Self::TestCase => "test_case",
-            Self::RustFn => "rust_fn",
-            Self::RustStruct => "rust_struct",
-            Self::RustEnum => "rust_enum",
-            Self::RustTrait => "rust_trait",
-            Self::RustImpl => "rust_impl",
-            Self::MdSection => "md_section",
-            Self::Other => "other",
-            Self::InnerFn => "inner_fn",
-        }
-    }
-
-    pub fn from_db(s: &str) -> Self {
-        match s {
-            "component" => Self::Component,
-            "hook" => Self::Hook,
-            "type_def" => Self::TypeDef,
-            "css_rule" => Self::CssRule,
-            "html_element" => Self::HtmlElement,
-            "test_case" => Self::TestCase,
-            "rust_fn" => Self::RustFn,
-            "rust_struct" => Self::RustStruct,
-            "rust_enum" => Self::RustEnum,
-            "rust_trait" => Self::RustTrait,
-            "rust_impl" => Self::RustImpl,
-            "md_section" => Self::MdSection,
-            "other" => Self::Other,
-            "inner_fn" => Self::InnerFn,
-            other => {
-                tracing::warn!(
-                    chunk_type = other,
-                    "Unknown chunk_type in DB, defaulting to Other"
-                );
-                Self::Other
-            }
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct Chunk {
-    pub file_path: String,
-    pub chunk_type: ChunkType,
-    pub name: Option<String>,
-    pub content: String,
-    pub start_line: u32,
-    pub end_line: u32,
-    pub parent_chunk_id: Option<i64>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct IndexStatus {
-    pub total_files: u32,
-    pub total_chunks: u32,
-    pub embeddable_chunks: u32,
-    pub embedded_chunks: u32,
-    pub last_indexed_at: Option<String>,
-}
-
-impl IndexStatus {
-    pub fn embed_coverage(&self) -> f32 {
-        if self.embeddable_chunks > 0 {
-            self.embedded_chunks as f32 / self.embeddable_chunks as f32
-        } else {
-            0.0
-        }
-    }
-
-    pub fn embed_percentage(&self) -> u32 {
-        (self.embed_coverage() as f64 * 100.0) as u32
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum MatchSource {
-    Semantic,
-    Fts,
-}
-
-#[derive(Debug, Clone)]
-pub struct SearchResult {
-    pub chunk: Chunk,
-    pub chunk_id: Option<i64>,
-    pub distance: f32,
-    pub match_source: MatchSource,
-    /// Reranked score (higher = better).
-    pub score: f32,
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum StorageError {
-    #[error("SQLite error: {0}")]
-    Sqlite(#[from] rusqlite::Error),
-    #[error("IO error: {0}")]
-    Io(#[from] std::io::Error),
-    #[error("chunks/embeddings length mismatch: {chunks} chunks vs {embeddings} embeddings")]
-    LengthMismatch { chunks: usize, embeddings: usize },
-    #[error("embedding dimension mismatch: expected {expected}, got {actual}")]
-    DimensionMismatch { expected: usize, actual: usize },
-    #[error("schema mismatch: missing columns {missing:?} in table '{table}' in {} — delete this file and re-run to recreate the index", path.display())]
-    SchemaMismatch {
-        table: &'static str,
-        missing: Vec<String>,
-        path: std::path::PathBuf,
-    },
-}
-
-pub struct NewChunk<'a> {
-    pub chunk_type: &'a ChunkType,
-    pub name: Option<&'a str>,
-    pub content: &'a str,
-    pub start_line: u32,
-    pub end_line: u32,
-    pub parent_index: Option<usize>,
-}
-
-pub struct FileData<'a> {
-    pub file_path: &'a str,
-    pub chunks: &'a [NewChunk<'a>],
-    pub file_hash: &'a str,
-    pub imports_text: &'a str,
-    pub refs: &'a [Reference],
-    pub mtime_epoch: Option<i64>,
-}
-
 fn check_embedding_dims(embedding: &[f32]) -> Result<(), StorageError> {
-    if embedding.len() != EMBEDDING_DIMS as usize {
+    if embedding.len() != EMBEDDING_DIMS {
         return Err(StorageError::DimensionMismatch {
-            expected: EMBEDDING_DIMS as usize,
+            expected: EMBEDDING_DIMS,
             actual: embedding.len(),
         });
     }
@@ -307,6 +158,7 @@ pub fn replace_file_chunks(
     replace_file_chunks_with(conn, &data, embeddings)
 }
 
+#[cfg(test)]
 pub fn replace_file_chunks_only(
     conn: &Connection,
     file_path: &str,
@@ -327,7 +179,7 @@ pub fn replace_file_chunks_only(
     replace_file_data(conn, &data, None)
 }
 
-fn replace_file_data(
+pub(crate) fn replace_file_data(
     conn: &Connection,
     data: &FileData,
     embeddings: Option<&[Vec<f32>]>,
@@ -336,43 +188,26 @@ fn replace_file_data(
     delete_file_chunks_in(&tx, data.file_path)?;
 
     let mut inserted_ids: Vec<i64> = Vec::with_capacity(data.chunks.len());
+    let mut emb_idx = 0;
 
-    match embeddings {
-        Some(embs) => {
-            let mut emb_idx = 0;
-            for (i, chunk) in data.chunks.iter().enumerate() {
-                let parent_chunk_id = resolve_parent(chunk, &inserted_ids, i);
-                if *chunk.chunk_type == ChunkType::InnerFn {
-                    let id = insert_chunk_row(
-                        &tx,
-                        data.file_path,
-                        chunk,
-                        data.file_hash,
-                        parent_chunk_id,
-                    )?;
-                    inserted_ids.push(id);
-                } else {
-                    let id = insert_chunk(
-                        &tx,
-                        data.file_path,
-                        chunk,
-                        data.file_hash,
-                        &embs[emb_idx],
-                        parent_chunk_id,
-                    )?;
-                    inserted_ids.push(id);
-                    emb_idx += 1;
-                }
-            }
-        }
-        None => {
-            for (i, chunk) in data.chunks.iter().enumerate() {
-                let parent_chunk_id = resolve_parent(chunk, &inserted_ids, i);
-                let id =
-                    insert_chunk_row(&tx, data.file_path, chunk, data.file_hash, parent_chunk_id)?;
-                inserted_ids.push(id);
-            }
-        }
+    for (i, chunk) in data.chunks.iter().enumerate() {
+        let parent_chunk_id = resolve_parent(chunk, &inserted_ids, i);
+        let is_embeddable = *chunk.chunk_type != ChunkType::InnerFn;
+        let id = if is_embeddable && let Some(embs) = embeddings {
+            let id = insert_chunk(
+                &tx,
+                data.file_path,
+                chunk,
+                data.file_hash,
+                &embs[emb_idx],
+                parent_chunk_id,
+            )?;
+            emb_idx += 1;
+            id
+        } else {
+            insert_chunk_row(&tx, data.file_path, chunk, data.file_hash, parent_chunk_id)?
+        };
+        inserted_ids.push(id);
     }
 
     write_file_metadata(
@@ -489,35 +324,6 @@ pub fn delete_file_chunks(conn: &Connection, file_path: &str) -> Result<(), Stor
     delete_file_chunks_in(&tx, file_path)?;
     tx.commit()?;
     Ok(())
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RefKind {
-    Named,
-    Default,
-    Namespace,
-    TypeOnly,
-    SideEffect,
-}
-
-impl RefKind {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Named => "named",
-            Self::Default => "default",
-            Self::Namespace => "namespace",
-            Self::TypeOnly => "type_only",
-            Self::SideEffect => "side_effect",
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct Reference {
-    pub source_file: String,
-    pub target_file: String,
-    pub symbol_name: Option<String>,
-    pub ref_kind: RefKind,
 }
 
 pub fn sql_placeholders(count: usize) -> String {

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -25,7 +25,7 @@ fn init_db_creates_tables() {
 #[test]
 fn insert_and_read_chunk() {
     let (conn, _dir) = test_db();
-    let embedding = vec![0.1_f32; 768];
+    let embedding = vec![0.1_f32; EMBEDDING_DIMS];
 
     let id = insert_chunk(
         &conn,
@@ -62,7 +62,7 @@ fn insert_and_read_chunk() {
 #[test]
 fn should_reindex_returns_false_for_same_hash() {
     let (conn, _dir) = test_db();
-    let embedding = vec![0.0_f32; 768];
+    let embedding = vec![0.0_f32; EMBEDDING_DIMS];
 
     insert_chunk(
         &conn,
@@ -87,7 +87,7 @@ fn should_reindex_returns_false_for_same_hash() {
 #[test]
 fn should_reindex_returns_true_for_different_hash() {
     let (conn, _dir) = test_db();
-    let embedding = vec![0.0_f32; 768];
+    let embedding = vec![0.0_f32; EMBEDDING_DIMS];
 
     insert_chunk(
         &conn,
@@ -118,7 +118,7 @@ fn should_reindex_returns_true_for_new_file() {
 #[test]
 fn get_stats_returns_counts() {
     let (conn, _dir) = test_db();
-    let embedding = vec![0.0_f32; 768];
+    let embedding = vec![0.0_f32; EMBEDDING_DIMS];
 
     insert_chunk(
         &conn,
@@ -177,7 +177,7 @@ fn get_stats_returns_counts() {
 #[test]
 fn get_all_file_paths_returns_distinct_paths() {
     let (conn, _dir) = test_db();
-    let embedding = vec![0.0_f32; 768];
+    let embedding = vec![0.0_f32; EMBEDDING_DIMS];
 
     insert_chunk(
         &conn,
@@ -237,7 +237,7 @@ fn get_all_file_paths_returns_distinct_paths() {
 #[test]
 fn delete_file_chunks_removes_all_chunks_for_file() {
     let (conn, _dir) = test_db();
-    let embedding = vec![0.0_f32; 768];
+    let embedding = vec![0.0_f32; EMBEDDING_DIMS];
 
     insert_chunk(
         &conn,
@@ -286,7 +286,7 @@ fn delete_file_chunks_removes_all_chunks_for_file() {
 #[test]
 fn replace_file_chunks_replaces_existing() {
     let (conn, _dir) = test_db();
-    let embedding = vec![0.0_f32; 768];
+    let embedding = vec![0.0_f32; EMBEDDING_DIMS];
 
     insert_chunk(
         &conn,
@@ -345,9 +345,9 @@ fn replace_file_chunks_replaces_existing() {
 #[test]
 fn search_similar_returns_ordered_results() {
     let (conn, _dir) = test_db();
-    let mut emb_a = vec![0.0_f32; 768];
+    let mut emb_a = vec![0.0_f32; EMBEDDING_DIMS];
     emb_a[0] = 1.0;
-    let mut emb_b = vec![0.0_f32; 768];
+    let mut emb_b = vec![0.0_f32; EMBEDDING_DIMS];
     emb_b[1] = 1.0;
 
     insert_chunk(
@@ -438,7 +438,7 @@ fn chunk_type_from_db_unknown_defaults_to_other() {
 #[test]
 fn delete_file_chunks_also_removes_file_context() {
     let (conn, _dir) = test_db();
-    let embedding = vec![0.0_f32; 768];
+    let embedding = vec![0.0_f32; EMBEDDING_DIMS];
     let chunks = vec![NewChunk {
         chunk_type: &ChunkType::Component,
         name: Some("A"),
@@ -478,7 +478,7 @@ fn delete_file_chunks_also_removes_file_context() {
 #[test]
 fn replace_file_chunks_stores_file_context() {
     let (conn, _dir) = test_db();
-    let embedding = vec![0.0_f32; 768];
+    let embedding = vec![0.0_f32; EMBEDDING_DIMS];
     let chunks = vec![NewChunk {
         chunk_type: &ChunkType::Component,
         name: Some("App"),
@@ -521,7 +521,7 @@ fn get_file_contexts_returns_empty_for_empty_input() {
 #[test]
 fn get_file_siblings_returns_all_chunks_for_file() {
     let (conn, _dir) = test_db();
-    let embedding = vec![0.0_f32; 768];
+    let embedding = vec![0.0_f32; EMBEDDING_DIMS];
     insert_chunk(
         &conn,
         "src/A.tsx",
@@ -667,7 +667,7 @@ fn replace_file_references_replaces_existing() {
 #[test]
 fn delete_file_chunks_also_removes_references() {
     let (conn, _dir) = test_db();
-    let embedding = vec![0.0_f32; 768];
+    let embedding = vec![0.0_f32; EMBEDDING_DIMS];
     let chunks = vec![NewChunk {
         chunk_type: &ChunkType::Component,
         name: Some("A"),
@@ -851,7 +851,7 @@ fn replace_file_chunks_only_inserts_chunks_without_embeddings() {
 #[test]
 fn replace_file_chunks_only_deletes_old_embeddings() {
     let (conn, _dir) = test_db();
-    let embedding = vec![0.0_f32; EMBEDDING_DIMS as usize];
+    let embedding = vec![0.0_f32; EMBEDDING_DIMS];
 
     insert_chunk(
         &conn,
@@ -930,9 +930,9 @@ fn add_embeddings_inserts_into_vec_chunks() {
     let ids = get_chunk_ids(&conn, "src/Card.tsx");
     assert_eq!(ids.len(), 2);
 
-    let mut emb1 = vec![0.0_f32; EMBEDDING_DIMS as usize];
+    let mut emb1 = vec![0.0_f32; EMBEDDING_DIMS];
     emb1[0] = 1.0;
-    let mut emb2 = vec![0.0_f32; EMBEDDING_DIMS as usize];
+    let mut emb2 = vec![0.0_f32; EMBEDDING_DIMS];
     emb2[1] = 1.0;
 
     let embeddings = vec![(ids[0], emb1), (ids[1], emb2)];
@@ -957,7 +957,7 @@ fn add_embeddings_skips_already_embedded() {
     replace_file_chunks_only(&conn, "src/Modal.tsx", &chunks, "hash_m", "", &[], None).unwrap();
 
     let ids = get_chunk_ids(&conn, "src/Modal.tsx");
-    let emb = vec![0.5_f32; EMBEDDING_DIMS as usize];
+    let emb = vec![0.5_f32; EMBEDDING_DIMS];
     let embeddings = vec![(ids[0], emb.clone())];
 
     let inserted = add_embeddings(&conn, &embeddings).unwrap();
@@ -973,7 +973,7 @@ fn add_embeddings_skips_already_embedded() {
 #[test]
 fn get_unembedded_file_paths_returns_only_unembedded() {
     let (conn, _dir) = test_db();
-    let embedding = vec![0.0_f32; EMBEDDING_DIMS as usize];
+    let embedding = vec![0.0_f32; EMBEDDING_DIMS];
 
     insert_chunk(
         &conn,
@@ -1056,7 +1056,7 @@ fn needs_embedding_returns_true_for_chunk_only_file() {
 #[test]
 fn needs_embedding_returns_false_for_fully_embedded() {
     let (conn, _dir) = test_db();
-    let embedding = vec![0.0_f32; EMBEDDING_DIMS as usize];
+    let embedding = vec![0.0_f32; EMBEDDING_DIMS];
 
     insert_chunk(
         &conn,
@@ -1081,7 +1081,7 @@ fn needs_embedding_returns_false_for_fully_embedded() {
 #[test]
 fn needs_embedding_returns_true_when_hash_changed() {
     let (conn, _dir) = test_db();
-    let embedding = vec![0.0_f32; EMBEDDING_DIMS as usize];
+    let embedding = vec![0.0_f32; EMBEDDING_DIMS];
 
     insert_chunk(
         &conn,
@@ -1106,7 +1106,7 @@ fn needs_embedding_returns_true_when_hash_changed() {
 #[test]
 fn get_stats_reports_embedded_vs_total_chunks() {
     let (conn, _dir) = test_db();
-    let embedding = vec![0.0_f32; EMBEDDING_DIMS as usize];
+    let embedding = vec![0.0_f32; EMBEDDING_DIMS];
 
     insert_chunk(
         &conn,
@@ -1299,7 +1299,7 @@ fn get_files_by_import_count_boosts_hook_component_files() {
 #[test]
 fn search_similar_sets_semantic_match_source() {
     let (conn, _dir) = test_db();
-    let mut emb = vec![0.0_f32; 768];
+    let mut emb = vec![0.0_f32; EMBEDDING_DIMS];
     emb[0] = 1.0;
 
     insert_chunk(
@@ -1327,7 +1327,7 @@ fn search_similar_sets_semantic_match_source() {
 #[test]
 fn search_similar_sets_initial_score() {
     let (conn, _dir) = test_db();
-    let mut emb = vec![0.0_f32; EMBEDDING_DIMS as usize];
+    let mut emb = vec![0.0_f32; EMBEDDING_DIMS];
     emb[0] = 1.0;
 
     insert_chunk(
@@ -1578,7 +1578,7 @@ fn get_unembedded_chunks_for_file_returns_triple() {
 #[test]
 fn get_unembedded_chunks_for_file_excludes_embedded() {
     let (conn, _dir) = test_db();
-    let embedding = vec![0.0_f32; EMBEDDING_DIMS as usize];
+    let embedding = vec![0.0_f32; EMBEDDING_DIMS];
 
     insert_chunk(
         &conn,
@@ -1754,7 +1754,7 @@ fn replace_file_chunks_rejects_length_mismatch() {
             parent_index: None,
         },
     ];
-    let embeddings = vec![vec![0.0_f32; EMBEDDING_DIMS as usize]]; // 1 embedding for 2 chunks
+    let embeddings = vec![vec![0.0_f32; EMBEDDING_DIMS]]; // 1 embedding for 2 chunks
 
     let result = replace_file_chunks(&conn, "src/test.rs", &chunks, &embeddings, "h1", "", &[]);
     assert!(result.is_err(), "should reject mismatched lengths");
@@ -1788,7 +1788,7 @@ fn insert_chunk_rejects_wrong_embedding_dims() {
     assert!(result.is_err(), "should reject wrong embedding dimensions");
     match result.unwrap_err() {
         StorageError::DimensionMismatch { expected, actual } => {
-            assert_eq!(expected, EMBEDDING_DIMS as usize);
+            assert_eq!(expected, EMBEDDING_DIMS);
             assert_eq!(actual, 10);
         }
         e => panic!("expected DimensionMismatch, got: {e}"),
@@ -1949,7 +1949,7 @@ fn t_009_out_of_order_chunks_resolves_to_null() {
 #[test]
 fn t_010_innerfn_in_embed_path_not_in_vec_chunks_yes_in_fts() {
     let (conn, _dir) = test_db();
-    let embedding = vec![0.0_f32; EMBEDDING_DIMS as usize];
+    let embedding = vec![0.0_f32; EMBEDDING_DIMS];
 
     let parent = NewChunk {
         chunk_type: &ChunkType::Component,
@@ -2035,7 +2035,7 @@ fn t_016_get_stats_returns_embeddable_and_total_chunks() {
 #[test]
 fn t_017_embed_percentage_uses_embeddable_chunks() {
     let (conn, _dir) = test_db();
-    let embedding = vec![0.0_f32; EMBEDDING_DIMS as usize];
+    let embedding = vec![0.0_f32; EMBEDDING_DIMS];
 
     insert_chunk(
         &conn,
@@ -2085,7 +2085,7 @@ fn t_017_embed_percentage_uses_embeddable_chunks() {
 #[test]
 fn t_018_embed_path_with_innerfn_no_length_mismatch() {
     let (conn, _dir) = test_db();
-    let embedding = vec![0.0_f32; EMBEDDING_DIMS as usize];
+    let embedding = vec![0.0_f32; EMBEDDING_DIMS];
 
     let parent = NewChunk {
         chunk_type: &ChunkType::Component,

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -1,0 +1,179 @@
+#[derive(Debug, Clone, PartialEq)]
+pub enum ChunkType {
+    Component,
+    Hook,
+    TypeDef,
+    CssRule,
+    HtmlElement,
+    TestCase,
+    RustFn,
+    RustStruct,
+    RustEnum,
+    RustTrait,
+    RustImpl,
+    MdSection,
+    Other,
+    InnerFn,
+}
+
+impl ChunkType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Component => "component",
+            Self::Hook => "hook",
+            Self::TypeDef => "type_def",
+            Self::CssRule => "css_rule",
+            Self::HtmlElement => "html_element",
+            Self::TestCase => "test_case",
+            Self::RustFn => "rust_fn",
+            Self::RustStruct => "rust_struct",
+            Self::RustEnum => "rust_enum",
+            Self::RustTrait => "rust_trait",
+            Self::RustImpl => "rust_impl",
+            Self::MdSection => "md_section",
+            Self::Other => "other",
+            Self::InnerFn => "inner_fn",
+        }
+    }
+
+    pub fn from_db(s: &str) -> Self {
+        match s {
+            "component" => Self::Component,
+            "hook" => Self::Hook,
+            "type_def" => Self::TypeDef,
+            "css_rule" => Self::CssRule,
+            "html_element" => Self::HtmlElement,
+            "test_case" => Self::TestCase,
+            "rust_fn" => Self::RustFn,
+            "rust_struct" => Self::RustStruct,
+            "rust_enum" => Self::RustEnum,
+            "rust_trait" => Self::RustTrait,
+            "rust_impl" => Self::RustImpl,
+            "md_section" => Self::MdSection,
+            "other" => Self::Other,
+            "inner_fn" => Self::InnerFn,
+            other => {
+                tracing::warn!(
+                    chunk_type = other,
+                    "Unknown chunk_type in DB, defaulting to Other"
+                );
+                Self::Other
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Chunk {
+    pub file_path: String,
+    pub chunk_type: ChunkType,
+    pub name: Option<String>,
+    pub content: String,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub parent_chunk_id: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct IndexStatus {
+    pub total_files: u32,
+    pub total_chunks: u32,
+    pub embeddable_chunks: u32,
+    pub embedded_chunks: u32,
+    pub last_indexed_at: Option<String>,
+}
+
+impl IndexStatus {
+    pub fn embed_coverage(&self) -> f32 {
+        if self.embeddable_chunks > 0 {
+            self.embedded_chunks as f32 / self.embeddable_chunks as f32
+        } else {
+            0.0
+        }
+    }
+
+    pub fn embed_percentage(&self) -> u32 {
+        (self.embed_coverage() as f64 * 100.0) as u32
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum MatchSource {
+    Semantic,
+    Fts,
+}
+
+#[derive(Debug, Clone)]
+pub struct SearchResult {
+    pub chunk: Chunk,
+    pub chunk_id: Option<i64>,
+    pub distance: f32,
+    pub match_source: MatchSource,
+    /// Reranked score (higher = better).
+    pub score: f32,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum StorageError {
+    #[error("SQLite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("chunks/embeddings length mismatch: {chunks} chunks vs {embeddings} embeddings")]
+    LengthMismatch { chunks: usize, embeddings: usize },
+    #[error("embedding dimension mismatch: expected {expected}, got {actual}")]
+    DimensionMismatch { expected: usize, actual: usize },
+    #[error("schema mismatch: missing columns {missing:?} in table '{table}' in {} — delete this file and re-run to recreate the index", path.display())]
+    SchemaMismatch {
+        table: &'static str,
+        missing: Vec<String>,
+        path: std::path::PathBuf,
+    },
+}
+
+pub struct NewChunk<'a> {
+    pub chunk_type: &'a ChunkType,
+    pub name: Option<&'a str>,
+    pub content: &'a str,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub parent_index: Option<usize>,
+}
+
+pub struct FileData<'a> {
+    pub file_path: &'a str,
+    pub chunks: &'a [NewChunk<'a>],
+    pub file_hash: &'a str,
+    pub imports_text: &'a str,
+    pub refs: &'a [Reference],
+    pub mtime_epoch: Option<i64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefKind {
+    Named,
+    Default,
+    Namespace,
+    TypeOnly,
+    SideEffect,
+}
+
+impl RefKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Named => "named",
+            Self::Default => "default",
+            Self::Namespace => "namespace",
+            Self::TypeOnly => "type_only",
+            Self::SideEffect => "side_effect",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Reference {
+    pub source_file: String,
+    pub target_file: String,
+    pub symbol_name: Option<String>,
+    pub ref_kind: RefKind,
+}

--- a/src/tools/embedder.rs
+++ b/src/tools/embedder.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use rurico::embed::{Embed, EmbedError, Embedder};
+use rurico::embed::{ChunkedEmbedding, Embed, EmbedError, Embedder};
 
 use super::Yomu;
 
@@ -53,7 +53,10 @@ impl Embed for NoOpEmbedder {
     fn embed_query(&self, _text: &str) -> Result<Vec<f32>, EmbedError> {
         Err(EmbedError::Inference("embedder not available".into()))
     }
-    fn embed_document(&self, _text: &str) -> Result<Vec<f32>, EmbedError> {
+    fn embed_document(&self, _text: &str) -> Result<ChunkedEmbedding, EmbedError> {
+        Err(EmbedError::Inference("embedder not available".into()))
+    }
+    fn embed_text(&self, _text: &str, _prefix: &str) -> Result<Vec<f32>, EmbedError> {
         Err(EmbedError::Inference("embedder not available".into()))
     }
 }
@@ -83,7 +86,7 @@ pub(super) fn parse_budget_value(value: Option<&str>) -> u32 {
 }
 
 fn try_load_embedder(disabled: bool) -> Result<Arc<dyn Embed>, DegradedReason> {
-    use rurico::embed::{ProbeStatus, model_paths_if_cached};
+    use rurico::embed::{ModelId, ProbeStatus, cached_artifacts};
 
     fn probe_failed(e: &dyn std::fmt::Display) -> DegradedReason {
         record_embedder_warning(DegradedReason::ProbeFailed, &e.to_string());
@@ -94,7 +97,7 @@ fn try_load_embedder(disabled: bool) -> Result<Arc<dyn Embed>, DegradedReason> {
         tracing::info!("Embedding disabled via YOMU_EMBED=0");
         return Err(DegradedReason::Disabled);
     }
-    let paths = match model_paths_if_cached() {
+    let paths = match cached_artifacts(ModelId::default()) {
         Ok(Some(p)) => p,
         Ok(None) => return Err(DegradedReason::NotInstalled),
         Err(e) => return Err(probe_failed(&e)),

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -11,7 +11,7 @@ fn parse_json(json: &str) -> serde_json::Value {
 }
 
 fn test_embedding() -> Vec<f32> {
-    let mut emb = vec![0.0_f32; storage::EMBEDDING_DIMS as usize];
+    let mut emb = vec![0.0_f32; storage::EMBEDDING_DIMS];
     emb[0] = 1.0;
     emb
 }
@@ -115,7 +115,7 @@ fn search_without_embedder_degrades_gracefully() {
 fn search_auto_indexes_empty_db() {
     let (y, _dir) = test_yomu_with_files_and_embedder(
         &[("src/Button.tsx", "function Button() { return <div/>; }")],
-        Arc::new(rurico::embed::MockEmbedder),
+        Arc::new(rurico::embed::MockEmbedder::default()),
     );
 
     let text = y.search("button component", 10, 0, false).unwrap();
@@ -143,7 +143,7 @@ fn search_auto_indexes_empty_db() {
 fn search_incremental_embeds_chunked_only() {
     let (y, _dir) = test_yomu_with_files_and_embedder(
         &[("src/Form.tsx", "export function Form() { return <form/>; }")],
-        Arc::new(rurico::embed::MockEmbedder),
+        Arc::new(rurico::embed::MockEmbedder::default()),
     );
 
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
@@ -250,13 +250,13 @@ fn search_degraded_with_results_shows_note() {
             "src/Button.tsx",
             "export function Button() { return <div/>; }",
         )],
-        Arc::new(rurico::embed::MockEmbedder),
+        Arc::new(rurico::embed::MockEmbedder::default()),
     );
 
     indexer::run_index(
         Arc::clone(&y.conn),
         y.root.as_path(),
-        &rurico::embed::MockEmbedder,
+        &rurico::embed::MockEmbedder::default(),
         false,
     )
     .unwrap();
@@ -926,7 +926,7 @@ fn integration_index_then_impact() {
     indexer::run_index(
         Arc::clone(&y.conn),
         y.root.as_path(),
-        &rurico::embed::MockEmbedder,
+        &rurico::embed::MockEmbedder::default(),
         false,
     )
     .unwrap();
@@ -1060,7 +1060,7 @@ fn determine_index_state_variants() {
 fn ensure_indexed_partially_embedded_triggers_embed() {
     let (y, _dir) = test_yomu_with_files_and_embedder(
         &[("src/App.tsx", "export function App() { return <div/>; }")],
-        Arc::new(rurico::embed::MockEmbedder),
+        Arc::new(rurico::embed::MockEmbedder::default()),
     );
 
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
@@ -1098,13 +1098,13 @@ fn ensure_indexed_fully_embedded_skips_embed() {
             "src/Button.tsx",
             "export function Button() { return <button/>; }",
         )],
-        Arc::new(rurico::embed::MockEmbedder),
+        Arc::new(rurico::embed::MockEmbedder::default()),
     );
 
     indexer::run_index(
         Arc::clone(&y.conn),
         y.root.as_path(),
-        &rurico::embed::MockEmbedder,
+        &rurico::embed::MockEmbedder::default(),
         false,
     )
     .unwrap();
@@ -1126,13 +1126,13 @@ fn ensure_indexed_fully_embedded_skips_embed() {
 fn ensure_indexed_fully_embedded_with_failing_embedder() {
     let (y, dir) = test_yomu_with_files_and_embedder(
         &[("src/Card.tsx", "export function Card() { return <div/>; }")],
-        Arc::new(rurico::embed::MockEmbedder),
+        Arc::new(rurico::embed::MockEmbedder::default()),
     );
 
     indexer::run_index(
         Arc::clone(&y.conn),
         y.root.as_path(),
-        &rurico::embed::MockEmbedder,
+        &rurico::embed::MockEmbedder::default(),
         false,
     )
     .unwrap();
@@ -1616,7 +1616,7 @@ fn t002_search_with_ok_embedder_no_degraded_note() {
     let y = Yomu::for_test(
         conn,
         dir.path().to_path_buf(),
-        Some(Arc::new(rurico::embed::MockEmbedder) as Arc<dyn rurico::embed::Embed>),
+        Some(Arc::new(rurico::embed::MockEmbedder::default()) as Arc<dyn rurico::embed::Embed>),
     );
 
     let text = y.search("button component", 10, 0, false).unwrap();
@@ -1765,7 +1765,7 @@ fn json_notes_empty_via_search_with_ok_embedder() {
     let y = Yomu::for_test(
         conn,
         dir.path().to_path_buf(),
-        Some(Arc::new(rurico::embed::MockEmbedder) as Arc<dyn rurico::embed::Embed>),
+        Some(Arc::new(rurico::embed::MockEmbedder::default()) as Arc<dyn rurico::embed::Embed>),
     );
 
     let json = y.search("nav", 10, 0, true).unwrap();


### PR DESCRIPTION
## 概要

rurico の API 破壊的変更 (rev 5569a30) に追従し、ビルドと既存機能を維持する。
`ChunkedEmbedding` を返す新しい `Embed` トレイトに対応し、型安全性とエラーハンドリングを改善する。

## 変更内容

- **Cargo.toml / Cargo.lock**: rurico の依存を dd1ad45 → 5569a30 に更新
- **src/indexer/embed.rs**: `first_chunk()` と `run_embed_batch()` を追加。`ChunkedEmbedding` の戻り値を処理し、コントラクト違反を `EmbedFailure::Contract` として明示的に扱う。両関数のユニットテストを追加
- **src/indexer/mod.rs**: `replace_file_chunks_only` を `FileData` 構造体 + `replace_file_data` に置き換え、呼び出し側の型安全性を向上
- **src/storage/mod.rs / src/storage/types.rs**: `ChunkType`、`Chunk`、`IndexStatus` などの型を `types.rs` に分離。`replace_file_data` を `pub(crate)` に、`replace_file_chunks_only` をテスト専用 (`#[cfg(test)]`) に変更
- **src/tools/embedder.rs**: `NoOpEmbedder` を新 `Embed` トレイトに対応。`embed_document` が `ChunkedEmbedding` を返すよう更新し、`embed_text` を追加。`model_paths_if_cached` → `cached_artifacts` にリネーム
- **examples/bench.rs**: `download_model()` → `download_model(ModelId::default())`
- **テストファイル群**: `MockEmbedder::default()` への移行、`EMBEDDING_DIMS` の型注釈整理

## 設計判断

- **`first_chunk()` で先頭チャンクのみ保持**: yomu の DB スキーマが 1 チャンク:1 ドキュメントの 1:1 構造のため、複数チャンクを返す新 API から先頭のみを取り出す。スキーマ変更は別 Issue で対応する
- **コントラクト違反を `IndexError::Internal` で送出**: 空のチャンク配列など API 仕様違反は暗黙スキップせず明示的エラーとして扱い、デバッグ容易性を確保
- **`run_embed_batch()` でコードパスを統合**: 同一の embed バッチ処理が 2 箇所に存在していたため DRY 原則に従い統合

## スコープ

- **対象外**: 複数チャンクへの対応（1:1 スキーマのまま先頭チャンクのみ使用）。multi-chunk サポートは別途 Issue 化する

## テスト方法

1. `cargo build` が成功することを確認
2. `cargo test` が全件パスすることを確認
3. `cargo run --example bench` が正常終了することを確認

## 関連

- Closes #53