### PR TITLE
マルチチャンクembedderが先頭チャンクのみ保持することのテストカバレッジ追加

### DIFF
--- a/src/indexer/tests.rs
+++ b/src/indexer/tests.rs
@@ -858,13 +858,8 @@ fn run_incremental_embed_with_multi_chunk_embedder_keeps_first_only() {
     let conn = Arc::new(Mutex::new(conn));
 
     // MockChunkedEmbedder returns 3 chunks per document; first_chunk keeps only the first.
-    let result = run_incremental_embed(
-        Arc::clone(&conn),
-        &MockChunkedEmbedder::new(3),
-        50,
-        None,
-    )
-    .unwrap();
+    let result =
+        run_incremental_embed(Arc::clone(&conn), &MockChunkedEmbedder::new(3), 50, None).unwrap();
 
     assert_eq!(result.files_completed, 1);
     assert_eq!(result.chunks_embedded, 1);

--- a/src/indexer/tests.rs
+++ b/src/indexer/tests.rs
@@ -834,6 +834,47 @@ fn order_files_for_embedding_type_hints_prioritize() {
 }
 
 #[test]
+fn run_incremental_embed_with_multi_chunk_embedder_keeps_first_only() {
+    let (conn, _dir) = test_db();
+
+    storage::replace_file_chunks_only(
+        &conn,
+        "src/App.tsx",
+        &[storage::NewChunk {
+            chunk_type: &storage::ChunkType::Component,
+            name: Some("App"),
+            content: "function App() { return <main/>; }",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        }],
+        "h1",
+        "",
+        &[],
+        None,
+    )
+    .unwrap();
+
+    let conn = Arc::new(Mutex::new(conn));
+
+    // MockChunkedEmbedder returns 3 chunks per document; first_chunk keeps only the first.
+    let result = run_incremental_embed(
+        Arc::clone(&conn),
+        &MockChunkedEmbedder::new(3),
+        50,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(result.files_completed, 1);
+    assert_eq!(result.chunks_embedded, 1);
+
+    let stats = storage::get_stats(&conn.lock().unwrap()).unwrap();
+    // Embedding count must equal embeddable chunk count (1:1), NOT chunk_count * 3.
+    assert_eq!(stats.embedded_chunks, stats.embeddable_chunks);
+}
+
+#[test]
 fn order_files_for_embedding_empty_hints_no_reorder() {
     let (conn, _dir) = test_db();
 


### PR DESCRIPTION
## 概要
- Closes #58: `run_incremental_embed` がembedderから複数チャンクを受け取った際、ファイルごとに先頭チャンクのみ保持することを検証するテストを追加
- 既存の `MockChunkedEmbedder`（`test-support` feature flag経由）を3チャンク返却に設定し、`embedded_chunks == embeddable_chunks`（1:1比率、1:3ではない）をアサート
- 振る舞いの変更なし — 監査所見 TC-1 に対応するテストのみの追加

## テスト計画
- [ ] `cargo test -p yomu indexer::tests::run_incremental_embed_with_multi_chunk_embedder_keeps_first_only` が通ることを確認
- [ ] 全テストスイート（`cargo test`）でリグレッションがないことを確認
- [ ] `test-support` feature flagが非テストビルドで有効にならないことを確認（`cargo build --release`）