### PR TITLE
Spinner を lib クレートに移動し非 TTY フォールバックを追加

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod indexer;
+pub mod progress;
 pub mod query;
 pub mod resolver;
 pub mod rust_resolver;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
-mod progress;
 mod shorthand;
+
+use yomu::progress;
 
 use std::io::{IsTerminal, Read};
 use std::process::ExitCode;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -9,13 +9,13 @@ use std::time::Duration;
 const FRAMES: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 const TICK_MS: u64 = 80;
 
-pub(crate) struct Spinner {
+pub struct Spinner {
     done: Arc<AtomicBool>,
     thread: Option<thread::JoinHandle<()>>,
 }
 
 impl Spinner {
-    pub(crate) fn new(msg: &str) -> Self {
+    pub fn new(msg: &str) -> Self {
         let done = Arc::new(AtomicBool::new(false));
 
         let thread = if std::io::stderr().is_terminal() {
@@ -35,21 +35,24 @@ impl Spinner {
                 }
             }))
         } else {
+            eprintln!("{msg}");
             None
         };
 
         Self { done, thread }
     }
 
-    pub(crate) fn finish(self, msg: &str) {
+    pub fn finish(self, msg: &str) {
         let is_tty = self.thread.is_some();
         drop(self);
         if is_tty {
             eprintln!("\x1b[32m✓\x1b[0m {msg}");
+        } else {
+            eprintln!("{msg}");
         }
     }
 
-    pub(crate) fn cancel(self) {
+    pub fn cancel(self) {
         tracing::trace!("spinner cancelled");
     }
 }

--- a/src/tools/embedder.rs
+++ b/src/tools/embedder.rs
@@ -114,12 +114,19 @@ fn try_load_embedder(disabled: bool) -> Result<Arc<dyn Embed>, DegradedReason> {
         auto_download,
         || rurico::embed::cached_artifacts(rurico::embed::ModelId::default()),
         || {
-            eprintln!("yomu: auto-downloading embedding model...");
+            let spinner =
+                crate::progress::Spinner::new("Downloading model (YOMU_AUTO_DOWNLOAD_MODEL=1)...");
             let result = rurico::embed::download_model(rurico::embed::ModelId::default());
-            if result.is_ok() {
-                eprintln!("yomu: model ready");
+            match result {
+                Ok(p) => {
+                    spinner.finish("Model ready");
+                    Ok(p)
+                }
+                Err(e) => {
+                    spinner.cancel();
+                    Err(e)
+                }
             }
-            result
         },
     )
 }


### PR DESCRIPTION
Closes #63

## 背景

`progress::Spinner` は `src/main.rs` (バイナリクレート) に `mod progress` として宣言されており、`src/tools/embedder.rs` (ライブラリクレート) からアクセスできなかった。
`try_load_embedder` の auto-download パスは `eprintln!` を使っており、`run_model_download` と表示が不統一だった。

## 変更内容

- `src/progress.rs` をバイナリ `mod` から `pub mod progress` (lib.rs) へ移動
- `Spinner`, `Spinner::new`, `Spinner::finish`, `Spinner::cancel` の visibility を `pub(crate)` → `pub` に変更
- `try_load_embedder` の `eprintln!` を `Spinner` に置き換え（`run_model_download` と同じパターン）
- 非 TTY フォールバック追加: `Spinner::new` と `Spinner::finish` で stderr が非ターミナルの場合に `eprintln!` 出力

## テスト計画

- [ ] `cargo build` が警告なしで成功
- [ ] `cargo test` がパス
- [ ] `YOMU_AUTO_DOWNLOAD_MODEL=1` を TTY で実行: ダウンロード中にスピナーアニメーション表示、成功時に "Model ready" 出力
- [ ] `YOMU_AUTO_DOWNLOAD_MODEL=1` を非 TTY で実行 (例: `yomu index ... | cat`): 開始・完了メッセージがプレーンテキストで出力
- [ ] ダウンロード失敗シミュレーション: `spinner.cancel()` パスで不要な出力なし