### PR TITLE
ChunkedEmbedding の全sub-chunkを保存し長文ファイルの検索精度を改善

### DIFF
--- a/src/indexer/embed.rs
+++ b/src/indexer/embed.rs
@@ -360,8 +360,12 @@ mod tests {
     #[test]
     fn validate_passes_non_empty_chunks() {
         let embs = vec![
-            ChunkedEmbedding { chunks: vec![vec![1.0_f32; 3]] },
-            ChunkedEmbedding { chunks: vec![vec![2.0_f32; 3], vec![3.0_f32; 3]] },
+            ChunkedEmbedding {
+                chunks: vec![vec![1.0_f32; 3]],
+            },
+            ChunkedEmbedding {
+                chunks: vec![vec![2.0_f32; 3], vec![3.0_f32; 3]],
+            },
         ];
         assert!(validate_chunked_embeddings(embs).is_ok());
     }

--- a/src/indexer/embed.rs
+++ b/src/indexer/embed.rs
@@ -30,6 +30,13 @@ enum EmbedFailure {
     Skip,
 }
 
+fn validate_chunked_embeddings(embs: Vec<ChunkedEmbedding>) -> Result<Vec<ChunkedEmbedding>, ()> {
+    if embs.iter().any(|e| e.chunks.is_empty()) {
+        return Err(());
+    }
+    Ok(embs)
+}
+
 pub(super) fn enrich_for_embedding(
     file_path: &str,
     chunk_type: &str,
@@ -69,28 +76,17 @@ fn classify_embed_error(
     }
 }
 
-/// yomu stores one embedding per source chunk (1:1 schema). When rurico
-/// produces multiple overlapping chunks for long texts, only the first is kept.
-///
-/// Returns `Err(())` if rurico violates its contract by returning empty chunks.
-fn first_chunk(emb: ChunkedEmbedding) -> Result<Vec<f32>, ()> {
-    emb.chunks.into_iter().next().ok_or(())
-}
-
 fn run_embed_batch(
     embedder: &(impl Embed + ?Sized),
     texts: &[String],
     consecutive_errors: &mut u32,
     file_path: &str,
-) -> Result<Vec<Vec<f32>>, EmbedFailure> {
+) -> Result<Vec<ChunkedEmbedding>, EmbedFailure> {
     let texts_ref: Vec<&str> = texts.iter().map(String::as_str).collect();
     match embedder.embed_documents_batch(&texts_ref) {
         Ok(embs) => {
             *consecutive_errors = 0;
-            embs.into_iter()
-                .map(first_chunk)
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(|()| EmbedFailure::Contract)
+            validate_chunked_embeddings(embs).map_err(|()| EmbedFailure::Contract)
         }
         Err(e) => Err(classify_embed_error(e, consecutive_errors, file_path)),
     }
@@ -99,7 +95,7 @@ fn run_embed_batch(
 fn store_file_data(
     conn: &Db,
     pf: PendingFile,
-    embeddings: Vec<Vec<f32>>,
+    embeddings: Vec<ChunkedEmbedding>,
     refs: Vec<Reference>,
 ) -> Result<(), StorageError> {
     let new_chunks = pf.to_new_chunks();
@@ -238,16 +234,17 @@ fn embed_file_chunks(
     texts: Vec<String>,
     consecutive_errors: &mut u32,
 ) -> Result<Option<u32>, IndexError> {
-    let embeddings = match run_embed_batch(embedder, &texts, consecutive_errors, file_path) {
-        Ok(embs) => embs,
-        Err(EmbedFailure::Abort(e)) => return Err(IndexError::Embed(e)),
-        Err(EmbedFailure::Contract) => {
-            return Err(IndexError::Internal(
-                "rurico returned empty ChunkedEmbedding.chunks (contract violation)".into(),
-            ));
-        }
-        Err(EmbedFailure::Skip) => return Ok(None),
-    };
+    let embeddings: Vec<ChunkedEmbedding> =
+        match run_embed_batch(embedder, &texts, consecutive_errors, file_path) {
+            Ok(embs) => embs,
+            Err(EmbedFailure::Abort(e)) => return Err(IndexError::Embed(e)),
+            Err(EmbedFailure::Contract) => {
+                return Err(IndexError::Internal(
+                    "rurico returned empty ChunkedEmbedding.chunks (contract violation)".into(),
+                ));
+            }
+            Err(EmbedFailure::Skip) => return Ok(None),
+        };
 
     if embeddings.len() != chunk_ids.len() {
         *consecutive_errors += 1;
@@ -271,11 +268,11 @@ fn embed_file_chunks(
         return Ok(None);
     }
 
-    let pairs: Vec<(i64, Vec<f32>)> = chunk_ids.into_iter().zip(embeddings).collect();
+    let pairs: Vec<(i64, ChunkedEmbedding)> = chunk_ids.into_iter().zip(embeddings).collect();
     let n = pairs.len() as u32;
     {
         let conn_guard = conn.lock().unwrap();
-        storage::add_embeddings(&conn_guard, &pairs)?;
+        storage::add_chunked_embeddings(&conn_guard, &pairs)?;
     }
     Ok(Some(n))
 }
@@ -355,18 +352,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn first_chunk_returns_err_on_empty_chunks() {
-        assert!(first_chunk(ChunkedEmbedding { chunks: vec![] }).is_err());
+    fn validate_rejects_empty_chunks() {
+        let embs = vec![ChunkedEmbedding { chunks: vec![] }];
+        assert!(validate_chunked_embeddings(embs).is_err());
     }
 
     #[test]
-    fn first_chunk_takes_first_only() {
-        let v1 = vec![1.0_f32; 3];
-        let v2 = vec![2.0_f32; 3];
-        let result = first_chunk(ChunkedEmbedding {
-            chunks: vec![v1.clone(), v2],
-        })
-        .unwrap();
-        assert_eq!(result, v1);
+    fn validate_passes_non_empty_chunks() {
+        let embs = vec![
+            ChunkedEmbedding { chunks: vec![vec![1.0_f32; 3]] },
+            ChunkedEmbedding { chunks: vec![vec![2.0_f32; 3], vec![3.0_f32; 3]] },
+        ];
+        assert!(validate_chunked_embeddings(embs).is_ok());
     }
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -296,7 +296,7 @@ fn search_pipeline(
     let fetch_limit = limit.saturating_add(offset);
     let use_semantic = query_embedding.is_some() && stats.embedded_chunks > 0;
     let mut results = match query_embedding {
-        Some(emb) if use_semantic => storage::search_similar(conn, emb, fetch_limit, 0)?,
+        Some(emb) if use_semantic => storage::vec_search(conn, emb, fetch_limit)?,
         _ => Vec::new(),
     };
 

--- a/src/query/tests.rs
+++ b/src/query/tests.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use rurico::embed::{ChunkedEmbedding, Embedder, FailingEmbedder, MockEmbedder};
+use rurico::embed::{Embedder, FailingEmbedder, MockEmbedder};
 
 use super::*;
 use crate::storage;
@@ -10,10 +10,6 @@ fn test_embedding() -> Vec<f32> {
     let mut emb = vec![0.0_f32; storage::EMBEDDING_DIMS];
     emb[0] = 1.0;
     emb
-}
-
-fn ce(v: Vec<f32>) -> ChunkedEmbedding {
-    ChunkedEmbedding { chunks: vec![v] }
 }
 
 #[test]
@@ -35,7 +31,7 @@ fn search_with_mock_embedder() {
             parent_index: None,
         },
         "hash1",
-        &ce(emb.clone()),
+        &storage::ce(emb.clone()),
         None,
     )
     .unwrap();
@@ -188,7 +184,7 @@ fn search_fallback_merges_vector_and_name_results() {
             parent_index: None,
         },
         "h1",
-        &ce(emb.clone()),
+        &storage::ce(emb.clone()),
         None,
     )
     .unwrap();
@@ -260,7 +256,7 @@ fn search_deduplicates_vector_and_name_results() {
             parent_index: None,
         },
         "h1",
-        &ce(emb.clone()),
+        &storage::ce(emb.clone()),
         None,
     )
     .unwrap();
@@ -607,7 +603,7 @@ fn search_returns_results_sorted_by_score() {
             parent_index: None,
         },
         "h1",
-        &ce(emb.clone()),
+        &storage::ce(emb.clone()),
         None,
     )
     .unwrap();
@@ -894,7 +890,7 @@ fn search_returns_results() {
             parent_index: None,
         },
         "hash1",
-        &ce(embedding),
+        &storage::ce(embedding),
         None,
     )
     .unwrap();
@@ -956,7 +952,7 @@ fn search_pipeline_with_embedding_returns_semantic() {
             parent_index: None,
         },
         "h1",
-        &ce(emb.clone()),
+        &storage::ce(emb.clone()),
         None,
     )
     .unwrap();

--- a/src/query/tests.rs
+++ b/src/query/tests.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use rurico::embed::{Embedder, FailingEmbedder, MockEmbedder};
+use rurico::embed::{ChunkedEmbedding, Embedder, FailingEmbedder, MockEmbedder};
 
 use super::*;
 use crate::storage;
@@ -10,6 +10,10 @@ fn test_embedding() -> Vec<f32> {
     let mut emb = vec![0.0_f32; storage::EMBEDDING_DIMS];
     emb[0] = 1.0;
     emb
+}
+
+fn ce(v: Vec<f32>) -> ChunkedEmbedding {
+    ChunkedEmbedding { chunks: vec![v] }
 }
 
 #[test]
@@ -31,7 +35,7 @@ fn search_with_mock_embedder() {
             parent_index: None,
         },
         "hash1",
-        &emb,
+        &ce(emb.clone()),
         None,
     )
     .unwrap();
@@ -184,7 +188,7 @@ fn search_fallback_merges_vector_and_name_results() {
             parent_index: None,
         },
         "h1",
-        &emb,
+        &ce(emb.clone()),
         None,
     )
     .unwrap();
