### PR TITLE
`StorageError::Sqlite` バリアントを `Db` に rename（amici 抽出前準備）

### DIFF
--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -115,8 +115,8 @@ pub struct SearchResult {
 
 #[derive(Debug, thiserror::Error)]
 pub enum StorageError {
-    #[error("SQLite error: {0}")]
-    Sqlite(#[from] rusqlite::Error),
+    #[error("Database error: {0}")]
+    Db(#[from] rusqlite::Error),
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
     #[error("chunks/embeddings length mismatch: {chunks} chunks vs {embeddings} embeddings")]


### PR DESCRIPTION
## 概要

`StorageError::Sqlite` バリアントを `Db` にrenameする。#83（#73）に続くsae parity / amici抽出前準備シリーズの一環。

## 変更内容

`src/storage/types.rs` の定義1箇所のみ。

```rust
// Before
#[error("SQLite error: {0}")]
Sqlite(#[from] rusqlite::Error),

// After
#[error("Database error: {0}")]
Db(#[from] rusqlite::Error),
```

`StorageError::Sqlite` を明示的に参照する箇所（パターンマッチ・直接構築）はsrc全域でゼロ。すべて `#[from]` 経由の自動変換のみのため、renameの影響は定義1箇所で完結する。

## 設計判断

- saeはすでに `Db` を使用しており、このrenameでyomuとsaeの `StorageError` 定義が完全parityになる
- ゴールはamici（shared crate）への共通コード抽出。saeとyomuのdiffをゼロにしてから切り出す
- `Sqlite` は実装の詳細（rusqlite）が名前に漏れている。`Db` の方がドメイン的に正しい

## 破壊的変更について

yomuは `StorageError` を `src/lib.rs` 経由で外部公開しているため、`Sqlite` → `Db` renameはSemVer breaking changeになる。intentionalと判断した根拠は以下。

- yomuをlibクレートとして外部から使っているdownstream cratesは想定されていない
- amici抽出時にどのみちbreaking changeが発生する
- 今 `Db` に統一しておくほうが、後で一括変更するより安全

## テスト手順

```bash
cargo test -p yomu
```

全394テストpass済み。バリアント名のrenameのみで新しい振る舞いは導入しないため、新規テストは追加しない。

Closes #74
