### PR TITLE
Spinner に set_message() を追加して sae との実装を揃える

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,6 +1,6 @@
 use std::io::{IsTerminal, Write};
 use std::sync::{
-    Arc,
+    Arc, Mutex,
     atomic::{AtomicBool, Ordering},
 };
 use std::thread;
@@ -11,16 +11,18 @@ const TICK_MS: u64 = 80;
 
 pub struct Spinner {
     done: Arc<AtomicBool>,
+    message: Arc<Mutex<String>>,
     thread: Option<thread::JoinHandle<()>>,
 }
 
 impl Spinner {
     pub fn new(msg: &str) -> Self {
         let done = Arc::new(AtomicBool::new(false));
+        let message = Arc::new(Mutex::new(msg.to_string()));
 
         let thread = if std::io::stderr().is_terminal() {
             let done = Arc::clone(&done);
-            let msg = msg.to_string();
+            let message = Arc::clone(&message);
             Some(thread::spawn(move || {
                 let mut err = std::io::stderr();
                 let mut i = 0;
@@ -28,6 +30,7 @@ impl Spinner {
                     if done.load(Ordering::Relaxed) {
                         break;
                     }
+                    let msg = message.lock().map(|m| m.clone()).unwrap_or_default();
                     let _ = write!(err, "\r\x1b[2K{} {}", FRAMES[i % FRAMES.len()], msg);
                     let _ = err.flush();
                     thread::sleep(Duration::from_millis(TICK_MS));
@@ -39,11 +42,23 @@ impl Spinner {
             None
         };
 
-        Self { done, thread }
+        Self {
+            done,
+            message,
+            thread,
+        }
+    }
+
+    pub fn set_message(&self, msg: &str) {
+        if let Ok(mut m) = self.message.lock() {
+            *m = msg.to_string();
+        }
     }
 
     pub fn finish(self, msg: &str) {
         let is_tty = self.thread.is_some();
+        // Drop first: signals the thread to stop and clears the spinner line via Drop::drop.
+        // The eprintln! must come after, or the success message would be overwritten.
         drop(self);
         if is_tty {
             eprintln!("\x1b[32m✓\x1b[0m {msg}");
@@ -65,5 +80,29 @@ impl Drop for Spinner {
             eprint!("\r\x1b[2K");
             let _ = std::io::stderr().flush();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spinner_set_message_updates_without_panic() {
+        let spinner = Spinner::new("initial");
+        spinner.set_message("updated");
+        let msg = spinner.message.lock().unwrap().clone();
+        assert_eq!(msg, "updated");
+        spinner.cancel();
+    }
+
+    #[test]
+    fn spinner_set_message_multiple_times() {
+        let spinner = Spinner::new("first");
+        spinner.set_message("second");
+        spinner.set_message("third");
+        let msg = spinner.message.lock().unwrap().clone();
+        assert_eq!(msg, "third");
+        spinner.cancel();
     }
 }


### PR DESCRIPTION
## 概要

amici（共通crate）への `Spinner` 抽出前準備として、yomuの `Spinner` に `set_message()` を追加し、sae側の実装と完全parityを実現する。

## 変更内容

`src/progress.rs` のみ変更。

- `message: Arc<Mutex<String>>` フィールドを追加（closure固定キャプチャから置き換え）
- tick loop内で毎フレーム `message.lock()` を参照するよう変更
- `pub fn set_message(&self, msg: &str)` を追加（mutex poison時はsilently skip）
- `finish()` に `drop(self)` 順序のコメントを追加（Drop内でのライン消去が先、`eprintln!` が後でないと成功メッセージが上書きされる）
- 単体テスト2本追加

## 設計判断

**parity 優先**
per-tickのlock+clone（80ms毎）はsaeと意図的に同一。効率面ではArcを外す手もあるが、saeとdivergeさせるとamici抽出時のdiffが増えるためスキップ。

**`pub` 維持**
yomuは外部公開バイナリのため `pub(crate)` ではなく `pub` を維持。saeと同一。

**テストの private アクセス**
テストは `use super::*` で `message` フィールドへ直接アクセス。saeと同じパターン。

## テスト手順

```bash
cargo test -p yomu progress::tests
```

2件のテストがpassすることを確認:

- `spinner_set_message_updates_without_panic`
- `spinner_set_message_multiple_times`

Closes #73