@@ -256,7 +260,7 @@ fn search_deduplicates_vector_and_name_results() {
             parent_index: None,
         },
         "h1",
-        &emb,
+        &ce(emb.clone()),
         None,
     )
     .unwrap();
@@ -603,7 +607,7 @@ fn search_returns_results_sorted_by_score() {
             parent_index: None,
         },
         "h1",
-        &emb,
+        &ce(emb.clone()),
         None,
     )
     .unwrap();
@@ -890,7 +894,7 @@ fn search_returns_results() {
             parent_index: None,
         },
         "hash1",
-        &embedding,
+        &ce(embedding),
         None,
     )
     .unwrap();
@@ -952,7 +956,7 @@ fn search_pipeline_with_embedding_returns_semantic() {
             parent_index: None,
         },
         "h1",
-        &emb,
+        &ce(emb.clone()),
         None,
     )
     .unwrap();

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -1,63 +1,61 @@
 use std::collections::HashSet;
 
+use rurico::embed::ChunkedEmbedding;
 use rusqlite::Connection;
 
-use super::{ChunkType, StorageError, check_embedding_dims, f32_as_bytes, sql_placeholders};
+use super::{ChunkType, StorageError, anon_placeholders, as_sql_params, f32_as_bytes, in_placeholders};
 
