### PR TITLE
yomu search に --path フィルタを追加

### DIFF
--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -197,7 +197,7 @@ fn run_explorer(conn: &Arc<Mutex<yomu::storage::Db>>, embedder: &rurico::embed::
 
     for query in &queries {
         let start = Instant::now();
-        let results = yomu::query::search(Arc::clone(conn), embedder, query, 5, 0, None);
+        let results = yomu::query::search(Arc::clone(conn), embedder, query, 5, 0, None, &[]);
         let elapsed = start.elapsed();
 
         match results {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,9 @@ enum Command {
         /// Skip N results (default: 0)
         #[arg(long, default_value_t = 0, value_parser = clap::value_parser!(u32).range(0..=MAX_SEARCH_OFFSET as i64))]
         offset: u32,
+        /// Restrict search to files under this path prefix (repeatable)
+        #[arg(long)]
+        path: Vec<String>,
         /// Deprecated: use global --json instead
         #[arg(long, hide = true)]
         format: Option<String>,
@@ -136,6 +139,7 @@ fn main() -> ExitCode {
             query,
             limit,
             offset,
+            path,
             format,
         } => {
             if format.is_some() {
@@ -149,7 +153,7 @@ fn main() -> ExitCode {
                     return ExitCode::from(2);
                 }
             };
-            yomu.search(&query, limit, offset, json)
+            yomu.search(&query, limit, offset, &path, json)
         }
         Command::Index { dry_run } => {
             if dry_run {
@@ -364,6 +368,49 @@ mod tests {
         match cli.command.unwrap() {
             Command::Search { query, .. } => assert_eq!(query.as_deref(), Some("query")),
             other => panic!("[T-049] expected Search, got {other:?}"),
+        }
+    }
+
+    // T-076: --path parses into path vec
+    #[test]
+    fn search_path_filter_parses() {
+        let cli = parse_cli_args(["yomu", "search", "query", "--path", "src/fetcher/"]).unwrap();
+        match cli.command.unwrap() {
+            Command::Search { path, .. } => {
+                assert_eq!(path, vec!["src/fetcher/"]);
+            }
+            other => panic!("expected Search, got {other:?}"),
+        }
+    }
+
+    // T-076: multiple --path values
+    #[test]
+    fn search_multiple_path_filters_parse() {
+        let cli = parse_cli_args([
+            "yomu",
+            "search",
+            "query",
+            "--path",
+            "src/fetcher/",
+            "--path",
+            "src/client/",
+        ])
+        .unwrap();
+        match cli.command.unwrap() {
+            Command::Search { path, .. } => {
+                assert_eq!(path, vec!["src/fetcher/", "src/client/"]);
+            }
+            other => panic!("expected Search, got {other:?}"),
+        }
+    }
+
+    // T-076: --path absent → empty vec (full search)
+    #[test]
+    fn search_no_path_defaults_to_empty() {
+        let cli = parse_cli_args(["yomu", "search", "query"]).unwrap();
+        match cli.command.unwrap() {
+            Command::Search { path, .. } => assert!(path.is_empty()),
+            other => panic!("expected Search, got {other:?}"),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,7 @@ enum ModelCommand {
 }
 
 fn main() -> ExitCode {
-    rurico::embed::handle_probe_if_needed();
+    rurico::model_probe::handle_probe_if_needed();
 
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -310,6 +310,7 @@ fn search_pipeline(
     limit: u32,
     offset: u32,
     reranker: Option<&dyn Rerank>,
+    path_filter: &[String],
 ) -> Result<Vec<SearchResult>, StorageError> {
     let keywords = extract_keywords(query);
     let type_hints = extract_type_hints(query);
@@ -323,7 +324,7 @@ fn search_pipeline(
     };
     let use_semantic = query_embedding.is_some() && stats.embedded_chunks > 0;
     let mut results = match query_embedding {
-        Some(emb) if use_semantic => storage::vec_search(conn, emb, fetch_limit)?,
+        Some(emb) if use_semantic => storage::vec_search(conn, emb, fetch_limit, path_filter)?,
         _ => Vec::new(),
     };
 
@@ -345,6 +346,7 @@ fn search_pipeline(
             type_filter,
             &exclude_ids,
             fallback_limit,
+            path_filter,
         )?;
         results.extend(fts_results);
     }
@@ -390,6 +392,7 @@ pub fn search(
     limit: u32,
     offset: u32,
     reranker: Option<&dyn Rerank>,
+    path_filter: &[String],
 ) -> Result<SearchOutcome, QueryError> {
     let (query_embedding, degraded) = match embedder.embed_query(query) {
         Ok(emb) => (Some(emb), false),
@@ -407,6 +410,7 @@ pub fn search(
         limit,
         offset,
         reranker,
+        path_filter,
     )?;
     Ok(SearchOutcome { results, degraded })
 }

--- a/src/query/tests.rs
+++ b/src/query/tests.rs
@@ -38,7 +38,7 @@ fn search_with_mock_embedder() {
     .unwrap();
 
     let conn = Arc::new(Mutex::new(conn));
-    let outcome = search(conn, &MockEmbedder::default(), "button", 10, 0, None).unwrap();
+    let outcome = search(conn, &MockEmbedder::default(), "button", 10, 0, None, &[]).unwrap();
     assert!(!outcome.degraded);
     assert_eq!(outcome.results.len(), 1);
     assert_eq!(outcome.results[0].chunk.name.as_deref(), Some("Button"));
@@ -209,7 +209,7 @@ fn search_fallback_merges_vector_and_name_results() {
     .unwrap();
 
     let conn = Arc::new(Mutex::new(conn));
-    let results = search(conn, &MockEmbedder::default(), "auth", 5, 0, None)
+    let results = search(conn, &MockEmbedder::default(), "auth", 5, 0, None, &[])
         .unwrap()
         .results;
 
@@ -263,7 +263,7 @@ fn search_deduplicates_vector_and_name_results() {
     .unwrap();
 
     let conn = Arc::new(Mutex::new(conn));
-    let results = search(conn, &MockEmbedder::default(), "auth", 5, 0, None)
+    let results = search(conn, &MockEmbedder::default(), "auth", 5, 0, None, &[])
         .unwrap()
         .results;
 
@@ -628,7 +628,7 @@ fn search_returns_results_sorted_by_score() {
     .unwrap();
 
     let conn = Arc::new(Mutex::new(conn));
-    let results = search(conn, &MockEmbedder::default(), "auth hook", 5, 0, None)
+    let results = search(conn, &MockEmbedder::default(), "auth hook", 5, 0, None, &[])
         .unwrap()
         .results;
 
@@ -839,6 +839,7 @@ fn search_degrades_on_embed_failure() {
         10,
         0,
         None,
+        &[],
     )
     .unwrap();
     assert!(outcome.degraded, "should be degraded when embed fails");
@@ -862,7 +863,7 @@ fn search_degrades_on_model_not_available() {
     let conn = storage::open_db(&db_path).unwrap();
     let conn = Arc::new(Mutex::new(conn));
 
-    let outcome = search(conn, &embedder, "test", 10, 0, None).unwrap();
+    let outcome = search(conn, &embedder, "test", 10, 0, None, &[]).unwrap();
     assert!(
         outcome.degraded,
         "should degrade to FTS5 when model not available"
@@ -979,6 +980,7 @@ fn t001_reranker_reorders_results_by_cross_encoder_score() {
         5,
         0,
         Some(&reranker),
+        &[],
     )
     .unwrap();
 
@@ -1031,11 +1033,12 @@ fn t002_no_reranker_produces_rrf_results() {
         5,
         0,
         None,
+        &[],
     )
     .unwrap();
 
     // Also call the existing (no reranker param) signature for reference
-    let outcome_existing = search(conn, &MockEmbedder::default(), "auth", 5, 0, None).unwrap();
+    let outcome_existing = search(conn, &MockEmbedder::default(), "auth", 5, 0, None, &[]).unwrap();
 
     assert_eq!(
         outcome.results.len(),
@@ -1104,6 +1107,7 @@ fn t006_reranker_increases_fetch_limit() {
         limit,
         offset,
         Some(&reranker),
+        &[],
     )
     .unwrap();
 
@@ -1198,6 +1202,7 @@ fn t007_reranker_scores_applied_before_cap_per_file() {
         10,
         0,
         Some(&reranker),
+        &[],
     )
     .unwrap();
 
@@ -1264,7 +1269,7 @@ fn search_returns_results() {
     .unwrap();
 
     let conn = Arc::new(Mutex::new(conn));
-    let outcome = search(conn, &embedder, "button", 10, 0, None).unwrap();
+    let outcome = search(conn, &embedder, "button", 10, 0, None, &[]).unwrap();
     assert!(!outcome.results.is_empty(), "expected at least one result");
 }
 
@@ -1292,7 +1297,7 @@ fn search_pipeline_text_only_returns_name_matches() {
     )
     .unwrap();
 
-    let results = search_pipeline(&conn, "auth", None, 10, 0, None).unwrap();
+    let results = search_pipeline(&conn, "auth", None, 10, 0, None, &[]).unwrap();
     assert!(
         !results.is_empty(),
         "text-only pipeline should find name matches"
@@ -1325,7 +1330,7 @@ fn search_pipeline_with_embedding_returns_semantic() {
     )
     .unwrap();
 
-    let results = search_pipeline(&conn, "button", Some(&emb), 10, 0, None).unwrap();
+    let results = search_pipeline(&conn, "button", Some(&emb), 10, 0, None, &[]).unwrap();
     assert!(!results.is_empty());
     assert_eq!(results[0].match_source, storage::MatchSource::Semantic);
 }
@@ -1348,7 +1353,7 @@ fn search_pipeline_caps_per_file() {
         .collect();
     storage::replace_file_chunks_only(&conn, "src/big.ts", &chunks, "h1", "", &[], None).unwrap();
 
-    let results = search_pipeline(&conn, "fn", None, 10, 0, None).unwrap();
+    let results = search_pipeline(&conn, "fn", None, 10, 0, None, &[]).unwrap();
     let file_count = results
         .iter()
         .filter(|r| r.chunk.file_path == "src/big.ts")
@@ -1410,6 +1415,7 @@ fn text_only_search_with_offset_returns_results() {
         3,
         10,
         None,
+        &[],
     )
     .unwrap();
     assert!(
@@ -1446,7 +1452,7 @@ fn search_chunk_only_index_with_embedder_falls_back_to_text() {
     assert_eq!(stats.embedded_chunks, 0, "no embeddings should exist");
 
     let conn = Arc::new(Mutex::new(conn));
-    let outcome = search(conn, &MockEmbedder::default(), "button", 10, 0, None).unwrap();
+    let outcome = search(conn, &MockEmbedder::default(), "button", 10, 0, None, &[]).unwrap();
     assert!(
         !outcome.results.is_empty(),
         "should return text/name fallback results even with zero embeddings"

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -4,7 +4,7 @@ use rusqlite::Connection;
 
 use super::{
     Chunk, ChunkType, MatchSource, SearchResult, StorageError, anon_placeholders, as_sql_params,
-    f32_as_bytes, in_placeholders,
+    f32_as_bytes,
 };
 
 fn chunk_from_row(row: &rusqlite::Row<'_>, offset: usize) -> rusqlite::Result<Chunk> {
@@ -25,6 +25,7 @@ pub fn vec_search(
     conn: &Connection,
     query_embedding: &[f32],
     limit: u32,
+    path_filter: &[String],
 ) -> Result<Vec<SearchResult>, StorageError> {
     let query_bytes = f32_as_bytes(query_embedding);
     let k = limit.saturating_mul(VEC_MAXSIM_OVERSAMPLE);
@@ -62,15 +63,21 @@ pub fn vec_search(
 
     // Batch-fetch chunk metadata for deduplicated chunk_ids.
     let chunk_ids: Vec<i64> = best.keys().copied().collect();
-    let sql = format!(
+    let mut sql = format!(
         "SELECT id, file_path, chunk_type, name, content, start_line, end_line, parent_chunk_id \
          FROM chunks WHERE id IN ({})",
-        in_placeholders(chunk_ids.len())
+        anon_placeholders(chunk_ids.len())
     );
-    let params = as_sql_params(&chunk_ids);
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = chunk_ids
+        .iter()
+        .map(|id| Box::new(*id) as Box<dyn rusqlite::types::ToSql>)
+        .collect();
+    append_path_filter(&mut sql, &mut params, "file_path", path_filter);
+
     let mut stmt2 = conn.prepare(&sql)?;
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|b| b.as_ref()).collect();
     let meta: HashMap<i64, Chunk> = stmt2
-        .query_map(params.as_slice(), |row| {
+        .query_map(param_refs.as_slice(), |row| {
             Ok((
                 row.get::<_, i64>(0)?,
                 Chunk {
@@ -110,6 +117,7 @@ pub fn search_by_fts(
     type_filter: Option<&[ChunkType]>,
     exclude_ids: &HashSet<i64>,
     limit: u32,
+    path_filter: &[String],
 ) -> Result<Vec<SearchResult>, StorageError> {
     if keywords.is_empty() {
         return Ok(Vec::new());
@@ -144,6 +152,7 @@ pub fn search_by_fts(
 
     append_type_filter(&mut sql, &mut params, "c.chunk_type", type_filter);
     append_exclude_ids(&mut sql, &mut params, "c.id", exclude_ids);
+    append_path_filter(&mut sql, &mut params, "c.file_path", path_filter);
     sql.push_str(&format!(" ORDER BY {BM25_EXPR} LIMIT ?"));
     params.push(Box::new(limit));
 
@@ -257,5 +266,30 @@ fn append_exclude_ids(
         for id in exclude_ids {
             params.push(Box::new(*id));
         }
+    }
+}
+
+fn escape_like(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
+fn append_path_filter(
+    sql: &mut String,
+    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
+    column: &str,
+    paths: &[String],
+) {
+    if paths.is_empty() {
+        return;
+    }
+    let conditions: Vec<String> = paths
+        .iter()
+        .map(|_| format!("{column} LIKE ? ESCAPE '\\'"))
+        .collect();
+    sql.push_str(&format!(" AND ({})", conditions.join(" OR ")));
+    for path in paths {
+        params.push(Box::new(format!("{}%", escape_like(path))));
     }
 }

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -383,7 +383,7 @@ fn vec_search_returns_ordered_results() {
     )
     .unwrap();
 
-    let results = vec_search(&conn, &emb_a, 10).unwrap();
+    let results = vec_search(&conn, &emb_a, 10, &[]).unwrap();
     assert_eq!(results.len(), 2);
     assert_eq!(results[0].chunk.name.as_deref(), Some("A"));
     assert!(results[0].distance <= results[1].distance);
@@ -1319,7 +1319,7 @@ fn vec_search_sets_semantic_match_source() {
     )
     .unwrap();
 
-    let results = vec_search(&conn, &emb, 10).unwrap();
+    let results = vec_search(&conn, &emb, 10, &[]).unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].match_source, MatchSource::Semantic);
 }
@@ -1347,7 +1347,7 @@ fn vec_search_sets_initial_score() {
     )
     .unwrap();
 
-    let results = vec_search(&conn, &emb, 10).unwrap();
+    let results = vec_search(&conn, &emb, 10, &[]).unwrap();
     assert_eq!(results.len(), 1);
 
     // score should be initialized to 1.0 / (1.0 + distance)
@@ -1466,14 +1466,14 @@ fn fts_chunks_deleted_with_file() {
     replace_file_chunks_only(&conn, "src/x.tsx", &chunks, "h1", "", &[], None).unwrap();
 
     // Should find it before delete
-    let results = search_by_fts(&conn, &["state"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["state"], None, &HashSet::new(), 10, &[]).unwrap();
     assert_eq!(results.len(), 1);
 
     // Delete file chunks
     delete_file_chunks(&conn, "src/x.tsx").unwrap();
 
     // Should not find it after delete
-    let results = search_by_fts(&conn, &["state"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["state"], None, &HashSet::new(), 10, &[]).unwrap();
     assert!(results.is_empty());
 }
 
@@ -1503,7 +1503,7 @@ fn fts5_migration_from_v2() {
     .unwrap();
 
     // Verify FTS5 is empty
-    let results = search_by_fts(&conn, &["loading"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["loading"], None, &HashSet::new(), 10, &[]).unwrap();
     assert!(
         results.is_empty(),
         "fts_chunks should be empty before migration"
@@ -1514,7 +1514,7 @@ fn fts5_migration_from_v2() {
     let conn = open_db(&db_path).unwrap();
 
     // Migration should have populated fts_chunks from existing chunks
-    let results = search_by_fts(&conn, &["loading"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["loading"], None, &HashSet::new(), 10, &[]).unwrap();
     assert_eq!(results.len(), 1, "migration should populate fts_chunks");
     assert_eq!(results[0].chunk.name.as_deref(), Some("useX"));
 }
@@ -1533,7 +1533,7 @@ fn fts5_handles_special_characters_in_content() {
     }];
     replace_file_chunks_only(&conn, "src/App.tsx", &chunks, "h1", "", &[], None).unwrap();
 
-    let results = search_by_fts(&conn, &["container"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["container"], None, &HashSet::new(), 10, &[]).unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].chunk.name.as_deref(), Some("App"));
 }
@@ -1694,7 +1694,7 @@ fn migration_v3_to_v4_creates_vocab_table() {
     );
 
     // Verify data preserved: chunk should still be searchable
-    let results = search_by_fts(&conn, &["migrationTest"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["migrationTest"], None, &HashSet::new(), 10, &[]).unwrap();
     assert!(
         !results.is_empty(),
         "seeded chunk should survive v3->v4 migration"
@@ -1833,7 +1833,7 @@ fn fts_automerge_guard_restores_on_drop() {
         None,
     )
     .unwrap();
-    let results = search_by_fts(&conn, &["function"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["function"], None, &HashSet::new(), 10, &[]).unwrap();
     assert!(
         results.len() >= 2,
         "FTS should work after guard drop, got {} results",
@@ -2214,7 +2214,7 @@ fn t_011_chunk_from_row_reads_parent_chunk_id() {
         )
         .unwrap();
 
-    let results = search_by_fts(&conn, &["handlesubmit"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["handlesubmit"], None, &HashSet::new(), 10, &[]).unwrap();
 
     assert!(
         !results.is_empty(),
@@ -2272,7 +2272,7 @@ fn t_011_chunk_from_row_reads_parent_chunk_id_name_search() {
         )
         .unwrap();
 
-    let results = search_by_fts(&conn, &["handlesubmit"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["handlesubmit"], None, &HashSet::new(), 10, &[]).unwrap();
 
     assert!(
         !results.is_empty(),
@@ -2314,7 +2314,7 @@ fn t_012_parent_chunk_search_result_has_no_parent_chunk_id() {
     )
     .unwrap();
 
-    let results = search_by_fts(&conn, &["userform"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["userform"], None, &HashSet::new(), 10, &[]).unwrap();
 
     assert!(!results.is_empty(), "should find UserForm via name search");
     let component_result = &results[0];
@@ -2454,7 +2454,7 @@ fn t_014_migration_v6_to_v7_preserves_fts_search() {
         "[T-014] schema_version should be 8 after migration"
     );
 
-    let results = search_by_fts(&conn, &["transform"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["transform"], None, &HashSet::new(), 10, &[]).unwrap();
     assert_eq!(
         results.len(),
         1,
@@ -2534,7 +2534,8 @@ fn t_004_search_by_fts_finds_camelcase_by_split_keywords() {
     replace_file_chunks_only(&conn, "src/form.tsx", &chunks, "h1", "", &[], None).unwrap();
 
     // Search with split keywords ["handle", "submit"] should find handleSubmit
-    let results = search_by_fts(&conn, &["handle", "submit"], None, &HashSet::new(), 10).unwrap();
+    let results =
+        search_by_fts(&conn, &["handle", "submit"], None, &HashSet::new(), 10, &[]).unwrap();
     let names: Vec<_> = results
         .iter()
         .filter_map(|r| r.chunk.name.as_deref())
@@ -2580,7 +2581,7 @@ fn t_005_search_by_fts_finds_by_path_segment() {
     }];
     replace_file_chunks_only(&conn, "src/auth/login.ts", &chunks, "h1", "", &[], None).unwrap();
 
-    let results = search_by_fts(&conn, &["auth"], None, &HashSet::new(), 10).unwrap();
+    let results = search_by_fts(&conn, &["auth"], None, &HashSet::new(), 10, &[]).unwrap();
     assert_eq!(
         results.len(),
         1,
@@ -2619,6 +2620,7 @@ fn t_007_search_by_fts_respects_type_filter() {
         Some(&[ChunkType::Hook]),
         &HashSet::new(),
         10,
+        &[],
     )
     .unwrap();
     assert_eq!(
@@ -2653,13 +2655,13 @@ fn t_016_search_by_fts_excludes_ids() {
     ];
     replace_file_chunks_only(&conn, "src/auth.tsx", &chunks, "h1", "", &[], None).unwrap();
 
-    let all = search_by_fts(&conn, &["auth"], None, &HashSet::new(), 10).unwrap();
+    let all = search_by_fts(&conn, &["auth"], None, &HashSet::new(), 10, &[]).unwrap();
     assert_eq!(all.len(), 2);
 
     let first_id = all[0].chunk_id.unwrap();
     let mut exclude = HashSet::new();
     exclude.insert(first_id);
-    let filtered = search_by_fts(&conn, &["auth"], None, &exclude, 10).unwrap();
+    let filtered = search_by_fts(&conn, &["auth"], None, &exclude, 10, &[]).unwrap();
     assert_eq!(
         filtered.len(),
         1,

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -126,6 +126,7 @@ impl Yomu {
         query: &str,
         limit: u32,
         offset: u32,
+        paths: &[String],
         json: bool,
     ) -> Result<String, YomuError> {
         if query.is_empty() {
@@ -137,11 +138,15 @@ impl Yomu {
             )));
         }
 
+        for path in paths {
+            validate_path(path)?;
+        }
+
         let embedder = self.get_embedder();
         let limit = limit.min(MAX_SEARCH_LIMIT);
         let offset = offset.min(MAX_SEARCH_OFFSET);
 
-        tracing::debug!(query, limit, offset, "search request");
+        tracing::debug!(query, limit, offset, ?paths, "search request");
 
         let type_hints = query::extract_type_hints(query);
         let hints_ref = if type_hints.is_empty() {
@@ -161,6 +166,7 @@ impl Yomu {
             limit,
             offset,
             self.get_reranker(),
+            paths,
         )?;
 
         let mut notes: Vec<String> = Vec::new();
@@ -286,11 +292,7 @@ impl Yomu {
 
         let (file_path, parsed_symbol) = parse_impact_target(target);
 
-        if file_path.contains("..") || std::path::Path::new(file_path).is_absolute() {
-            return Err(YomuError::InvalidInput(
-                "target path must be relative and must not contain '..'".into(),
-            ));
-        }
+        validate_path(file_path)?;
 
         let symbol_filter = symbol.or(parsed_symbol);
         let max_depth = depth.min(MAX_IMPACT_DEPTH);
@@ -488,6 +490,15 @@ impl Yomu {
         let conn = self.conn.lock().unwrap();
         f(&conn).map_err(YomuError::from)
     }
+}
+
+fn validate_path(path: &str) -> Result<(), YomuError> {
+    if path.contains("..") || std::path::Path::new(path).is_absolute() {
+        return Err(YomuError::InvalidInput(format!(
+            "'{path}' must be a relative path and must not contain '..'"
+        )));
+    }
+    Ok(())
 }
 
 fn parse_impact_target(target: &str) -> (&str, Option<&str>) {

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -81,7 +81,7 @@ fn seed_index(conn: &storage::Db) {
 #[test]
 fn search_rejects_empty_query() {
     let (y, _dir) = test_yomu();
-    let err = y.search("", 10, 0, false).unwrap_err();
+    let err = y.search("", 10, 0, &[], false).unwrap_err();
     assert!(
         err.to_string().contains("empty"),
         "expected empty error, got: {}",
@@ -93,7 +93,7 @@ fn search_rejects_empty_query() {
 fn search_rejects_long_query() {
     let (y, _dir) = test_yomu();
     let long_query = "a".repeat(MAX_QUERY_LENGTH + 1);
-    let err = y.search(&long_query, 10, 0, false).unwrap_err();
+    let err = y.search(&long_query, 10, 0, &[], false).unwrap_err();
     assert!(
         err.to_string().contains("maximum length"),
         "expected max length error, got: {}",
@@ -102,9 +102,56 @@ fn search_rejects_long_query() {
 }
 
 #[test]
+fn search_rejects_path_traversal() {
+    let (y, _dir) = test_yomu();
+    let err = y
+        .search("query", 10, 0, &["../etc".to_string()], false)
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("must be a relative path"),
+        "expected traversal error, got: {err}"
+    );
+}
+
+#[test]
+fn search_rejects_absolute_path() {
+    let (y, _dir) = test_yomu();
+    let err = y
+        .search("query", 10, 0, &["/etc".to_string()], false)
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("must be a relative path"),
+        "expected relative path error, got: {err}"
+    );
+}
+
+#[test]
+fn search_path_filter_excludes_other_dirs() {
+    let (y, _dir) = test_yomu_with_files_and_embedder(
+        &[
+            ("src/fetcher/index.ts", "export function fetchData() {}"),
+            ("src/storage/db.ts", "export function openDb() {}"),
+        ],
+        Arc::new(rurico::embed::MockEmbedder::default()),
+    );
+
+    let text = y
+        .search("open", 10, 0, &["src/storage/".to_string()], false)
+        .unwrap();
+    assert!(
+        text.contains("db.ts") || text.contains("openDb") || text.contains("No results"),
+        "unexpected result: {text}"
+    );
+    assert!(
+        !text.contains("fetchData"),
+        "fetcher should be excluded: {text}"
+    );
+}
+
+#[test]
 fn search_without_embedder_degrades_gracefully() {
     let (y, _dir) = test_yomu();
-    let text = y.search("test query", 10, 0, false).unwrap();
+    let text = y.search("test query", 10, 0, &[], false).unwrap();
     assert!(
         text.contains("No results found"),
         "expected no results: {text}"
@@ -118,7 +165,7 @@ fn search_auto_indexes_empty_db() {
         Arc::new(rurico::embed::MockEmbedder::default()),
     );
 
-    let text = y.search("button component", 10, 0, false).unwrap();
+    let text = y.search("button component", 10, 0, &[], false).unwrap();
     assert!(
         !text.contains("No results found"),
         "expected results after auto-index, got: {text}"
@@ -155,7 +202,7 @@ fn search_incremental_embeds_chunked_only() {
         assert_eq!(stats.embedded_chunks, 0, "should have no embeddings yet");
     }
 
-    let text = y.search("form component", 10, 0, false).unwrap();
+    let text = y.search("form component", 10, 0, &[], false).unwrap();
     assert!(text.contains("Form"), "expected Form in results: {text}");
 
     {
@@ -232,7 +279,7 @@ fn search_degraded_empty_results_shows_note() {
             as Arc<dyn rurico::embed::Embed>),
     );
 
-    let text = y.search("zzzznonexistent", 10, 0, false).unwrap();
+    let text = y.search("zzzznonexistent", 10, 0, &[], false).unwrap();
     assert!(
         text.contains("No results found"),
         "expected no results: {text}"
@@ -270,7 +317,7 @@ fn search_degraded_with_results_shows_note() {
             as Arc<dyn rurico::embed::Embed>),
     );
 
-    let result = y_failing.search("Button", 10, 0, false).unwrap();
+    let result = y_failing.search("Button", 10, 0, &[], false).unwrap();
     assert!(result.contains("Button"), "should have search results");
     assert!(
         result.contains("embedding model not loaded"),
@@ -1075,7 +1122,7 @@ fn ensure_indexed_partially_embedded_triggers_embed() {
         "should have no embeddings yet"
     );
 
-    let result = y.search("App component", 10, 0, false).unwrap();
+    let result = y.search("App component", 10, 0, &[], false).unwrap();
     assert!(
         result.contains("App"),
         "should find App after embedding: {result}"
@@ -1118,7 +1165,7 @@ fn ensure_indexed_fully_embedded_skips_embed() {
         "should be fully embedded"
     );
 
-    let result = y.search("Button", 10, 0, false).unwrap();
+    let result = y.search("Button", 10, 0, &[], false).unwrap();
     assert!(result.contains("Button"), "should find Button: {result}");
 }
 
@@ -1146,7 +1193,7 @@ fn ensure_indexed_fully_embedded_with_failing_embedder() {
             as Arc<dyn rurico::embed::Embed>),
     );
 
-    let result = y_failing.search("Card", 10, 0, false).unwrap();
+    let result = y_failing.search("Card", 10, 0, &[], false).unwrap();
     assert!(
         result.contains("Card"),
         "should find Card with existing embeddings: {result}"
@@ -1181,7 +1228,7 @@ fn search_without_embedder_skips_embed_attempt() {
         assert_eq!(stats.embedded_chunks, 0, "should have no embeddings");
     }
 
-    let text = y.search("card", 10, 0, false).unwrap();
+    let text = y.search("card", 10, 0, &[], false).unwrap();
     assert!(
         !text.contains("embedding failed"),
         "should not attempt embed when embedder unavailable: {text}"
@@ -1196,7 +1243,7 @@ fn search_json_format_returns_valid_json() {
     )]);
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
 
-    let json = y.search("button", 10, 0, true).unwrap();
+    let json = y.search("button", 10, 0, &[], true).unwrap();
     let parsed = parse_json(&json);
     assert!(
         parsed["results"].is_array(),
@@ -1223,7 +1270,7 @@ fn search_json_format_empty_results() {
         test_yomu_with_files(&[("src/A.tsx", "export function A() { return <div/>; }")]);
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
 
-    let json = y.search("zzzznonexistent", 10, 0, true).unwrap();
+    let json = y.search("zzzznonexistent", 10, 0, &[], true).unwrap();
     let parsed = parse_json(&json);
     assert!(
         parsed["results"].as_array().unwrap().is_empty(),
@@ -1290,7 +1337,7 @@ fn search_json_format_degraded_includes_flag() {
     );
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
 
-    let json = y.search("card", 10, 0, true).unwrap();
+    let json = y.search("card", 10, 0, &[], true).unwrap();
     let parsed = parse_json(&json);
     assert_eq!(
         parsed["degraded"], true,
@@ -1459,7 +1506,7 @@ fn t_ac5_subchunk_innerfn_is_hit_at_1_for_inner_function_query() {
 
     y.index(false).unwrap();
 
-    let result = y.search("handleSubmit", 10, 0, false).unwrap();
+    let result = y.search("handleSubmit", 10, 0, &[], false).unwrap();
     assert!(
         result.contains("handleSubmit"),
         "[AC-5] search should find handleSubmit: {result}"
@@ -1600,7 +1647,7 @@ fn t001_search_with_not_installed_shows_note() {
     let y = Yomu::for_test(conn, dir.path().to_path_buf(), None);
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
 
-    let text = y.search("button", 10, 0, false).unwrap();
+    let text = y.search("button", 10, 0, &[], false).unwrap();
     assert!(
         text.contains("not installed"),
         "[T-001] expected NotInstalled note in results: {text}"
@@ -1619,7 +1666,7 @@ fn t002_search_with_ok_embedder_no_degraded_note() {
         Some(Arc::new(rurico::embed::MockEmbedder::default()) as Arc<dyn rurico::embed::Embed>),
     );
 
-    let text = y.search("button component", 10, 0, false).unwrap();
+    let text = y.search("button component", 10, 0, &[], false).unwrap();
     assert!(
         !text.contains("not installed"),
         "[T-002] should have no 'not installed' note: {text}"
@@ -1643,7 +1690,7 @@ fn t003_search_with_backend_unavailable_shows_note() {
     );
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
 
-    let text = y.search("button", 10, 0, false).unwrap();
+    let text = y.search("button", 10, 0, &[], false).unwrap();
     assert!(
         text.contains("unavailable"),
         "[T-003] expected BackendUnavailable note in results: {text}"
@@ -1663,7 +1710,7 @@ fn t004_search_with_probe_failed_shows_note() {
     );
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
 
-    let text = y.search("button", 10, 0, false).unwrap();
+    let text = y.search("button", 10, 0, &[], false).unwrap();
     assert!(
         text.contains("unavailable"),
         "[T-004] expected ProbeFailed note in results: {text}"
@@ -1695,7 +1742,7 @@ fn t009_disabled_no_user_note_in_search() {
     );
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
 
-    let text = y.search("button", 10, 0, false).unwrap();
+    let text = y.search("button", 10, 0, &[], false).unwrap();
     assert!(
         !text.contains("not installed"),
         "[T-009] should not show 'not installed' when disabled: {text}"
@@ -1746,7 +1793,7 @@ fn json_notes_present_when_degraded() {
     let y = Yomu::for_test(conn, dir.path().to_path_buf(), None);
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
 
-    let json = y.search("card", 10, 0, true).unwrap();
+    let json = y.search("card", 10, 0, &[], true).unwrap();
     let parsed = parse_json(&json);
     assert_eq!(parsed["degraded"], true);
     let notes = parsed["notes"]
@@ -1772,7 +1819,7 @@ fn json_notes_empty_via_search_with_ok_embedder() {
         Some(Arc::new(rurico::embed::MockEmbedder::default()) as Arc<dyn rurico::embed::Embed>),
     );
 
-    let json = y.search("nav", 10, 0, true).unwrap();
+    let json = y.search("nav", 10, 0, &[], true).unwrap();
     let parsed = parse_json(&json);
     assert_eq!(parsed["degraded"], false, "should not be degraded: {json}");
     let notes = parsed["notes"]
@@ -1792,7 +1839,7 @@ fn json_notes_outcome_degraded_fallback() {
     );
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
 
-    let json = y.search("card", 10, 0, true).unwrap();
+    let json = y.search("card", 10, 0, &[], true).unwrap();
     let parsed = parse_json(&json);
     assert_eq!(parsed["degraded"], true);
     let notes = parsed["notes"]
@@ -1821,7 +1868,7 @@ fn json_notes_backend_unavailable() {
     );
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
 
-    let json = y.search("button", 10, 0, true).unwrap();
+    let json = y.search("button", 10, 0, &[], true).unwrap();
     let parsed = parse_json(&json);
     assert_eq!(parsed["degraded"], true);
     let notes = parsed["notes"]


### PR DESCRIPTION
## 概要

`yomu search` に `--path` フィルターを追加し、検索結果を特定のディレクトリ・ファイルプレフィックスに絞り込めるようにする。大規模リポジトリで無関係なファイルのノイズを除外するために必要。

## 変更内容

- `src/main.rs`: `--path Vec<String>` CLI 引数を追加。3件の CLI パース用テスト追加
- `src/storage/search.rs`: `append_path_filter` ヘルパーで LIKE エスケープ処理を実装。`vec_search` で SQL レベルのパスフィルタリング、`search_by_fts` にもパスフィルター適用
- `src/tools/mod.rs`: `validate_path` を `impact` のインラインチェックから抽出して共有（DRY）。`search()` が `paths` 引数を受け取るよう更新
- `src/query/mod.rs`: `search_pipeline` / `search` を通じて `path_filter` を伝搬
- `src/tools/tests.rs`: パストラバーサル・絶対パス・フィルター除外の3件の新規テスト追加

## 設計判断

- **SQL レベルのフィルタリング**: `vec_search` では Rust の `retain` ではなく SQL の WHERE 句でフィルタリング。未使用コンテンツのロードを回避
- **LIKE エスケープ**: `_` と `%` を `escape_like` でエスケープし `ESCAPE '\\'` 句を使用。リテラルプレフィックスマッチを保証
- **末尾スラッシュの正規化なし**: 生のプレフィックスマッチ。ディレクトリスコープにするかどうかはユーザーが `/` の有無で制御

## テスト手順

- [ ] `yomu search "query" --path src/tools` → `src/tools/` 配下のファイルのみヒット
- [ ] `yomu search "query" --path src/tools --path src/query` → 両方のパス配下の結果
- [ ] `yomu search "query" --path ../outside` → パストラバーサルエラー
- [ ] `yomu search "query" --path /abs/path` → 絶対パスエラー
- [ ] マッチしないパス（`--path nonexistent/`）→ 結果0件

Closes #76