### PR TITLE
ModelCorrupt検出時に破損モデルファイルを削除

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,7 +2039,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=5569a30#5569a30cc9a6509b5ce2b8220e95dc0257a35d2c"
+source = "git+https://github.com/thkt/rurico?rev=03275f7#03275f78ec1c1b677566a9c04d3cdad03e29b3d9"
 dependencies = [
  "bytemuck",
  "hf-hub",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ test-support = ["rurico/test-support"]
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
-rurico = { git = "https://github.com/thkt/rurico", rev = "5569a30" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "03275f7" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -28,7 +28,7 @@ tree-sitter-rust = "0.24"
 tree-sitter-typescript = "0.23"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "5569a30", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "03275f7", features = ["test-support"] }
 tempfile = "3"
 
 [profile.release]

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,7 +239,7 @@ fn resolve_query_with(
 }
 
 fn run_model_download(json: bool) -> Result<String, YomuError> {
-    use rurico::embed::{Embedder, ModelId, ProbeStatus};
+    use rurico::embed::{EmbedInitError, Embedder, ModelId, ProbeStatus};
 
     let spinner = progress::Spinner::new("Downloading model...");
     let paths = match rurico::embed::download_model(ModelId::default()) {
@@ -262,6 +262,11 @@ fn run_model_download(json: bool) -> Result<String, YomuError> {
         }
         Err(e) => {
             spinner.cancel();
+            if matches!(e, EmbedInitError::ModelCorrupt { .. }) {
+                if let Err(del_err) = paths.delete_files() {
+                    tracing::warn!(error = %del_err, "failed to delete corrupt model files");
+                }
+            }
             return Err(YomuError::Internal(format!("Model probe failed: {e}")));
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,10 +262,10 @@ fn run_model_download(json: bool) -> Result<String, YomuError> {
         }
         Err(e) => {
             spinner.cancel();
-            if matches!(e, EmbedInitError::ModelCorrupt { .. }) {
-                if let Err(del_err) = paths.delete_files() {
-                    tracing::warn!(error = %del_err, "failed to delete corrupt model files");
-                }
+            if matches!(e, EmbedInitError::ModelCorrupt { .. })
+                && let Err(del_err) = paths.delete_files()
+            {
+                tracing::warn!(error = %del_err, "failed to delete corrupt model files");
             }
             return Err(YomuError::Internal(format!("Model probe failed: {e}")));
         }

--- a/src/tools/embedder.rs
+++ b/src/tools/embedder.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use rurico::embed::{ChunkedEmbedding, Embed, EmbedError, Embedder};
+use rurico::embed::{ChunkedEmbedding, Embed, EmbedError, EmbedInitError, Embedder};
 
 use super::Yomu;
 
@@ -136,11 +136,37 @@ fn try_load_embedder_with<CE: std::fmt::Display, DE: std::fmt::Display>(
     cache_check: impl FnOnce() -> Result<Option<rurico::embed::Artifacts>, CE>,
     download_fn: impl FnOnce() -> Result<rurico::embed::Artifacts, DE>,
 ) -> Result<Arc<dyn Embed>, DegradedReason> {
+    try_load_embedder_with_fns(
+        auto_download,
+        cache_check,
+        download_fn,
+        |a| Embedder::probe(a),
+        |a| Embedder::new(a),
+    )
+}
+
+fn try_load_embedder_with_fns<CE, DE>(
+    auto_download: bool,
+    cache_check: impl FnOnce() -> Result<Option<rurico::embed::Artifacts>, CE>,
+    download_fn: impl FnOnce() -> Result<rurico::embed::Artifacts, DE>,
+    probe_fn: impl FnOnce(&rurico::embed::Artifacts) -> Result<rurico::embed::ProbeStatus, EmbedInitError>,
+    new_fn: impl FnOnce(&rurico::embed::Artifacts) -> Result<Embedder, EmbedInitError>,
+) -> Result<Arc<dyn Embed>, DegradedReason>
+where
+    CE: std::fmt::Display,
+    DE: std::fmt::Display,
+{
     use rurico::embed::ProbeStatus;
 
     fn probe_failed(e: &dyn std::fmt::Display) -> DegradedReason {
         record_embedder_warning(DegradedReason::ProbeFailed, &e.to_string());
         DegradedReason::ProbeFailed
+    }
+
+    fn delete_corrupt(paths: rurico::embed::Artifacts) {
+        if let Err(e) = paths.delete_files() {
+            tracing::warn!(error = %e, "failed to delete corrupt model files");
+        }
     }
 
     let paths = match cache_check() {
@@ -155,7 +181,7 @@ fn try_load_embedder_with<CE: std::fmt::Display, DE: std::fmt::Display>(
         Ok(None) => return Err(DegradedReason::NotInstalled),
         Err(e) => return Err(probe_failed(&e)),
     };
-    match Embedder::probe(&paths) {
+    match probe_fn(&paths) {
         Ok(ProbeStatus::Available) => {}
         Ok(ProbeStatus::BackendUnavailable) => {
             record_embedder_warning(
@@ -164,9 +190,13 @@ fn try_load_embedder_with<CE: std::fmt::Display, DE: std::fmt::Display>(
             );
             return Err(DegradedReason::BackendUnavailable);
         }
+        Err(e @ EmbedInitError::ModelCorrupt { .. }) => {
+            delete_corrupt(paths);
+            return Err(probe_failed(&e));
+        }
         Err(e) => return Err(probe_failed(&e)),
     }
-    let embedder = Embedder::new(&paths).map_err(|e| probe_failed(&e))?;
+    let embedder = new_fn(&paths).map_err(|e| probe_failed(&e))?;
     tracing::info!("Embedding model loaded successfully");
     Ok(Arc::new(embedder) as Arc<dyn Embed>)
 }

--- a/src/tools/embedder.rs
+++ b/src/tools/embedder.rs
@@ -140,8 +140,8 @@ fn try_load_embedder_with<CE: std::fmt::Display, DE: std::fmt::Display>(
         auto_download,
         cache_check,
         download_fn,
-        |a| Embedder::probe(a),
-        |a| Embedder::new(a),
+        Embedder::probe,
+        Embedder::new,
     )
 }
 
@@ -149,7 +149,9 @@ fn try_load_embedder_with_fns<CE, DE>(
     auto_download: bool,
     cache_check: impl FnOnce() -> Result<Option<rurico::embed::Artifacts>, CE>,
     download_fn: impl FnOnce() -> Result<rurico::embed::Artifacts, DE>,
-    probe_fn: impl FnOnce(&rurico::embed::Artifacts) -> Result<rurico::embed::ProbeStatus, EmbedInitError>,
+    probe_fn: impl FnOnce(
+        &rurico::embed::Artifacts,
+    ) -> Result<rurico::embed::ProbeStatus, EmbedInitError>,
     new_fn: impl FnOnce(&rurico::embed::Artifacts) -> Result<Embedder, EmbedInitError>,
 ) -> Result<Arc<dyn Embed>, DegradedReason>
 where


### PR DESCRIPTION
When `Embedder::probe` detects corrupt model files (`ModelCorrupt`), the corrupt cached files remained on disk. On the next run, `cached_artifacts` found them and skipped re-download, creating an infinite failure loop where the tool could never recover without manual cache cleanup.

## 変更内容

- `run_model_download` in `main.rs`: calls `paths.delete_files()` when probe returns `ModelCorrupt`, so the next run triggers a fresh download from the network
- `embedder.rs`: split `try_load_embedder_with` into a wrapper and `try_load_embedder_with_fns` (accepting `probe_fn`/`new_fn`) to enable unit testing; added `ModelCorrupt` match arm that deletes corrupt files before returning `ProbeFailed`
- `Cargo.toml`: bumped `rurico` rev to `03275f7`, which adds `VerifiedArtifacts::delete_files`; removed dev-only `[patch]` section

Depends on thkt/rurico#33.

Closes #61.