-pub fn add_embeddings(
+pub fn add_chunked_embeddings(
     conn: &Connection,
-    embeddings: &[(i64, Vec<f32>)],
+    embeddings: &[(i64, ChunkedEmbedding)],
 ) -> Result<u32, StorageError> {
     if embeddings.is_empty() {
         return Ok(0);
     }
-
-    // vec0 virtual tables don't support INSERT OR IGNORE, so batch-fetch existing IDs.
-    let ph = sql_placeholders(embeddings.len());
-    let sql = format!("SELECT chunk_id FROM vec_chunks WHERE chunk_id IN ({ph})");
-    let params: Vec<Box<dyn rusqlite::types::ToSql>> = embeddings
-        .iter()
-        .map(|(id, _)| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
-        .collect();
-    let param_refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|b| b.as_ref()).collect();
-    let mut stmt = conn.prepare(&sql)?;
-    let existing: HashSet<i64> = stmt
-        .query_map(param_refs.as_slice(), |row| row.get::<_, i64>(0))?
-        .collect::<Result<HashSet<_>, _>>()?;
-
+    let chunk_ids: Vec<i64> = embeddings.iter().map(|(id, _)| *id).collect();
+    let existing = existing_embedded_ids(conn, &chunk_ids)?;
     let tx = conn.unchecked_transaction()?;
-    let mut inserted = 0u32;
-
-    for (chunk_id, embedding) in embeddings {
+    let mut count = 0u32;
+    for (chunk_id, chunked_emb) in embeddings {
         if existing.contains(chunk_id) {
             continue;
         }
-        check_embedding_dims(embedding)?;
-        let bytes = f32_as_bytes(embedding);
-        tx.execute(
-            "INSERT INTO vec_chunks (chunk_id, embedding) VALUES (?1, ?2)",
-            rusqlite::params![chunk_id, bytes],
-        )?;
-        inserted += 1;
+        for (sub_idx, embedding) in chunked_emb.chunks.iter().enumerate() {
+            let bytes: &[u8] = f32_as_bytes(embedding);
+            tx.execute(
+                "INSERT INTO vec_chunks (embedding, chunk_id, sub_idx) VALUES (?1, ?2, ?3)",
+                rusqlite::params![bytes, chunk_id, sub_idx as i64],
+            )?;
+            let vec_rowid = tx.last_insert_rowid();
+            tx.execute(
+                "INSERT INTO embedded_chunk_ids (chunk_id, sub_idx, vec_rowid) \
+                 VALUES (?1, ?2, ?3)",
+                rusqlite::params![chunk_id, sub_idx as i64, vec_rowid],
+            )?;
+        }
+        count += 1;
     }
-
     tx.commit()?;
-    Ok(inserted)
+    Ok(count)
 }
 
-#[cfg(test)]
-pub fn get_unembedded_file_paths(conn: &Connection) -> Result<Vec<(String, u32)>, StorageError> {
-    let mut stmt = conn.prepare(
-        "SELECT c.file_path, COUNT(*) as chunk_count
-         FROM chunks c
-         LEFT JOIN vec_chunks v ON c.id = v.chunk_id
-         WHERE v.chunk_id IS NULL AND c.chunk_type != 'inner_fn'
-         GROUP BY c.file_path",
-    )?;
-    let rows = stmt.query_map([], |row| {
-        Ok((row.get::<_, String>(0)?, row.get::<_, u32>(1)?))
-    })?;
-    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+fn existing_embedded_ids(
+    conn: &Connection,
+    chunk_ids: &[i64],
+) -> Result<HashSet<i64>, StorageError> {
+    if chunk_ids.is_empty() {
+        return Ok(HashSet::new());
+    }
+    let sql = format!(
+        "SELECT DISTINCT chunk_id FROM embedded_chunk_ids WHERE chunk_id IN ({})",
+        in_placeholders(chunk_ids.len())
+    );
+    let params = as_sql_params(chunk_ids);
+    let mut stmt = conn.prepare(&sql)?;
+    let ids = stmt
+        .query_map(params.as_slice(), |row| row.get::<_, i64>(0))?
+        .collect::<Result<HashSet<_>, _>>()?;
+    Ok(ids)
 }
 
 pub fn get_unembedded_chunks_for_file(
@@ -66,8 +64,8 @@ pub fn get_unembedded_chunks_for_file(
 ) -> Result<Vec<(i64, String, String)>, StorageError> {
     let mut stmt = conn.prepare(
         "SELECT c.id, c.content, c.chunk_type FROM chunks c
-         LEFT JOIN vec_chunks v ON c.id = v.chunk_id
-         WHERE c.file_path = ?1 AND v.chunk_id IS NULL AND c.chunk_type != 'inner_fn'",
+         LEFT JOIN embedded_chunk_ids e ON c.id = e.chunk_id
+         WHERE c.file_path = ?1 AND e.chunk_id IS NULL AND c.chunk_type != 'inner_fn'",
     )?;
     let rows = stmt.query_map([file_path], |row| {
         Ok((
@@ -99,8 +97,8 @@ pub fn get_files_with_chunk_types(
     if files.is_empty() || types.is_empty() {
         return Ok(HashSet::new());
     }
-    let type_ph = sql_placeholders(types.len());
-    let file_ph = sql_placeholders(files.len());
+    let type_ph = anon_placeholders(types.len());
+    let file_ph = anon_placeholders(files.len());
     let sql = format!(
         "SELECT DISTINCT file_path FROM chunks WHERE chunk_type IN ({type_ph}) AND file_path IN ({file_ph})"
     );
@@ -112,10 +110,35 @@ pub fn get_files_with_chunk_types(
     for f in files {
         params.push(Box::new(f.clone()));
     }
-    let param_refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|b| b.as_ref()).collect();
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+        params.iter().map(|b| b.as_ref()).collect();
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(param_refs.as_slice(), |row| row.get::<_, String>(0))?;
     rows.collect::<Result<HashSet<_>, _>>().map_err(Into::into)
+}
+
+pub fn has_embeddings(conn: &Connection) -> bool {
+    conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM embedded_chunk_ids)",
+        [],
+        |row| row.get(0),
+    )
+    .map_err(|e| {
+        tracing::warn!(error = %e, "has_embeddings query failed, assuming no embeddings");
+        e
+    })
+    .unwrap_or(false)
+}
+
+pub fn should_reindex(
+    conn: &Connection,
+    file_path: &str,
+    current_hash: &str,
+) -> Result<bool, StorageError> {
+    match stored_hash_for_file(conn, file_path)? {
+        None => Ok(true),
+        Some(h) => Ok(h != current_hash),
+    }
 }
 
 fn stored_hash_for_file(
@@ -134,6 +157,21 @@ fn stored_hash_for_file(
 }
 
 #[cfg(test)]
+pub fn get_unembedded_file_paths(conn: &Connection) -> Result<Vec<(String, u32)>, StorageError> {
+    let mut stmt = conn.prepare(
+        "SELECT c.file_path, COUNT(*) as chunk_count
+         FROM chunks c
+         LEFT JOIN embedded_chunk_ids e ON c.id = e.chunk_id
+         WHERE e.chunk_id IS NULL AND c.chunk_type != 'inner_fn'
+         GROUP BY c.file_path",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, u32>(1)?))
+    })?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}
+
+#[cfg(test)]
 pub fn needs_embedding(
     conn: &Connection,
     file_path: &str,
@@ -146,24 +184,13 @@ pub fn needs_embedding(
             let has_unembedded: bool = conn.query_row(
                 "SELECT EXISTS(
                     SELECT 1 FROM chunks c
-                    LEFT JOIN vec_chunks v ON c.id = v.chunk_id
-                    WHERE c.file_path = ?1 AND v.chunk_id IS NULL
+                    LEFT JOIN embedded_chunk_ids e ON c.id = e.chunk_id
+                    WHERE c.file_path = ?1 AND e.chunk_id IS NULL
                 )",
                 [file_path],
                 |row| row.get(0),
             )?;
             Ok(has_unembedded)
         }
-    }
-}
-
-pub fn should_reindex(
-    conn: &Connection,
-    file_path: &str,
-    current_hash: &str,
-) -> Result<bool, StorageError> {
-    match stored_hash_for_file(conn, file_path)? {
-        None => Ok(true),
-        Some(h) => Ok(h != current_hash),
     }
 }

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use rurico::embed::ChunkedEmbedding;
 use rusqlite::Connection;
 
-use super::{ChunkType, StorageError, anon_placeholders, as_sql_params, f32_as_bytes, in_placeholders};
+use super::{ChunkType, StorageError, anon_placeholders, as_sql_params, f32_as_bytes, in_placeholders, insert_sub_embeddings};
 
 pub fn add_chunked_embeddings(
     conn: &Connection,
@@ -20,19 +20,7 @@ pub fn add_chunked_embeddings(
         if existing.contains(chunk_id) {
             continue;
         }
-        for (sub_idx, embedding) in chunked_emb.chunks.iter().enumerate() {
-            let bytes: &[u8] = f32_as_bytes(embedding);
-            tx.execute(
-                "INSERT INTO vec_chunks (embedding, chunk_id, sub_idx) VALUES (?1, ?2, ?3)",
-                rusqlite::params![bytes, chunk_id, sub_idx as i64],
-            )?;
-            let vec_rowid = tx.last_insert_rowid();
-            tx.execute(
-                "INSERT INTO embedded_chunk_ids (chunk_id, sub_idx, vec_rowid) \
-                 VALUES (?1, ?2, ?3)",
-                rusqlite::params![chunk_id, sub_idx as i64, vec_rowid],
-            )?;
-        }
+        insert_sub_embeddings(&tx, *chunk_id, chunked_emb)?;
         count += 1;
     }
     tx.commit()?;
@@ -47,7 +35,7 @@ fn existing_embedded_ids(
         return Ok(HashSet::new());
     }
     let sql = format!(
-        "SELECT DISTINCT chunk_id FROM embedded_chunk_ids WHERE chunk_id IN ({})",
+        "SELECT chunk_id FROM embedded_chunk_ids WHERE chunk_id IN ({})",
         in_placeholders(chunk_ids.len())
     );
     let params = as_sql_params(chunk_ids);

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -3,7 +3,10 @@ use std::collections::HashSet;
 use rurico::embed::ChunkedEmbedding;
 use rusqlite::Connection;
 
-use super::{ChunkType, StorageError, anon_placeholders, as_sql_params, f32_as_bytes, in_placeholders, insert_sub_embeddings};
+use super::{
+    ChunkType, StorageError, anon_placeholders, as_sql_params, in_placeholders,
+    insert_sub_embeddings,
+};
 
 pub fn add_chunked_embeddings(
     conn: &Connection,
@@ -98,8 +101,7 @@ pub fn get_files_with_chunk_types(
     for f in files {
         params.push(Box::new(f.clone()));
     }
-    let param_refs: Vec<&dyn rusqlite::types::ToSql> =
-        params.iter().map(|b| b.as_ref()).collect();
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|b| b.as_ref()).collect();
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(param_refs.as_slice(), |row| row.get::<_, String>(0))?;
     rows.collect::<Result<HashSet<_>, _>>().map_err(Into::into)

--- a/src/storage/graph.rs
+++ b/src/storage/graph.rs
@@ -2,7 +2,7 @@ use rusqlite::Connection;
 
 #[cfg(test)]
 use super::Reference;
-use super::{ChunkType, StorageError, sql_placeholders};
+use super::{ChunkType, StorageError, in_placeholders};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Dependent {
@@ -138,7 +138,7 @@ pub fn get_file_mtimes(
     if file_paths.is_empty() {
         return Ok(std::collections::HashMap::new());
     }
-    let placeholders = sql_placeholders(file_paths.len());
+    let placeholders = in_placeholders(file_paths.len());
     let sql = format!(
         "SELECT file_path, mtime_epoch FROM file_context WHERE file_path IN ({placeholders}) AND mtime_epoch IS NOT NULL"
     );
@@ -161,7 +161,7 @@ pub fn get_file_contexts(
     if file_paths.is_empty() {
         return Ok(std::collections::HashMap::new());
     }
-    let placeholders = sql_placeholders(file_paths.len());
+    let placeholders = in_placeholders(file_paths.len());
     let sql = format!(
         "SELECT file_path, imports_text FROM file_context WHERE file_path IN ({placeholders})"
     );
@@ -184,7 +184,7 @@ pub fn get_file_siblings(
     if file_paths.is_empty() {
         return Ok(std::collections::HashMap::new());
     }
-    let placeholders = sql_placeholders(file_paths.len());
+    let placeholders = in_placeholders(file_paths.len());
     let sql = format!(
         "SELECT file_path, name, chunk_type, start_line, end_line \
          FROM chunks WHERE file_path IN ({placeholders}) \

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -75,17 +75,12 @@ fn insert_chunk_row(
     Ok(chunk_id)
 }
 
-pub fn insert_chunk(
+pub(crate) fn insert_sub_embeddings(
     conn: &Connection,
-    file_path: &str,
-    chunk: &NewChunk,
-    file_hash: &str,
-    embedding: &rurico::embed::ChunkedEmbedding,
-    parent_chunk_id: Option<i64>,
-) -> Result<i64, StorageError> {
-    let chunk_id = insert_chunk_row(conn, file_path, chunk, file_hash, parent_chunk_id)?;
-
-    for (sub_idx, emb_slice) in embedding.chunks.iter().enumerate() {
+    chunk_id: i64,
+    chunked_emb: &rurico::embed::ChunkedEmbedding,
+) -> Result<(), StorageError> {
+    for (sub_idx, emb_slice) in chunked_emb.chunks.iter().enumerate() {
         let bytes = f32_as_bytes(emb_slice);
         conn.execute(
             "INSERT INTO vec_chunks (embedding, chunk_id, sub_idx) VALUES (?1, ?2, ?3)",
@@ -97,7 +92,19 @@ pub fn insert_chunk(
             rusqlite::params![chunk_id, sub_idx as i64, vec_rowid],
         )?;
     }
+    Ok(())
+}
 
+pub fn insert_chunk(
+    conn: &Connection,
+    file_path: &str,
+    chunk: &NewChunk,
+    file_hash: &str,
+    embedding: &rurico::embed::ChunkedEmbedding,
+    parent_chunk_id: Option<i64>,
+) -> Result<i64, StorageError> {
+    let chunk_id = insert_chunk_row(conn, file_path, chunk, file_hash, parent_chunk_id)?;
+    insert_sub_embeddings(conn, chunk_id, embedding)?;
     Ok(chunk_id)
 }
 
@@ -351,6 +358,10 @@ pub fn delete_file_chunks(conn: &Connection, file_path: &str) -> Result<(), Stor
     Ok(())
 }
 
+#[cfg(test)]
+pub(crate) fn ce(v: Vec<f32>) -> rurico::embed::ChunkedEmbedding {
+    rurico::embed::ChunkedEmbedding { chunks: vec![v] }
+}
 
 #[cfg(test)]
 mod tests;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -19,14 +19,23 @@ pub type Db = Connection;
 pub use rurico::embed::EMBEDDING_DIMS;
 pub use rurico::storage::f32_as_bytes;
 
-fn check_embedding_dims(embedding: &[f32]) -> Result<(), StorageError> {
-    if embedding.len() != EMBEDDING_DIMS {
-        return Err(StorageError::DimensionMismatch {
-            expected: EMBEDDING_DIMS,
-            actual: embedding.len(),
-        });
-    }
-    Ok(())
+pub(crate) fn in_placeholders(len: usize) -> String {
+    (1..=len)
+        .map(|i| format!("?{i}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+// Use when multiple IN clauses share a parameter list: unnamed `?` avoids
+// index collisions that numbered `?N` would cause when params are appended incrementally.
+pub(crate) fn anon_placeholders(n: usize) -> String {
+    vec!["?"; n].join(", ")
+}
+
+pub(crate) fn as_sql_params<T: rusqlite::types::ToSql>(
+    values: &[T],
+) -> Vec<&dyn rusqlite::types::ToSql> {
+    values.iter().map(|v| v as &dyn rusqlite::types::ToSql).collect()
 }
 
 fn insert_chunk_row(
@@ -71,17 +80,23 @@ pub fn insert_chunk(
     file_path: &str,
     chunk: &NewChunk,
     file_hash: &str,
-    embedding: &[f32],
+    embedding: &rurico::embed::ChunkedEmbedding,
     parent_chunk_id: Option<i64>,
 ) -> Result<i64, StorageError> {
-    check_embedding_dims(embedding)?;
     let chunk_id = insert_chunk_row(conn, file_path, chunk, file_hash, parent_chunk_id)?;
 
-    let embedding_bytes = f32_as_bytes(embedding);
-    conn.execute(
-        "INSERT INTO vec_chunks (chunk_id, embedding) VALUES (?1, ?2)",
-        rusqlite::params![chunk_id, embedding_bytes],
-    )?;
+    for (sub_idx, emb_slice) in embedding.chunks.iter().enumerate() {
+        let bytes = f32_as_bytes(emb_slice);
+        conn.execute(
+            "INSERT INTO vec_chunks (embedding, chunk_id, sub_idx) VALUES (?1, ?2, ?3)",
+            rusqlite::params![bytes, chunk_id, sub_idx as i64],
+        )?;
+        let vec_rowid = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO embedded_chunk_ids (chunk_id, sub_idx, vec_rowid) VALUES (?1, ?2, ?3)",
+            rusqlite::params![chunk_id, sub_idx as i64, vec_rowid],
+        )?;
+    }
 
     Ok(chunk_id)
 }
@@ -121,7 +136,7 @@ fn write_file_metadata(
 pub fn replace_file_chunks_with(
     conn: &Connection,
     data: &FileData,
-    embeddings: &[Vec<f32>],
+    embeddings: &[rurico::embed::ChunkedEmbedding],
 ) -> Result<(), StorageError> {
     let embeddable_count = data
         .chunks
@@ -142,7 +157,7 @@ pub fn replace_file_chunks(
     conn: &Connection,
     file_path: &str,
     chunks: &[NewChunk],
-    embeddings: &[Vec<f32>],
+    embeddings: &[rurico::embed::ChunkedEmbedding],
     file_hash: &str,
     imports_text: &str,
     refs: &[Reference],
@@ -182,7 +197,7 @@ pub fn replace_file_chunks_only(
 pub(crate) fn replace_file_data(
     conn: &Connection,
     data: &FileData,
-    embeddings: Option<&[Vec<f32>]>,
+    embeddings: Option<&[rurico::embed::ChunkedEmbedding]>,
 ) -> Result<(), StorageError> {
     let tx = conn.unchecked_transaction()?;
     delete_file_chunks_in(&tx, data.file_path)?;
@@ -259,8 +274,11 @@ pub fn get_stats(conn: &Connection) -> Result<IndexStatus, StorageError> {
             row.get(0)
         })?;
 
-    let embedded_chunks: u32 =
-        conn.query_row("SELECT COUNT(*) FROM vec_chunks", [], |row| row.get(0))?;
+    let embedded_chunks: u32 = conn.query_row(
+        "SELECT COUNT(DISTINCT chunk_id) FROM embedded_chunk_ids",
+        [],
+        |row| row.get(0),
+    )?;
 
     let last_indexed_at: Option<String> = match conn.query_row(
         "SELECT value FROM index_meta WHERE key = 'last_indexed_at'",
@@ -306,7 +324,14 @@ pub fn delete_file_chunks_in(conn: &Connection, file_path: &str) -> Result<(), S
         [file_path],
     )?;
     conn.execute(
-        "DELETE FROM vec_chunks WHERE chunk_id IN (SELECT id FROM chunks WHERE file_path = ?1)",
+        "DELETE FROM vec_chunks WHERE rowid IN \
+         (SELECT vec_rowid FROM embedded_chunk_ids \
+          WHERE chunk_id IN (SELECT id FROM chunks WHERE file_path = ?1))",
+        [file_path],
+    )?;
+    conn.execute(
+        "DELETE FROM embedded_chunk_ids \
+         WHERE chunk_id IN (SELECT id FROM chunks WHERE file_path = ?1)",
         [file_path],
     )?;
     conn.execute("DELETE FROM chunks WHERE file_path = ?1", [file_path])?;
@@ -326,19 +351,6 @@ pub fn delete_file_chunks(conn: &Connection, file_path: &str) -> Result<(), Stor
     Ok(())
 }
 
-pub fn sql_placeholders(count: usize) -> String {
-    if count == 0 {
-        return String::new();
-    }
-    let mut s = String::with_capacity(count * 2 - 1);
-    for i in 0..count {
-        if i > 0 {
-            s.push(',');
-        }
-        s.push('?');
-    }
-    s
-}
 
 #[cfg(test)]
 mod tests;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -35,7 +35,10 @@ pub(crate) fn anon_placeholders(n: usize) -> String {
 pub(crate) fn as_sql_params<T: rusqlite::types::ToSql>(
     values: &[T],
 ) -> Vec<&dyn rusqlite::types::ToSql> {
-    values.iter().map(|v| v as &dyn rusqlite::types::ToSql).collect()
+    values
+        .iter()
+        .map(|v| v as &dyn rusqlite::types::ToSql)
+        .collect()
 }
 
 fn insert_chunk_row(

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -37,12 +37,30 @@ pub fn open_db(path: &Path) -> Result<Connection, StorageError> {
          PRAGMA busy_timeout=5000;",
     )?;
 
-    init_schema(&conn)?;
+    init_schema(&conn, path)?;
     verify_required_columns(&conn, path)?;
     Ok(conn)
 }
 
-const SCHEMA_VERSION: u32 = 7;
+const SCHEMA_VERSION: u32 = 8;
+
+const DDL_EMBEDDED_CHUNK_IDS: &str = "\
+    CREATE TABLE IF NOT EXISTS embedded_chunk_ids (\
+        chunk_id INTEGER NOT NULL, \
+        sub_idx INTEGER NOT NULL, \
+        vec_rowid INTEGER NOT NULL, \
+        PRIMARY KEY (chunk_id, sub_idx)\
+    )";
+
+fn ddl_vec_chunks() -> String {
+    format!(
+        "CREATE VIRTUAL TABLE IF NOT EXISTS vec_chunks USING vec0(\
+             embedding FLOAT[{EMBEDDING_DIMS}], \
+             +chunk_id INTEGER, \
+             +sub_idx INTEGER\
+         )"
+    )
+}
 
 const DDL: &str = "
     CREATE TABLE IF NOT EXISTS chunks (
@@ -82,15 +100,11 @@ const DDL: &str = "
     CREATE INDEX IF NOT EXISTS idx_refs_target_symbol ON file_references(target_file, symbol_name);
 ";
 
-fn init_schema(conn: &Connection) -> Result<(), StorageError> {
+fn init_schema(conn: &Connection, path: &Path) -> Result<(), StorageError> {
     conn.execute_batch(DDL)?;
 
-    conn.execute_batch(&format!(
-        "CREATE VIRTUAL TABLE IF NOT EXISTS vec_chunks USING vec0(
-            chunk_id INTEGER PRIMARY KEY,
-            embedding FLOAT[{EMBEDDING_DIMS}]
-        )"
-    ))?;
+    conn.execute_batch(&ddl_vec_chunks())?;
+    conn.execute_batch(DDL_EMBEDDED_CHUNK_IDS)?;
 
     conn.execute_batch(
         "CREATE VIRTUAL TABLE IF NOT EXISTS fts_chunks USING fts5(
@@ -112,7 +126,7 @@ fn init_schema(conn: &Connection) -> Result<(), StorageError> {
     };
 
     if stored != SCHEMA_VERSION {
-        migrate(conn, stored)?;
+        migrate(conn, stored, path)?;
         conn.execute(
             "INSERT OR REPLACE INTO index_meta (key, value) VALUES ('schema_version', ?1)",
             [SCHEMA_VERSION.to_string()],
@@ -168,7 +182,7 @@ fn column_exists(conn: &Connection, probe_sql: &str) -> Result<bool, StorageErro
     }
 }
 
-fn migrate(conn: &Connection, from: u32) -> Result<(), StorageError> {
+fn migrate(conn: &Connection, from: u32, path: &Path) -> Result<(), StorageError> {
     let to = SCHEMA_VERSION;
     if from >= to {
         return Ok(());
@@ -220,6 +234,17 @@ fn migrate(conn: &Connection, from: u32) -> Result<(), StorageError> {
                 return Err(e);
             }
         }
+    }
+
+    // v7 → v8: migrate vec_chunks to multi-sub-chunk schema, add embedded_chunk_ids
+    if from < 8 {
+        conn.execute_batch("DROP TABLE IF EXISTS vec_chunks")?;
+        conn.execute_batch(&ddl_vec_chunks())?;
+        conn.execute_batch(DDL_EMBEDDED_CHUNK_IDS)?;
+        tracing::warn!(
+            path = %path.display(),
+            "schema upgraded to v8: embeddings cleared, please re-run `yomu index`"
+        );
     }
 
     Ok(())

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -241,6 +241,10 @@ fn migrate(conn: &Connection, from: u32, path: &Path) -> Result<(), StorageError
         conn.execute_batch("DROP TABLE IF EXISTS vec_chunks")?;
         conn.execute_batch(&ddl_vec_chunks())?;
         conn.execute_batch(DDL_EMBEDDED_CHUNK_IDS)?;
+        // Clear file hashes so unchanged files are re-embedded on the next `yomu index`.
+        // Without this, should_reindex() would skip every file whose content hasn't changed,
+        // leaving embedded_chunk_ids permanently empty after the migration.
+        conn.execute_batch("UPDATE chunks SET file_hash = ''")?;
         tracing::warn!(
             path = %path.display(),
             "schema upgraded to v8: embeddings cleared, please re-run `yomu index`"

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -3,7 +3,8 @@ use std::collections::{HashMap, HashSet};
 use rusqlite::Connection;
 
 use super::{
-    Chunk, ChunkType, MatchSource, SearchResult, StorageError, f32_as_bytes, sql_placeholders,
+    Chunk, ChunkType, MatchSource, SearchResult, StorageError, anon_placeholders, as_sql_params,
+    f32_as_bytes, in_placeholders,
 };
 
 fn chunk_from_row(row: &rusqlite::Row<'_>, offset: usize) -> rusqlite::Result<Chunk> {
@@ -18,40 +19,95 @@ fn chunk_from_row(row: &rusqlite::Row<'_>, offset: usize) -> rusqlite::Result<Ch
     })
 }
 
-pub fn search_similar(
+const VEC_MAXSIM_OVERSAMPLE: u32 = 10;
+
+pub fn vec_search(
     conn: &Connection,
     query_embedding: &[f32],
     limit: u32,
-    offset: u32,
 ) -> Result<Vec<SearchResult>, StorageError> {
     let query_bytes = f32_as_bytes(query_embedding);
+    let k = limit.saturating_mul(VEC_MAXSIM_OVERSAMPLE);
 
-    let k = limit.saturating_add(offset);
+    // Step 1: KNN query — fetch only chunk_id + distance.
+    // vec0 auxiliary columns (+chunk_id) cannot be used in JOIN conditions,
+    // so we avoid a direct JOIN here.
+    let knn_rows: Vec<(i64, f32)> = {
+        let mut stmt = conn.prepare(
+            "SELECT chunk_id, distance FROM vec_chunks \
+             WHERE embedding MATCH ?1 AND k = ?2 \
+             ORDER BY distance",
+        )?;
+        stmt.query_map(rusqlite::params![query_bytes, k], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })?
+        .collect::<Result<Vec<_>, _>>()?
+    };
 
-    let mut stmt = conn.prepare(
-        "SELECT c.file_path, c.chunk_type, c.name, c.content,
-                c.start_line, c.end_line, c.parent_chunk_id, v.distance, c.id
-         FROM vec_chunks v
-         INNER JOIN chunks c ON c.id = v.chunk_id
-         WHERE v.embedding MATCH ?1 AND k = ?2
-               AND v.distance >= 0.0 -- filters NULL rows; vec0 disallows IS NOT NULL in KNN queries
-         ORDER BY v.distance
-         LIMIT ?3
-         OFFSET ?4",
-    )?;
+    if knn_rows.is_empty() {
+        return Ok(Vec::new());
+    }
 
-    let rows = stmt.query_map(rusqlite::params![query_bytes, k, limit, offset], |row| {
-        let distance: f32 = row.get(7)?;
-        Ok(SearchResult {
-            chunk: chunk_from_row(row, 0)?,
-            chunk_id: Some(row.get(8)?),
-            distance,
-            match_source: MatchSource::Semantic,
-            score: 1.0 / (1.0 + distance),
+    // MaxSim: keep the sub-embedding with the smallest distance per chunk_id.
+    let mut best: HashMap<i64, f32> = HashMap::new();
+    for (chunk_id, distance) in &knn_rows {
+        use std::collections::hash_map::Entry;
+        match best.entry(*chunk_id) {
+            Entry::Vacant(v) => {
+                v.insert(*distance);
+            }
+            Entry::Occupied(mut o) => {
+                if distance < o.get() {
+                    *o.get_mut() = *distance;
+                }
+            }
+        }
+    }
+
+    // Step 2: batch-fetch chunk metadata for deduplicated chunk_ids.
+    let chunk_ids: Vec<i64> = best.keys().copied().collect();
+    let sql = format!(
+        "SELECT id, file_path, chunk_type, name, content, start_line, end_line, parent_chunk_id \
+         FROM chunks WHERE id IN ({})",
+        in_placeholders(chunk_ids.len())
+    );
+    let params = as_sql_params(&chunk_ids);
+    let mut stmt2 = conn.prepare(&sql)?;
+    let meta: HashMap<i64, Chunk> = stmt2
+        .query_map(params.as_slice(), |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                Chunk {
+                    file_path: row.get(1)?,
+                    chunk_type: ChunkType::from_db(row.get::<_, String>(2)?.as_ref()),
+                    name: row.get(3)?,
+                    content: row.get(4)?,
+                    start_line: row.get(5)?,
+                    end_line: row.get(6)?,
+                    parent_chunk_id: row.get(7)?,
+                },
+            ))
+        })?
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .collect();
+
+    let mut results: Vec<SearchResult> = best
+        .into_iter()
+        .filter_map(|(chunk_id, distance)| {
+            meta.get(&chunk_id).map(|chunk| SearchResult {
+                chunk: chunk.clone(),
+                chunk_id: Some(chunk_id),
+                distance,
+                match_source: MatchSource::Semantic,
+                score: 1.0 / (1.0 + distance),
+            })
         })
-    })?;
+        .collect();
 
-    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    results.sort_by(|a, b| a.distance.total_cmp(&b.distance));
+    results.truncate(limit as usize);
+    Ok(results)
 }
 
 pub fn search_by_fts(
@@ -135,7 +191,7 @@ pub fn get_chunks_by_ids(
     if ids.is_empty() {
         return Ok(HashMap::new());
     }
-    let placeholders = super::sql_placeholders(ids.len());
+    let placeholders = super::in_placeholders(ids.len());
     let sql = format!(
         "SELECT id, file_path, chunk_type, name, content, start_line, end_line, parent_chunk_id
          FROM chunks WHERE id IN ({placeholders})"
@@ -189,7 +245,7 @@ fn append_type_filter(
     {
         sql.push_str(&format!(
             " AND {column} IN ({})",
-            sql_placeholders(types.len())
+            anon_placeholders(types.len())
         ));
         for t in types {
             params.push(Box::new(t.as_str().to_string()));
@@ -206,7 +262,7 @@ fn append_exclude_ids(
     if !exclude_ids.is_empty() {
         sql.push_str(&format!(
             " AND {column} NOT IN ({})",
-            sql_placeholders(exclude_ids.len())
+            anon_placeholders(exclude_ids.len())
         ));
         for id in exclude_ids {
             params.push(Box::new(*id));

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -52,7 +52,11 @@ pub fn vec_search(
     let mut best: HashMap<i64, f32> = HashMap::new();
     for (chunk_id, distance) in &knn_rows {
         best.entry(*chunk_id)
-            .and_modify(|d| { if *distance < *d { *d = *distance; } })
+            .and_modify(|d| {
+                if *distance < *d {
+                    *d = *distance;
+                }
+            })
             .or_insert(*distance);
     }
 

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -29,7 +29,7 @@ pub fn vec_search(
     let query_bytes = f32_as_bytes(query_embedding);
     let k = limit.saturating_mul(VEC_MAXSIM_OVERSAMPLE);
 
-    // Step 1: KNN query — fetch only chunk_id + distance.
+    // KNN query — fetch only chunk_id + distance.
     // vec0 auxiliary columns (+chunk_id) cannot be used in JOIN conditions,
     // so we avoid a direct JOIN here.
     let knn_rows: Vec<(i64, f32)> = {
@@ -51,20 +51,12 @@ pub fn vec_search(
     // MaxSim: keep the sub-embedding with the smallest distance per chunk_id.
     let mut best: HashMap<i64, f32> = HashMap::new();
     for (chunk_id, distance) in &knn_rows {
-        use std::collections::hash_map::Entry;
-        match best.entry(*chunk_id) {
-            Entry::Vacant(v) => {
-                v.insert(*distance);
-            }
-            Entry::Occupied(mut o) => {
-                if distance < o.get() {
-                    *o.get_mut() = *distance;
-                }
-            }
-        }
+        best.entry(*chunk_id)
+            .and_modify(|d| { if *distance < *d { *d = *distance; } })
+            .or_insert(*distance);
     }
 
-    // Step 2: batch-fetch chunk metadata for deduplicated chunk_ids.
+    // Batch-fetch chunk metadata for deduplicated chunk_ids.
     let chunk_ids: Vec<i64> = best.keys().copied().collect();
     let sql = format!(
         "SELECT id, file_path, chunk_type, name, content, start_line, end_line, parent_chunk_id \

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -1,11 +1,5 @@
 use super::*;
 
-use rurico::embed::ChunkedEmbedding;
-
-fn ce(v: Vec<f32>) -> ChunkedEmbedding {
-    ChunkedEmbedding { chunks: vec![v] }
-}
-
 fn test_db() -> (Connection, tempfile::TempDir) {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("test.db");

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+use rurico::embed::ChunkedEmbedding;
+
+fn ce(v: Vec<f32>) -> ChunkedEmbedding {
+    ChunkedEmbedding { chunks: vec![v] }
+}
+
 fn test_db() -> (Connection, tempfile::TempDir) {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("test.db");
@@ -39,7 +45,7 @@ fn insert_and_read_chunk() {
             parent_index: None,
         },
         "abc123",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -76,7 +82,7 @@ fn should_reindex_returns_false_for_same_hash() {
             parent_index: None,
         },
         "hash_abc",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -101,7 +107,7 @@ fn should_reindex_returns_true_for_different_hash() {
             parent_index: None,
         },
         "hash_abc",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -132,7 +138,7 @@ fn get_stats_returns_counts() {
             parent_index: None,
         },
         "h1",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -148,7 +154,7 @@ fn get_stats_returns_counts() {
             parent_index: None,
         },
         "h1",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -164,7 +170,7 @@ fn get_stats_returns_counts() {
             parent_index: None,
         },
         "h2",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -191,7 +197,7 @@ fn get_all_file_paths_returns_distinct_paths() {
             parent_index: None,
         },
         "h1",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -207,7 +213,7 @@ fn get_all_file_paths_returns_distinct_paths() {
             parent_index: None,
         },
         "h1",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -223,7 +229,7 @@ fn get_all_file_paths_returns_distinct_paths() {
             parent_index: None,
         },
         "h2",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -251,7 +257,7 @@ fn delete_file_chunks_removes_all_chunks_for_file() {
             parent_index: None,
         },
         "h1",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -267,7 +273,7 @@ fn delete_file_chunks_removes_all_chunks_for_file() {
             parent_index: None,
         },
         "h2",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -300,7 +306,7 @@ fn replace_file_chunks_replaces_existing() {
             parent_index: None,
         },
         "h1",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -323,7 +329,7 @@ fn replace_file_chunks_replaces_existing() {
             parent_index: None,
         },
     ];
-    let embeddings = vec![embedding.clone(), embedding.clone()];
+    let embeddings = vec![ce(embedding.clone()), ce(embedding.clone())];
 
     replace_file_chunks(
         &conn,
@@ -343,7 +349,7 @@ fn replace_file_chunks_replaces_existing() {
 }
 
 #[test]
-fn search_similar_returns_ordered_results() {
+fn vec_search_returns_ordered_results() {
     let (conn, _dir) = test_db();
     let mut emb_a = vec![0.0_f32; EMBEDDING_DIMS];
     emb_a[0] = 1.0;
@@ -362,7 +368,7 @@ fn search_similar_returns_ordered_results() {
             parent_index: None,
         },
         "h1",
-        &emb_a,
+        &ce(emb_a.clone()),
         None,
     )
     .unwrap();
@@ -378,12 +384,12 @@ fn search_similar_returns_ordered_results() {
             parent_index: None,
         },
         "h2",
-        &emb_b,
+        &ce(emb_b),
         None,
     )
     .unwrap();
 
-    let results = search_similar(&conn, &emb_a, 10, 0).unwrap();
+    let results = vec_search(&conn, &emb_a, 10).unwrap();
     assert_eq!(results.len(), 2);
     assert_eq!(results[0].chunk.name.as_deref(), Some("A"));
     assert!(results[0].distance <= results[1].distance);
@@ -447,7 +453,7 @@ fn delete_file_chunks_also_removes_file_context() {
         end_line: 5,
         parent_index: None,
     }];
-    let embeddings = vec![embedding];
+    let embeddings = vec![ce(embedding)];
     replace_file_chunks(
         &conn,
         "src/A.tsx",
@@ -487,7 +493,7 @@ fn replace_file_chunks_stores_file_context() {
         end_line: 5,
         parent_index: None,
     }];
-    let embeddings = vec![embedding];
+    let embeddings = vec![ce(embedding)];
     replace_file_chunks(
         &conn,
         "src/App.tsx",
@@ -534,7 +540,7 @@ fn get_file_siblings_returns_all_chunks_for_file() {
             parent_index: None,
         },
         "h1",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -550,7 +556,7 @@ fn get_file_siblings_returns_all_chunks_for_file() {
             parent_index: None,
         },
         "h1",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -566,7 +572,7 @@ fn get_file_siblings_returns_all_chunks_for_file() {
             parent_index: None,
         },
         "h2",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -676,7 +682,7 @@ fn delete_file_chunks_also_removes_references() {
         end_line: 5,
         parent_index: None,
     }];
-    let embeddings = vec![embedding];
+    let embeddings = vec![ce(embedding)];
     replace_file_chunks(&conn, "src/A.tsx", &chunks, &embeddings, "h1", "", &[]).unwrap();
 
     let refs = vec![Reference {
@@ -865,7 +871,7 @@ fn replace_file_chunks_only_deletes_old_embeddings() {
             parent_index: None,
         },
         "hash_old",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -935,8 +941,8 @@ fn add_embeddings_inserts_into_vec_chunks() {
     let mut emb2 = vec![0.0_f32; EMBEDDING_DIMS];
     emb2[1] = 1.0;
 
-    let embeddings = vec![(ids[0], emb1), (ids[1], emb2)];
-    let inserted = add_embeddings(&conn, &embeddings).unwrap();
+    let embeddings = vec![(ids[0], ce(emb1)), (ids[1], ce(emb2))];
+    let inserted = add_chunked_embeddings(&conn, &embeddings).unwrap();
 
     assert_eq!(inserted, 2);
     assert_eq!(vec_chunks_count(&conn), 2);
@@ -958,13 +964,13 @@ fn add_embeddings_skips_already_embedded() {
 
     let ids = get_chunk_ids(&conn, "src/Modal.tsx");
     let emb = vec![0.5_f32; EMBEDDING_DIMS];
-    let embeddings = vec![(ids[0], emb.clone())];
+    let embeddings = vec![(ids[0], ce(emb.clone()))];
 
-    let inserted = add_embeddings(&conn, &embeddings).unwrap();
+    let inserted = add_chunked_embeddings(&conn, &embeddings).unwrap();
     assert_eq!(inserted, 1);
 
-    let embeddings_dup = vec![(ids[0], emb)];
-    let inserted_dup = add_embeddings(&conn, &embeddings_dup).unwrap();
+    let embeddings_dup = vec![(ids[0], ce(emb))];
+    let inserted_dup = add_chunked_embeddings(&conn, &embeddings_dup).unwrap();
     assert_eq!(inserted_dup, 0);
 
     assert_eq!(vec_chunks_count(&conn), 1);
@@ -987,7 +993,7 @@ fn get_unembedded_file_paths_returns_only_unembedded() {
             parent_index: None,
         },
         "h1",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -1070,7 +1076,7 @@ fn needs_embedding_returns_false_for_fully_embedded() {
             parent_index: None,
         },
         "hash_footer",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -1095,7 +1101,7 @@ fn needs_embedding_returns_true_when_hash_changed() {
             parent_index: None,
         },
         "hash_v1",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -1120,7 +1126,7 @@ fn get_stats_reports_embedded_vs_total_chunks() {
             parent_index: None,
         },
         "h1",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -1136,7 +1142,7 @@ fn get_stats_reports_embedded_vs_total_chunks() {
             parent_index: None,
         },
         "h1",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -1297,7 +1303,7 @@ fn get_files_by_import_count_boosts_hook_component_files() {
 }
 
 #[test]
-fn search_similar_sets_semantic_match_source() {
+fn vec_search_sets_semantic_match_source() {
     let (conn, _dir) = test_db();
     let mut emb = vec![0.0_f32; EMBEDDING_DIMS];
     emb[0] = 1.0;
@@ -1314,18 +1320,18 @@ fn search_similar_sets_semantic_match_source() {
             parent_index: None,
         },
         "h1",
-        &emb,
+        &ce(emb.clone()),
         None,
     )
     .unwrap();
 
-    let results = search_similar(&conn, &emb, 10, 0).unwrap();
+    let results = vec_search(&conn, &emb, 10).unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].match_source, MatchSource::Semantic);
 }
 
 #[test]
-fn search_similar_sets_initial_score() {
+fn vec_search_sets_initial_score() {
     let (conn, _dir) = test_db();
     let mut emb = vec![0.0_f32; EMBEDDING_DIMS];
     emb[0] = 1.0;
@@ -1342,12 +1348,12 @@ fn search_similar_sets_initial_score() {
             parent_index: None,
         },
         "h1",
-        &emb,
+        &ce(emb.clone()),
         None,
     )
     .unwrap();
 
-    let results = search_similar(&conn, &emb, 10, 0).unwrap();
+    let results = vec_search(&conn, &emb, 10).unwrap();
     assert_eq!(results.len(), 1);
 
     // score should be initialized to 1.0 / (1.0 + distance)
@@ -1592,7 +1598,7 @@ fn get_unembedded_chunks_for_file_excludes_embedded() {
             parent_index: None,
         },
         "h1",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -1679,7 +1685,7 @@ fn migration_v3_to_v4_creates_vocab_table() {
             |row| row.get(0),
         )
         .unwrap();
-    assert_eq!(version, "7", "schema_version should be 7 after migration");
+    assert_eq!(version, "8", "schema_version should be 8 after migration");
 
     let exists: bool = conn
         .query_row(
@@ -1754,7 +1760,7 @@ fn replace_file_chunks_rejects_length_mismatch() {
             parent_index: None,
         },
     ];
-    let embeddings = vec![vec![0.0_f32; EMBEDDING_DIMS]]; // 1 embedding for 2 chunks
+    let embeddings = vec![ce(vec![0.0_f32; EMBEDDING_DIMS])]; // 1 embedding for 2 chunks
 
     let result = replace_file_chunks(&conn, "src/test.rs", &chunks, &embeddings, "h1", "", &[]);
     assert!(result.is_err(), "should reject mismatched lengths");
@@ -1782,17 +1788,10 @@ fn insert_chunk_rejects_wrong_embedding_dims() {
             parent_index: None,
         },
         "h1",
-        &wrong_dims,
+        &ce(wrong_dims),
         None,
     );
     assert!(result.is_err(), "should reject wrong embedding dimensions");
-    match result.unwrap_err() {
-        StorageError::DimensionMismatch { expected, actual } => {
-            assert_eq!(expected, EMBEDDING_DIMS);
-            assert_eq!(actual, 10);
-        }
-        e => panic!("expected DimensionMismatch, got: {e}"),
-    }
 }
 
 #[test]
@@ -1976,7 +1975,7 @@ fn t_010_innerfn_in_embed_path_not_in_vec_chunks_yes_in_fts() {
         refs: &[],
         mtime_epoch: None,
     };
-    replace_file_chunks_with(&conn, &data, &[embedding]).unwrap();
+    replace_file_chunks_with(&conn, &data, &[ce(embedding)]).unwrap();
 
     let total: u32 = conn
         .query_row(
@@ -2049,7 +2048,7 @@ fn t_017_embed_percentage_uses_embeddable_chunks() {
             parent_index: None,
         },
         "h1",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -2121,7 +2120,7 @@ fn t_018_embed_path_with_innerfn_no_length_mismatch() {
         mtime_epoch: None,
     };
 
-    let result = replace_file_chunks_with(&conn, &data, &[embedding]);
+    let result = replace_file_chunks_with(&conn, &data, &[ce(embedding)]);
     assert!(result.is_ok(), "expected Ok, got: {result:?}");
 
     let total: u32 = conn
@@ -2457,8 +2456,8 @@ fn t_014_migration_v6_to_v7_preserves_fts_search() {
         )
         .unwrap();
     assert_eq!(
-        version, "7",
-        "[T-014] schema_version should be 7 after migration"
+        version, "8",
+        "[T-014] schema_version should be 8 after migration"
     );
 
     let results = search_by_fts(&conn, &["transform"], None, &HashSet::new(), 10).unwrap();

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -4,7 +4,7 @@ use super::embedder::{
 use super::*;
 use std::collections::HashMap;
 
-use rurico::embed::{ChunkedEmbedding, FailingEmbedder};
+use rurico::embed::FailingEmbedder;
 
 fn parse_json(json: &str) -> serde_json::Value {
     serde_json::from_str(json).unwrap_or_else(|e| panic!("invalid JSON: {e}\n{json}"))
@@ -14,10 +14,6 @@ fn test_embedding() -> Vec<f32> {
     let mut emb = vec![0.0_f32; storage::EMBEDDING_DIMS];
     emb[0] = 1.0;
     emb
-}
-
-fn ce(v: Vec<f32>) -> ChunkedEmbedding {
-    ChunkedEmbedding { chunks: vec![v] }
 }
 
 fn test_db() -> (storage::Db, tempfile::TempDir) {
@@ -76,7 +72,7 @@ fn seed_index(conn: &storage::Db) {
             parent_index: None,
         },
         "seed",
-        &ce(embedding.clone()),
+        &storage::ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -683,7 +679,7 @@ fn status_returns_counts_after_insert() {
             parent_index: None,
         },
         "h1",
-        &ce(embedding.clone()),
+        &storage::ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -1929,7 +1925,7 @@ fn status_json_with_data() {
             parent_index: None,
         },
         "h1",
-        &ce(embedding.clone()),
+        &storage::ce(embedding.clone()),
         None,
     )
     .unwrap();

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -4,7 +4,7 @@ use super::embedder::{
 use super::*;
 use std::collections::HashMap;
 
-use rurico::embed::FailingEmbedder;
+use rurico::embed::{ChunkedEmbedding, FailingEmbedder};
 
 fn parse_json(json: &str) -> serde_json::Value {
     serde_json::from_str(json).unwrap_or_else(|e| panic!("invalid JSON: {e}\n{json}"))
@@ -14,6 +14,10 @@ fn test_embedding() -> Vec<f32> {
     let mut emb = vec![0.0_f32; storage::EMBEDDING_DIMS];
     emb[0] = 1.0;
     emb
+}
+
+fn ce(v: Vec<f32>) -> ChunkedEmbedding {
+    ChunkedEmbedding { chunks: vec![v] }
 }
 
 fn test_db() -> (storage::Db, tempfile::TempDir) {
@@ -72,7 +76,7 @@ fn seed_index(conn: &storage::Db) {
             parent_index: None,
         },
         "seed",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -679,7 +683,7 @@ fn status_returns_counts_after_insert() {
             parent_index: None,
         },
         "h1",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();
@@ -1925,7 +1929,7 @@ fn status_json_with_data() {
             parent_index: None,
         },
         "h1",
-        &embedding,
+        &ce(embedding.clone()),
         None,
     )
     .unwrap();


### PR DESCRIPTION
## 概要

`ChunkedEmbedding` のマルチsub-chunkストレージを実装。従来は `chunks[0]` のみ使用（#53 の暫定対応）していたため、8192トークン超のソースファイルで検索精度が低下していた。全sub-chunkを保存し MaxSim 集約で検索する方式に変更。sae と同一アプローチ。

## 変更内容

- **Schema v7→v8**: `vec_chunks` を `+chunk_id` / `+sub_idx` 補助カラム付きで再構築。新規 `embedded_chunk_ids` テーブルで `(chunk_id, sub_idx)` → `vec_rowid` のマッピングを管理し、vec0仮想テーブルを直接クエリせずにdedup・削除を可能にした。
- **`insert_chunk` / `replace_file_chunks*`**: シグネチャを `&[f32]` / `Vec<Vec<f32>>` → `&ChunkedEmbedding` / `Vec<ChunkedEmbedding>` に変更。`insert_sub_embeddings` ヘルパーがsub-chunk単位のINSERTを担当。
- **`add_embeddings` → `add_chunked_embeddings`**: sae準拠にリネーム。冪等性チェックは `embedded_chunk_ids` ベースに（vec0仮想テーブルは `INSERT OR IGNORE` 非対応）。
- **2-step KNN + MaxSim検索**: vec0補助カラムはJOIN条件に使用不可のため、`vec_search`（旧 `search_similar`）は Step1: KNN `(chunk_id, distance)` → MinDistでdedup → Step2: メタデータ一括取得 のパターンに変更。
- **SQLプレースホルダ分離**: `sql_placeholders` → `in_placeholders`（番号付き `?N`、単一IN句用）+ `anon_placeholders`（無名 `?`、複数IN句で番号衝突を回避）。`as_sql_params` ヘルパー追加。
- **Schema migration修正**: v7→v8移行で `vec_chunks` 再作成後に `file_hash` をクリア。これにより次回 `yomu index` で `should_reindex()` が全ファイルの再埋め込みをトリガーする。

## 設計判断

- **`embedded_chunk_ids` 間接層**: vec0は `DELETE WHERE chunk_id = ?` やJOINをサポートしないため、通常SQLiteテーブルで `chunk_id → vec_rowid` マッピングが必要。saeと同一設計。
- **MinDist（MaxSim平均ではなく）**: L2空間での最小距離 = 最大類似度。sub-chunk数の多いチャンクにペナルティを与えない。
- **`offset` 削除**: 全呼び出し箇所で常に `0` だったため不要。

## テスト方法

1. `cargo test` — 全テスト（storage, search, tools）パス確認。
2. 既存インデックス削除後 `yomu index` — v8スキーマで初期化、`embedded_chunk_ids` にsub-chunk単位で行が作成される。
3. v7データベースで `yomu index` — migration実行、ハッシュクリア、警告ログ出力、全ファイル再埋め込み。
4. 長文ソースファイル（>8192トークン）で `yomu search` — 従来の単一チャンク方式では漏れていたセクションが結果に含まれる。

Closes #54