### PR TITLE
yomu model download コマンド追加と embedder ダウンロード注入

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+mod progress;
+
 use std::io::{IsTerminal, Read};
 use std::process::ExitCode;
 
@@ -55,6 +57,21 @@ enum Command {
     },
     /// Show index statistics.
     Status,
+    /// Manage the embedding model.
+    #[command(subcommand_required = true, arg_required_else_help = true, after_help = "\
+Examples:
+  yomu model download
+  YOMU_AUTO_DOWNLOAD_MODEL=1 yomu search \"auth hooks\"")]
+    Model {
+        #[command(subcommand)]
+        command: ModelCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum ModelCommand {
+    /// Download embedding model from Hugging Face Hub.
+    Download,
 }
 
 fn main() -> ExitCode {
@@ -71,14 +88,6 @@ fn main() -> ExitCode {
     let cli = parse_cli();
     let json = cli.json;
 
-    let yomu = match Yomu::new() {
-        Ok(y) => y,
-        Err(e) => {
-            eprintln!("error: {e}");
-            return exit_code_for(&e);
-        }
-    };
-
     let command = match cli.command {
         Some(cmd) => cmd,
         None => {
@@ -88,6 +97,31 @@ fn main() -> ExitCode {
                     "requires a subcommand",
                 )
                 .exit();
+        }
+    };
+
+    // model subcommands do not require a project root or DB
+    if let Command::Model { command } = &command {
+        let result = match command {
+            ModelCommand::Download => run_model_download(json),
+        };
+        return match result {
+            Ok(output) => {
+                println!("{output}");
+                ExitCode::SUCCESS
+            }
+            Err(e) => {
+                eprintln!("error: {e}");
+                exit_code_for(&e)
+            }
+        };
+    }
+
+    let yomu = match Yomu::new() {
+        Ok(y) => y,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return exit_code_for(&e);
         }
     };
 
@@ -131,6 +165,7 @@ fn main() -> ExitCode {
             depth,
         } => yomu.impact(&target, symbol.as_deref(), depth, json),
         Command::Status => yomu.status(json),
+        Command::Model { .. } => unreachable!("handled before Yomu::new()"),
     };
 
     match result {
@@ -235,11 +270,38 @@ fn resolve_query_with(
             stdin
                 .read_to_string(&mut buf)
                 .map_err(|e| format!("failed to read from stdin: {e}"))?;
-            let trimmed = buf.trim().to_string();
+            let trimmed = buf.trim();
             if trimmed.is_empty() {
                 return Err("empty query from stdin".into());
             }
-            Ok(trimmed)
+            Ok(trimmed.to_string())
+        }
+    }
+}
+
+fn run_model_download(json: bool) -> Result<String, YomuError> {
+    use rurico::embed::{Embedder, ModelId};
+
+    let spinner = progress::Spinner::new("Downloading model...");
+    let paths = match rurico::embed::download_model(ModelId::default()) {
+        Ok(p) => p,
+        Err(e) => {
+            spinner.cancel();
+            return Err(YomuError::Internal(format!("Failed to download model: {e}")));
+        }
+    };
+    match Embedder::new(&paths) {
+        Ok(_) => {
+            spinner.finish("Model ready");
+            if json {
+                Ok(serde_json::json!({"status": "ok"}).to_string())
+            } else {
+                Ok("Model downloaded and verified".to_string())
+            }
+        }
+        Err(e) => {
+            spinner.cancel();
+            Err(YomuError::Internal(format!("Failed to verify model: {e}")))
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -280,16 +280,30 @@ fn resolve_query_with(
 }
 
 fn run_model_download(json: bool) -> Result<String, YomuError> {
-    use rurico::embed::{Embedder, ModelId};
+    use rurico::embed::{Embedder, ModelId, ProbeStatus};
 
     let spinner = progress::Spinner::new("Downloading model...");
     let paths = match rurico::embed::download_model(ModelId::default()) {
         Ok(p) => p,
         Err(e) => {
             spinner.cancel();
+            tracing::error!(error = %e, "Model download failed");
             return Err(YomuError::Internal(format!("Failed to download model: {e}")));
         }
     };
+    match Embedder::probe(&paths) {
+        Ok(ProbeStatus::Available) => {}
+        Ok(ProbeStatus::BackendUnavailable) => {
+            spinner.cancel();
+            return Err(YomuError::Internal(
+                "Model downloaded but MLX backend is unavailable".to_string(),
+            ));
+        }
+        Err(e) => {
+            spinner.cancel();
+            return Err(YomuError::Internal(format!("Model probe failed: {e}")));
+        }
+    }
     match Embedder::new(&paths) {
         Ok(_) => {
             spinner.finish("Model ready");

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,10 +58,14 @@ enum Command {
     /// Show index statistics.
     Status,
     /// Manage the embedding model.
-    #[command(subcommand_required = true, arg_required_else_help = true, after_help = "\
+    #[command(
+        subcommand_required = true,
+        arg_required_else_help = true,
+        after_help = "\
 Examples:
   yomu model download
-  YOMU_AUTO_DOWNLOAD_MODEL=1 yomu search \"auth hooks\"")]
+  YOMU_AUTO_DOWNLOAD_MODEL=1 yomu search \"auth hooks\""
+    )]
     Model {
         #[command(subcommand)]
         command: ModelCommand,
@@ -288,7 +292,9 @@ fn run_model_download(json: bool) -> Result<String, YomuError> {
         Err(e) => {
             spinner.cancel();
             tracing::error!(error = %e, "Model download failed");
-            return Err(YomuError::Internal(format!("Failed to download model: {e}")));
+            return Err(YomuError::Internal(format!(
+                "Failed to download model: {e}"
+            )));
         }
     };
     match Embedder::probe(&paths) {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,66 @@
+use std::io::{IsTerminal, Write};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use std::thread;
+use std::time::Duration;
+
+const FRAMES: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+const TICK_MS: u64 = 80;
+
+pub(crate) struct Spinner {
+    done: Arc<AtomicBool>,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl Spinner {
+    pub(crate) fn new(msg: &str) -> Self {
+        let done = Arc::new(AtomicBool::new(false));
+
+        let thread = if std::io::stderr().is_terminal() {
+            let done = Arc::clone(&done);
+            let msg = msg.to_string();
+            Some(thread::spawn(move || {
+                let mut err = std::io::stderr();
+                let mut i = 0;
+                loop {
+                    if done.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    let _ = write!(err, "\r\x1b[2K{} {}", FRAMES[i % FRAMES.len()], msg);
+                    let _ = err.flush();
+                    thread::sleep(Duration::from_millis(TICK_MS));
+                    i += 1;
+                }
+            }))
+        } else {
+            None
+        };
+
+        Self { done, thread }
+    }
+
+    pub(crate) fn finish(self, msg: &str) {
+        let is_tty = self.thread.is_some();
+        drop(self);
+        if is_tty {
+            eprintln!("\x1b[32m✓\x1b[0m {msg}");
+        }
+    }
+
+    pub(crate) fn cancel(self) {
+        tracing::trace!("spinner cancelled");
+    }
+}
+
+impl Drop for Spinner {
+    fn drop(&mut self) {
+        self.done.store(true, Ordering::Relaxed);
+        if let Some(t) = self.thread.take() {
+            let _ = t.join();
+            eprint!("\r\x1b[2K");
+            let _ = std::io::stderr().flush();
+        }
+    }
+}

--- a/src/tools/embedder.rs
+++ b/src/tools/embedder.rs
@@ -140,15 +140,13 @@ fn try_load_embedder_with<CE: std::fmt::Display, DE: std::fmt::Display>(
     }
     let paths = match cache_check() {
         Ok(Some(p)) => p,
-        Ok(None) if auto_download => {
-            match download_fn() {
-                Ok(p) => p,
-                Err(e) => {
-                    record_embedder_warning(DegradedReason::DownloadFailed, &e.to_string());
-                    return Err(DegradedReason::DownloadFailed);
-                }
+        Ok(None) if auto_download => match download_fn() {
+            Ok(p) => p,
+            Err(e) => {
+                record_embedder_warning(DegradedReason::DownloadFailed, &e.to_string());
+                return Err(DegradedReason::DownloadFailed);
             }
-        }
+        },
         Ok(None) => return Err(DegradedReason::NotInstalled),
         Err(e) => return Err(probe_failed(&e)),
     };
@@ -234,8 +232,8 @@ mod tests {
             false,
             || Ok::<_, &str>(None),
             || -> Result<rurico::embed::Artifacts, &str> {
-            unreachable!("download_fn must not be called when disabled")
-        },
+                unreachable!("download_fn must not be called when disabled")
+            },
         );
         assert!(matches!(result, Err(DegradedReason::Disabled)));
     }

--- a/src/tools/embedder.rs
+++ b/src/tools/embedder.rs
@@ -14,6 +14,7 @@ pub(super) enum DegradedReason {
     NotInstalled,
     BackendUnavailable,
     ProbeFailed,
+    DownloadFailed,
 }
 
 impl DegradedReason {
@@ -25,6 +26,9 @@ impl DegradedReason {
             }
             Self::BackendUnavailable | Self::ProbeFailed => {
                 Some("embedding model unavailable; results from text search only")
+            }
+            Self::DownloadFailed => {
+                Some("embedding model download failed; results from text search only")
             }
         }
     }
@@ -85,17 +89,43 @@ pub(super) fn parse_budget_value(value: Option<&str>) -> u32 {
     }
 }
 
-fn try_load_embedder(disabled: bool) -> Result<Arc<dyn Embed>, DegradedReason> {
-    let auto_download = std::env::var("YOMU_AUTO_DOWNLOAD_MODEL").ok().as_deref() == Some("1");
-    try_load_embedder_with(disabled, auto_download, || {
-        rurico::embed::cached_artifacts(rurico::embed::ModelId::default())
-    })
+pub(super) fn parse_auto_download(value: Option<&str>) -> bool {
+    match value {
+        Some("1" | "true" | "yes" | "on") => true,
+        Some("0" | "false" | "no" | "off") | None => false,
+        Some(v) => {
+            tracing::warn!(
+                value = %v,
+                "YOMU_AUTO_DOWNLOAD_MODEL only accepts 1/true/yes/on, ignoring"
+            );
+            false
+        }
+    }
 }
 
-fn try_load_embedder_with<E: std::fmt::Display>(
+fn try_load_embedder(disabled: bool) -> Result<Arc<dyn Embed>, DegradedReason> {
+    let auto_download =
+        parse_auto_download(std::env::var("YOMU_AUTO_DOWNLOAD_MODEL").ok().as_deref());
+    try_load_embedder_with(
+        disabled,
+        auto_download,
+        || rurico::embed::cached_artifacts(rurico::embed::ModelId::default()),
+        || {
+            eprintln!("yomu: auto-downloading embedding model...");
+            let result = rurico::embed::download_model(rurico::embed::ModelId::default());
+            if result.is_ok() {
+                eprintln!("yomu: model ready");
+            }
+            result
+        },
+    )
+}
+
+fn try_load_embedder_with<CE: std::fmt::Display, DE: std::fmt::Display>(
     disabled: bool,
     auto_download: bool,
-    cache_check: impl FnOnce() -> Result<Option<rurico::embed::Artifacts>, E>,
+    cache_check: impl FnOnce() -> Result<Option<rurico::embed::Artifacts>, CE>,
+    download_fn: impl FnOnce() -> Result<rurico::embed::Artifacts, DE>,
 ) -> Result<Arc<dyn Embed>, DegradedReason> {
     use rurico::embed::ProbeStatus;
 
@@ -111,9 +141,12 @@ fn try_load_embedder_with<E: std::fmt::Display>(
     let paths = match cache_check() {
         Ok(Some(p)) => p,
         Ok(None) if auto_download => {
-            match rurico::embed::download_model(rurico::embed::ModelId::default()) {
+            match download_fn() {
                 Ok(p) => p,
-                Err(e) => return Err(probe_failed(&e)),
+                Err(e) => {
+                    record_embedder_warning(DegradedReason::DownloadFailed, &e.to_string());
+                    return Err(DegradedReason::DownloadFailed);
+                }
             }
         }
         Ok(None) => return Err(DegradedReason::NotInstalled),
@@ -196,14 +229,28 @@ mod tests {
     // disabled=true → DegradedReason::Disabled
     #[test]
     fn disabled_returns_disabled_reason() {
-        let result = try_load_embedder_with(true, false, || Ok::<_, &str>(None));
+        let result = try_load_embedder_with(
+            true,
+            false,
+            || Ok::<_, &str>(None),
+            || -> Result<rurico::embed::Artifacts, &str> {
+            unreachable!("download_fn must not be called when disabled")
+        },
+        );
         assert!(matches!(result, Err(DegradedReason::Disabled)));
     }
 
     // cache returns None, no auto_download → DegradedReason::NotInstalled
     #[test]
     fn absent_returns_not_installed() {
-        let result = try_load_embedder_with(false, false, || Ok::<_, &str>(None));
+        let result = try_load_embedder_with(
+            false,
+            false,
+            || Ok::<_, &str>(None),
+            || -> Result<rurico::embed::Artifacts, &str> {
+                unreachable!("download_fn must not be called when auto_download=false")
+            },
+        );
         assert!(matches!(result, Err(DegradedReason::NotInstalled)));
     }
 
@@ -214,15 +261,46 @@ mod tests {
             false,
             false,
             || Err::<Option<rurico::embed::Artifacts>, _>("cache broken"),
+            || -> Result<rurico::embed::Artifacts, &str> {
+                unreachable!("download_fn must not be called when cache_check fails")
+            },
         );
         assert!(matches!(result, Err(DegradedReason::ProbeFailed)));
     }
 
-    // auto_download=true, model absent → attempts download (fails in test env → ProbeFailed, not NotInstalled)
+    // auto_download=true, model absent, download fails → DegradedReason::DownloadFailed
     #[test]
-    fn auto_download_attempts_download_when_absent() {
-        let result = try_load_embedder_with(false, true, || Ok::<_, &str>(None));
-        // download_model fails in test env, but the path taken is download (not NotInstalled)
-        assert!(!matches!(result, Err(DegradedReason::NotInstalled)));
+    fn auto_download_failure_returns_download_failed() {
+        let result = try_load_embedder_with(
+            false,
+            true,
+            || Ok::<_, &str>(None),
+            || Err::<rurico::embed::Artifacts, _>("download failed"),
+        );
+        assert!(matches!(result, Err(DegradedReason::DownloadFailed)));
+    }
+
+    #[test]
+    fn parse_auto_download_truthy_values() {
+        assert!(parse_auto_download(Some("1")));
+        assert!(parse_auto_download(Some("true")));
+        assert!(parse_auto_download(Some("yes")));
+        assert!(parse_auto_download(Some("on")));
+    }
+
+    #[test]
+    fn parse_auto_download_falsy_values() {
+        assert!(!parse_auto_download(Some("0")));
+        assert!(!parse_auto_download(Some("false")));
+        assert!(!parse_auto_download(Some("no")));
+        assert!(!parse_auto_download(Some("off")));
+        assert!(!parse_auto_download(None));
+    }
+
+    #[test]
+    fn parse_auto_download_unrecognized_returns_false() {
+        assert!(!parse_auto_download(Some("TRUE")));
+        assert!(!parse_auto_download(Some("2")));
+        assert!(!parse_auto_download(Some("enabled")));
     }
 }

--- a/src/tools/embedder.rs
+++ b/src/tools/embedder.rs
@@ -86,7 +86,18 @@ pub(super) fn parse_budget_value(value: Option<&str>) -> u32 {
 }
 
 fn try_load_embedder(disabled: bool) -> Result<Arc<dyn Embed>, DegradedReason> {
-    use rurico::embed::{ModelId, ProbeStatus, cached_artifacts};
+    let auto_download = std::env::var("YOMU_AUTO_DOWNLOAD_MODEL").ok().as_deref() == Some("1");
+    try_load_embedder_with(disabled, auto_download, || {
+        rurico::embed::cached_artifacts(rurico::embed::ModelId::default())
+    })
+}
+
+fn try_load_embedder_with<E: std::fmt::Display>(
+    disabled: bool,
+    auto_download: bool,
+    cache_check: impl FnOnce() -> Result<Option<rurico::embed::Artifacts>, E>,
+) -> Result<Arc<dyn Embed>, DegradedReason> {
+    use rurico::embed::ProbeStatus;
 
     fn probe_failed(e: &dyn std::fmt::Display) -> DegradedReason {
         record_embedder_warning(DegradedReason::ProbeFailed, &e.to_string());
@@ -97,8 +108,14 @@ fn try_load_embedder(disabled: bool) -> Result<Arc<dyn Embed>, DegradedReason> {
         tracing::info!("Embedding disabled via YOMU_EMBED=0");
         return Err(DegradedReason::Disabled);
     }
-    let paths = match cached_artifacts(ModelId::default()) {
+    let paths = match cache_check() {
         Ok(Some(p)) => p,
+        Ok(None) if auto_download => {
+            match rurico::embed::download_model(rurico::embed::ModelId::default()) {
+                Ok(p) => p,
+                Err(e) => return Err(probe_failed(&e)),
+            }
+        }
         Ok(None) => return Err(DegradedReason::NotInstalled),
         Err(e) => return Err(probe_failed(&e)),
     };
@@ -169,5 +186,43 @@ impl Yomu {
             embed_budget: DEFAULT_EMBED_BUDGET,
             embed_disabled: true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // disabled=true → DegradedReason::Disabled
+    #[test]
+    fn disabled_returns_disabled_reason() {
+        let result = try_load_embedder_with(true, false, || Ok::<_, &str>(None));
+        assert!(matches!(result, Err(DegradedReason::Disabled)));
+    }
+
+    // cache returns None, no auto_download → DegradedReason::NotInstalled
+    #[test]
+    fn absent_returns_not_installed() {
+        let result = try_load_embedder_with(false, false, || Ok::<_, &str>(None));
+        assert!(matches!(result, Err(DegradedReason::NotInstalled)));
+    }
+
+    // cache_check fails → DegradedReason::ProbeFailed
+    #[test]
+    fn cache_error_returns_probe_failed() {
+        let result = try_load_embedder_with(
+            false,
+            false,
+            || Err::<Option<rurico::embed::Artifacts>, _>("cache broken"),
+        );
+        assert!(matches!(result, Err(DegradedReason::ProbeFailed)));
+    }
+
+    // auto_download=true, model absent → attempts download (fails in test env → ProbeFailed, not NotInstalled)
+    #[test]
+    fn auto_download_attempts_download_when_absent() {
+        let result = try_load_embedder_with(false, true, || Ok::<_, &str>(None));
+        // download_model fails in test env, but the path taken is download (not NotInstalled)
+        assert!(!matches!(result, Err(DegradedReason::NotInstalled)));
     }
 }

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -1721,6 +1721,10 @@ fn user_note_exact_values_for_all_variants() {
         DegradedReason::ProbeFailed.user_note(),
         Some("embedding model unavailable; results from text search only")
     );
+    assert_eq!(
+        DegradedReason::DownloadFailed.user_note(),
+        Some("embedding model download failed; results from text search only")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## 概要

- `yomu model download` サブコマンドを追加。モデルを probe してからインストールし、TTY 対応の Spinner で進捗表示。model サブコマンドはプロジェクトルートや DB が不要なため `Yomu::new()` の前にディスパッチ。
- `try_load_embedder_with` に `cache_check` と `download_fn` クロージャを注入し、ネットワークなしで auto-download パスをユニットテスト可能に。2つのエラー型には別々のジェネリックパラメータを使用し `Box<dyn Error>` を回避。
- `DownloadFailed` を `DegradedReason` の独立した variant として追加（`ProbeFailed` とは分離）。ダウンロード失敗と probe エラーを区別可能に。`YOMU_AUTO_DOWNLOAD_MODEL` は truthy 値（`1/true/yes/on`）を受理し、不正値は警告を出力。

Closes #27, #56.

## テスト計画

- [ ] `yomu model download`（モデル未取得）: Spinner 表示、モデルインストール、exit 0
- [ ] `yomu model download`（モデル取得済み）: probe 即成功、再ダウンロードなし
- [ ] `yomu model download`（ダウンロード失敗）: `tracing::error` 出力、exit non-zero
- [ ] `YOMU_AUTO_DOWNLOAD_MODEL=1 yomu search <query>`（キャッシュなし）: 自動ダウンロード実行後に検索完了
- [ ] `YOMU_AUTO_DOWNLOAD_MODEL=invalid yomu search <query>`: 警告出力、自動ダウンロードスキップ
- [ ] `DegradedReason::DownloadFailed` の user_note が `src/tools/tests.rs` のアサーションと一致
- [ ] ユニットテスト（`cargo test`）: `embedder.rs` の新規8テスト + `tests.rs` の `DownloadFailed` アサーションが全て pass
- [ ] 非 TTY 環境（パイプ出力）: Spinner 抑制、ANSI エスケープなし