### PR TITLE
storageレイヤーのprepare_cached・as_sql_paramsヘルパー・DDL定数を統一

### DIFF
--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -99,7 +99,9 @@ pub fn get_files_with_chunk_types(
         .chain(files.iter().cloned())
         .collect();
     let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map(as_sql_params(&params).as_slice(), |row| row.get::<_, String>(0))?;
+    let rows = stmt.query_map(as_sql_params(&params).as_slice(), |row| {
+        row.get::<_, String>(0)
+    })?;
     rows.collect::<Result<HashSet<_>, _>>().map_err(Into::into)
 }
 

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -53,7 +53,7 @@ pub fn get_unembedded_chunks_for_file(
     conn: &Connection,
     file_path: &str,
 ) -> Result<Vec<(i64, String, String)>, StorageError> {
-    let mut stmt = conn.prepare(
+    let mut stmt = conn.prepare_cached(
         "SELECT c.id, c.content, c.chunk_type FROM chunks c
          LEFT JOIN embedded_chunk_ids e ON c.id = e.chunk_id
          WHERE c.file_path = ?1 AND e.chunk_id IS NULL AND c.chunk_type != 'inner_fn'",
@@ -93,17 +93,13 @@ pub fn get_files_with_chunk_types(
     let sql = format!(
         "SELECT DISTINCT file_path FROM chunks WHERE chunk_type IN ({type_ph}) AND file_path IN ({file_ph})"
     );
-    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> =
-        Vec::with_capacity(types.len() + files.len());
-    for t in types {
-        params.push(Box::new(t.as_str().to_string()));
-    }
-    for f in files {
-        params.push(Box::new(f.clone()));
-    }
-    let param_refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|b| b.as_ref()).collect();
+    let params: Vec<String> = types
+        .iter()
+        .map(|t| t.as_str().to_string())
+        .chain(files.iter().cloned())
+        .collect();
     let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map(param_refs.as_slice(), |row| row.get::<_, String>(0))?;
+    let rows = stmt.query_map(as_sql_params(&params).as_slice(), |row| row.get::<_, String>(0))?;
     rows.collect::<Result<HashSet<_>, _>>().map_err(Into::into)
 }
 
@@ -148,7 +144,7 @@ fn stored_hash_for_file(
 
 #[cfg(test)]
 pub fn get_unembedded_file_paths(conn: &Connection) -> Result<Vec<(String, u32)>, StorageError> {
-    let mut stmt = conn.prepare(
+    let mut stmt = conn.prepare_cached(
         "SELECT c.file_path, COUNT(*) as chunk_count
          FROM chunks c
          LEFT JOIN embedded_chunk_ids e ON c.id = e.chunk_id

--- a/src/storage/graph.rs
+++ b/src/storage/graph.rs
@@ -189,8 +189,7 @@ pub fn get_file_siblings(
             },
         ))
     })?;
-    let mut map: HashMap<String, Vec<SiblingInfo>> =
-        HashMap::new();
+    let mut map: HashMap<String, Vec<SiblingInfo>> = HashMap::new();
     for row in rows {
         let (path, info) = row?;
         map.entry(path).or_default().push(info);
@@ -230,8 +229,9 @@ pub fn get_dependents(
     conn: &Connection,
     target_file: &str,
 ) -> Result<Vec<Dependent>, StorageError> {
-    let mut stmt =
-        conn.prepare_cached("SELECT DISTINCT source_file FROM file_references WHERE target_file = ?1")?;
+    let mut stmt = conn.prepare_cached(
+        "SELECT DISTINCT source_file FROM file_references WHERE target_file = ?1",
+    )?;
     let rows = stmt.query_map([target_file], |row| {
         Ok(Dependent {
             file_path: row.get(0)?,

--- a/src/storage/graph.rs
+++ b/src/storage/graph.rs
@@ -1,8 +1,10 @@
+use std::collections::HashMap;
+
 use rusqlite::Connection;
 
 #[cfg(test)]
 use super::Reference;
-use super::{ChunkType, StorageError, in_placeholders};
+use super::{ChunkType, StorageError, as_sql_params, in_placeholders};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Dependent {
@@ -18,7 +20,21 @@ pub struct SiblingInfo {
     pub end_line: u32,
 }
 
-const HOOK_COMPONENT_PRIORITY_BOOST: u32 = 3;
+const SQL_FILES_BY_IMPORT_COUNT: &str = "SELECT c.file_path
+         FROM chunks c
+         LEFT JOIN vec_chunks v ON c.id = v.chunk_id
+         WHERE v.chunk_id IS NULL
+         GROUP BY c.file_path
+         ORDER BY (
+             SELECT COUNT(*) FROM file_references r
+             WHERE r.target_file = c.file_path
+         ) + (
+             SELECT CASE WHEN EXISTS(
+                 SELECT 1 FROM chunks c2
+                 WHERE c2.file_path = c.file_path
+                 AND c2.chunk_type IN ('hook', 'component')
+             ) THEN 3 ELSE 0 END
+         ) DESC, c.file_path ASC";
 
 pub fn get_transitive_dependents(
     conn: &Connection,
@@ -26,7 +42,7 @@ pub fn get_transitive_dependents(
     max_depth: u32,
 ) -> Result<Vec<Dependent>, StorageError> {
     let max_depth = max_depth.min(10);
-    let mut stmt = conn.prepare(
+    let mut stmt = conn.prepare_cached(
         "WITH RECURSIVE deps(file_path, depth, visited) AS (
             SELECT DISTINCT source_file, 1,
                    ',' || ?1 || ',' || source_file || ','
@@ -57,7 +73,7 @@ pub fn get_symbol_dependents(
     target_file: &str,
     symbol_name: &str,
 ) -> Result<Vec<String>, StorageError> {
-    let mut stmt = conn.prepare(
+    let mut stmt = conn.prepare_cached(
         "SELECT DISTINCT source_file FROM file_references
          WHERE target_file = ?1 AND symbol_name = ?2",
     )?;
@@ -75,24 +91,7 @@ pub fn get_reference_count(conn: &Connection) -> Result<u32, StorageError> {
 
 /// Returns un-embedded file paths ordered by import count (most-imported first).
 pub fn get_files_by_import_count(conn: &Connection) -> Result<Vec<String>, StorageError> {
-    let sql = format!(
-        "SELECT c.file_path
-         FROM chunks c
-         LEFT JOIN vec_chunks v ON c.id = v.chunk_id
-         WHERE v.chunk_id IS NULL
-         GROUP BY c.file_path
-         ORDER BY (
-             SELECT COUNT(*) FROM file_references r
-             WHERE r.target_file = c.file_path
-         ) + (
-             SELECT CASE WHEN EXISTS(
-                 SELECT 1 FROM chunks c2
-                 WHERE c2.file_path = c.file_path
-                 AND c2.chunk_type IN ('hook', 'component')
-             ) THEN {HOOK_COMPONENT_PRIORITY_BOOST} ELSE 0 END
-         ) DESC, c.file_path ASC"
-    );
-    let mut stmt = conn.prepare(&sql)?;
+    let mut stmt = conn.prepare_cached(SQL_FILES_BY_IMPORT_COUNT)?;
     let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
     rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
 }
@@ -100,9 +99,9 @@ pub fn get_files_by_import_count(conn: &Connection) -> Result<Vec<String>, Stora
 pub fn get_import_counts(
     conn: &Connection,
     file_paths: &[&str],
-) -> Result<std::collections::HashMap<String, u32>, StorageError> {
+) -> Result<HashMap<String, u32>, StorageError> {
     if file_paths.is_empty() {
-        return Ok(std::collections::HashMap::new());
+        return Ok(HashMap::new());
     }
     let sql = format!(
         "SELECT fp.path, COALESCE(cnt.c, 0)
@@ -120,69 +119,57 @@ pub fn get_import_counts(
             .join(" UNION ALL ")
     );
     let mut stmt = conn.prepare(&sql)?;
-    let params: Vec<&dyn rusqlite::types::ToSql> = file_paths
-        .iter()
-        .map(|s| s as &dyn rusqlite::types::ToSql)
-        .collect();
-    let rows = stmt.query_map(params.as_slice(), |row| {
+    let rows = stmt.query_map(as_sql_params(file_paths).as_slice(), |row| {
         Ok((row.get::<_, String>(0)?, row.get::<_, u32>(1)?))
     })?;
-    rows.collect::<Result<std::collections::HashMap<_, _>, _>>()
+    rows.collect::<Result<HashMap<_, _>, _>>()
         .map_err(Into::into)
 }
 
 pub fn get_file_mtimes(
     conn: &Connection,
     file_paths: &[&str],
-) -> Result<std::collections::HashMap<String, i64>, StorageError> {
+) -> Result<HashMap<String, i64>, StorageError> {
     if file_paths.is_empty() {
-        return Ok(std::collections::HashMap::new());
+        return Ok(HashMap::new());
     }
     let placeholders = in_placeholders(file_paths.len());
     let sql = format!(
         "SELECT file_path, mtime_epoch FROM file_context WHERE file_path IN ({placeholders}) AND mtime_epoch IS NOT NULL"
     );
     let mut stmt = conn.prepare(&sql)?;
-    let params: Vec<&dyn rusqlite::types::ToSql> = file_paths
-        .iter()
-        .map(|s| s as &dyn rusqlite::types::ToSql)
-        .collect();
-    let rows = stmt.query_map(params.as_slice(), |row| {
+    let rows = stmt.query_map(as_sql_params(file_paths).as_slice(), |row| {
         Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
     })?;
-    rows.collect::<Result<std::collections::HashMap<_, _>, _>>()
+    rows.collect::<Result<HashMap<_, _>, _>>()
         .map_err(Into::into)
 }
 
 pub fn get_file_contexts(
     conn: &Connection,
     file_paths: &[&str],
-) -> Result<std::collections::HashMap<String, String>, StorageError> {
+) -> Result<HashMap<String, String>, StorageError> {
     if file_paths.is_empty() {
-        return Ok(std::collections::HashMap::new());
+        return Ok(HashMap::new());
     }
     let placeholders = in_placeholders(file_paths.len());
     let sql = format!(
         "SELECT file_path, imports_text FROM file_context WHERE file_path IN ({placeholders})"
     );
     let mut stmt = conn.prepare(&sql)?;
-    let params: Vec<&dyn rusqlite::types::ToSql> = file_paths
-        .iter()
-        .map(|s| s as &dyn rusqlite::types::ToSql)
-        .collect();
-    let rows = stmt.query_map(params.as_slice(), |row| {
+    let rows = stmt.query_map(as_sql_params(file_paths).as_slice(), |row| {
         Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
     })?;
-    rows.collect::<Result<std::collections::HashMap<_, _>, _>>()
+    rows.collect::<Result<HashMap<_, _>, _>>()
         .map_err(Into::into)
 }
 
 pub fn get_file_siblings(
     conn: &Connection,
     file_paths: &[&str],
-) -> Result<std::collections::HashMap<String, Vec<SiblingInfo>>, StorageError> {
+) -> Result<HashMap<String, Vec<SiblingInfo>>, StorageError> {
     if file_paths.is_empty() {
-        return Ok(std::collections::HashMap::new());
+        return Ok(HashMap::new());
     }
     let placeholders = in_placeholders(file_paths.len());
     let sql = format!(
@@ -191,11 +178,7 @@ pub fn get_file_siblings(
          ORDER BY file_path, start_line"
     );
     let mut stmt = conn.prepare(&sql)?;
-    let params: Vec<&dyn rusqlite::types::ToSql> = file_paths
-        .iter()
-        .map(|s| s as &dyn rusqlite::types::ToSql)
-        .collect();
-    let rows = stmt.query_map(params.as_slice(), |row| {
+    let rows = stmt.query_map(as_sql_params(file_paths).as_slice(), |row| {
         Ok((
             row.get::<_, String>(0)?,
             SiblingInfo {
@@ -206,8 +189,8 @@ pub fn get_file_siblings(
             },
         ))
     })?;
-    let mut map: std::collections::HashMap<String, Vec<SiblingInfo>> =
-        std::collections::HashMap::new();
+    let mut map: HashMap<String, Vec<SiblingInfo>> =
+        HashMap::new();
     for row in rows {
         let (path, info) = row?;
         map.entry(path).or_default().push(info);
@@ -248,7 +231,7 @@ pub fn get_dependents(
     target_file: &str,
 ) -> Result<Vec<Dependent>, StorageError> {
     let mut stmt =
-        conn.prepare("SELECT DISTINCT source_file FROM file_references WHERE target_file = ?1")?;
+        conn.prepare_cached("SELECT DISTINCT source_file FROM file_references WHERE target_file = ?1")?;
     let rows = stmt.query_map([target_file], |row| {
         Ok(Dependent {
             file_path: row.get(0)?,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -322,7 +322,7 @@ pub fn is_index_fresh(conn: &Connection, max_age_secs: u32) -> Result<bool, Stor
 }
 
 pub fn get_all_file_paths(conn: &Connection) -> Result<HashSet<String>, StorageError> {
-    let mut stmt = conn.prepare("SELECT DISTINCT file_path FROM chunks")?;
+    let mut stmt = conn.prepare_cached("SELECT DISTINCT file_path FROM chunks")?;
     let paths = stmt.query_map([], |row| row.get::<_, String>(0))?;
     paths.collect::<Result<HashSet<_>, _>>().map_err(Into::into)
 }

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -44,6 +44,12 @@ pub fn open_db(path: &Path) -> Result<Connection, StorageError> {
 
 const SCHEMA_VERSION: u32 = 8;
 
+const DDL_FTS_CHUNKS: &str =
+    "CREATE VIRTUAL TABLE IF NOT EXISTS fts_chunks USING fts5(name, content, file_path)";
+
+const DDL_FTS_CHUNKS_VOCAB: &str =
+    "CREATE VIRTUAL TABLE IF NOT EXISTS fts_chunks_vocab USING fts5vocab(fts_chunks, row)";
+
 const DDL_EMBEDDED_CHUNK_IDS: &str = "\
     CREATE TABLE IF NOT EXISTS embedded_chunk_ids (\
         chunk_id INTEGER NOT NULL, \
@@ -106,11 +112,7 @@ fn init_schema(conn: &Connection, path: &Path) -> Result<(), StorageError> {
     conn.execute_batch(&ddl_vec_chunks())?;
     conn.execute_batch(DDL_EMBEDDED_CHUNK_IDS)?;
 
-    conn.execute_batch(
-        "CREATE VIRTUAL TABLE IF NOT EXISTS fts_chunks USING fts5(
-            name, content, file_path
-        )",
-    )?;
+    conn.execute_batch(DDL_FTS_CHUNKS)?;
 
     let stored: u32 = match conn.query_row(
         "SELECT value FROM index_meta WHERE key = 'schema_version'",
@@ -201,9 +203,7 @@ fn migrate(conn: &Connection, from: u32, path: &Path) -> Result<(), StorageError
 
     // v3 → v4: add fts5vocab table for short-term expansion
     if from < 4 {
-        conn.execute_batch(
-            "CREATE VIRTUAL TABLE IF NOT EXISTS fts_chunks_vocab USING fts5vocab(fts_chunks, row)",
-        )?;
+        conn.execute_batch(DDL_FTS_CHUNKS_VOCAB)?;
     }
 
     // v4 → v5: add parent_chunk_id for subchunk extraction
@@ -281,9 +281,7 @@ fn rebuild_fts_v7(conn: &Connection) -> Result<(), StorageError> {
 
     fts_optimize(conn)?;
 
-    conn.execute_batch(
-        "CREATE VIRTUAL TABLE IF NOT EXISTS fts_chunks_vocab USING fts5vocab(fts_chunks, row)",
-    )?;
+    conn.execute_batch(DDL_FTS_CHUNKS_VOCAB)?;
     Ok(())
 }
 

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -33,7 +33,7 @@ pub fn vec_search(
     // vec0 auxiliary columns (+chunk_id) cannot be used in JOIN conditions,
     // so we avoid a direct JOIN here.
     let knn_rows: Vec<(i64, f32)> = {
-        let mut stmt = conn.prepare(
+        let mut stmt = conn.prepare_cached(
             "SELECT chunk_id, distance FROM vec_chunks \
              WHERE embedding MATCH ?1 AND k = ?2 \
              ORDER BY distance",
@@ -84,9 +84,7 @@ pub fn vec_search(
                 },
             ))
         })?
-        .collect::<Result<Vec<_>, _>>()?
-        .into_iter()
-        .collect();
+        .collect::<Result<HashMap<_, _>, _>>()?;
 
     let mut results: Vec<SearchResult> = best
         .into_iter()
@@ -169,7 +167,7 @@ pub fn search_by_fts(
 }
 
 pub fn get_chunk_by_id(conn: &Connection, chunk_id: i64) -> Result<Option<Chunk>, StorageError> {
-    let mut stmt = conn.prepare(
+    let mut stmt = conn.prepare_cached(
         "SELECT file_path, chunk_type, name, content, start_line, end_line, parent_chunk_id
          FROM chunks WHERE id = ?1",
     )?;
@@ -193,11 +191,7 @@ pub fn get_chunks_by_ids(
          FROM chunks WHERE id IN ({placeholders})"
     );
     let mut stmt = conn.prepare(&sql)?;
-    let params: Vec<&dyn rusqlite::types::ToSql> = ids
-        .iter()
-        .map(|id| id as &dyn rusqlite::types::ToSql)
-        .collect();
-    let rows = stmt.query_map(params.as_slice(), |row| {
+    let rows = stmt.query_map(as_sql_params(ids).as_slice(), |row| {
         let id: i64 = row.get(0)?;
         let chunk = chunk_from_row(row, 1)?;
         Ok((id, chunk))


### PR DESCRIPTION
Closes #57

## 変更内容

saeクレートで確立済みのパターンに合わせ、storageレイヤーをリファクタリング。

- **prepare → prepare_cached** を `embed.rs`・`graph.rs`・`mod.rs`・`search.rs` の静的SQL全9箇所に適用
- **`as_sql_params` ヘルパー**で `Vec<Box<dyn ToSql>>` + `param_refs.as_slice()` パターンを置換（`embed.rs`・`graph.rs`・`search.rs`）
- **DDL定数** `DDL_FTS_CHUNKS`・`DDL_FTS_CHUNKS_VOCAB` を `schema.rs` に抽出（各3箇所で使用）
- **`SQL_FILES_BY_IMPORT_COUNT` 定数**で `get_files_by_import_count` の `format!` ベースSQLを置換し、呼び出し毎のヒープ割り当てを除去
- **二重collect除去**: `vec_search` のホットパスで `Vec → HashMap` 中間collectを排除
- **`HashMap` import追加**: `graph.rs` の完全修飾 `std::collections::HashMap` 13箇所を置換

ロジック変更なし。全383テスト通過。

## スコープ外

- 動的SQL（可変長IN句）は意図的に `prepare` のまま — ステートメントキャッシュ汚染を回避
- `search_by_fts` の `Vec<Box<dyn ToSql>>` は現状維持 — 異種型のためヘルパーリファクタが別途必要