### PR TITLE
埋め込みコンテキストにシンボル名と親ヘッダーを追加

### DIFF
--- a/src/indexer/chunker/rust.rs
+++ b/src/indexer/chunker/rust.rs
@@ -29,6 +29,14 @@ pub(super) fn chunk_rust(source: &str) -> FileChunks {
             "line_comment" | "block_comment" => {
                 pending_comments.push(node);
             }
+            "impl_item" => {
+                let impl_index = chunks.len();
+                let name = extract_rust_impl_name(&node, source);
+                let mut impl_chunk = make_chunk(source, &node, ChunkType::RustImpl, name);
+                attach_pending_comments(&mut impl_chunk, &mut pending_comments, source);
+                chunks.push(impl_chunk);
+                chunks.extend(extract_impl_methods(&node, source, impl_index));
+            }
             _ => {
                 if let Some(mut chunk) = classify_rust_node(&node, source) {
                     attach_pending_comments(&mut chunk, &mut pending_comments, source);
@@ -55,14 +63,31 @@ fn classify_rust_node(node: &tree_sitter::Node, source: &str) -> Option<RawChunk
         "struct_item" => ChunkType::RustStruct,
         "enum_item" => ChunkType::RustEnum,
         "trait_item" => ChunkType::RustTrait,
-        "impl_item" => {
-            let name = extract_rust_impl_name(node, source);
-            return Some(make_chunk(source, node, ChunkType::RustImpl, name));
-        }
         _ => return other_or_skip(source, node),
     };
     let name = extract_name(node, source);
     Some(make_chunk(source, node, chunk_type, name))
+}
+
+fn extract_impl_methods(
+    impl_node: &tree_sitter::Node,
+    source: &str,
+    impl_index: usize,
+) -> Vec<RawChunk> {
+    let Some(body) = impl_node.child_by_field_name("body") else {
+        return vec![];
+    };
+    let mut result = Vec::new();
+    let mut cursor = body.walk();
+    for child in body.children(&mut cursor) {
+        if child.kind() == "function_item" {
+            let name = extract_name(&child, source);
+            let mut chunk = make_chunk(source, &child, ChunkType::RustFn, name);
+            chunk.parent_index = Some(impl_index);
+            result.push(chunk);
+        }
+    }
+    result
 }
 
 fn parse_rust_use(node: &tree_sitter::Node, source: &str) -> Vec<ParsedImport> {

--- a/src/indexer/chunker/tests.rs
+++ b/src/indexer/chunker/tests.rs
@@ -431,9 +431,12 @@ fn chunk_rust_trait() {
 fn chunk_rust_impl() {
     let source = "impl Config { fn new() -> Self { Config { name: String::new(), value: 0 } } }";
     let result = chunk_file(source, "rs");
-    assert_eq!(result.chunks.len(), 1);
+    assert_eq!(result.chunks.len(), 2);
     assert_eq!(result.chunks[0].chunk_type, ChunkType::RustImpl);
     assert_eq!(result.chunks[0].name.as_deref(), Some("Config"));
+    assert_eq!(result.chunks[1].chunk_type, ChunkType::RustFn);
+    assert_eq!(result.chunks[1].name.as_deref(), Some("new"));
+    assert_eq!(result.chunks[1].parent_index, Some(0));
 }
 
 #[test]
@@ -441,9 +444,12 @@ fn chunk_rust_impl_trait() {
     let source =
         "impl Display for Config { fn fmt(&self, f: &mut Formatter) -> Result { Ok(()) } }";
     let result = chunk_file(source, "rs");
-    assert_eq!(result.chunks.len(), 1);
+    assert_eq!(result.chunks.len(), 2);
     assert_eq!(result.chunks[0].chunk_type, ChunkType::RustImpl);
     assert_eq!(result.chunks[0].name.as_deref(), Some("Display for Config"));
+    assert_eq!(result.chunks[1].chunk_type, ChunkType::RustFn);
+    assert_eq!(result.chunks[1].name.as_deref(), Some("fmt"));
+    assert_eq!(result.chunks[1].parent_index, Some(0));
 }
 
 #[test]
@@ -477,11 +483,14 @@ fn baz() {}
 fn chunk_rust_impl_generic() {
     let source = "impl<T> From<T> for Wrapper<T> { fn from(val: T) -> Self { Wrapper(val) } }";
     let result = chunk_file(source, "rs");
-    assert_eq!(result.chunks.len(), 1);
+    assert_eq!(result.chunks.len(), 2);
     assert_eq!(result.chunks[0].chunk_type, ChunkType::RustImpl);
     let name = result.chunks[0].name.as_deref().unwrap();
     assert!(name.contains("From"), "expected From in name: {name}");
     assert!(name.contains("Wrapper"), "expected Wrapper in name: {name}");
+    assert_eq!(result.chunks[1].chunk_type, ChunkType::RustFn);
+    assert_eq!(result.chunks[1].name.as_deref(), Some("from"));
+    assert_eq!(result.chunks[1].parent_index, Some(0));
 }
 
 #[test]

--- a/src/indexer/embed.rs
+++ b/src/indexer/embed.rs
@@ -40,10 +40,18 @@ fn validate_chunked_embeddings(embs: Vec<ChunkedEmbedding>) -> Result<Vec<Chunke
 pub(super) fn enrich_for_embedding(
     file_path: &str,
     chunk_type: &str,
+    name: Option<&str>,
+    parent_name: Option<&str>,
     imports: &str,
     content: &str,
 ) -> String {
     let mut result = format!("// File: {file_path}\n// Type: {chunk_type}\n");
+    if let Some(n) = name {
+        result.push_str(&format!("// Name: {n}\n"));
+    }
+    if let Some(p) = parent_name {
+        result.push_str(&format!("// Parent: {p}\n"));
+    }
     if !imports.is_empty() {
         for line in imports.lines() {
             result.push_str("// ");
@@ -129,9 +137,12 @@ pub(super) fn embed_and_store(
             .iter()
             .filter(|c| c.chunk_type != storage::ChunkType::InnerFn)
             .map(|c| {
+                let parent_name = c.parent_index.and_then(|i| pf.raw_chunks[i].name.as_deref());
                 enrich_for_embedding(
                     &pf.rel_path,
                     c.chunk_type.as_str(),
+                    c.name.as_deref(),
+                    parent_name,
                     &pf.imports_text,
                     &c.content,
                 )
@@ -213,13 +224,20 @@ fn fetch_unembedded_file(
     file_path: &str,
 ) -> Result<(Vec<i64>, Vec<String>), IndexError> {
     let conn_guard = conn.lock().unwrap();
-    let triples = storage::get_unembedded_chunks_for_file(&conn_guard, file_path)?;
+    let rows = storage::get_unembedded_chunks_for_file(&conn_guard, file_path)?;
     let imports = storage::get_imports_for_file(&conn_guard, file_path)?;
-    let ids: Vec<i64> = triples.iter().map(|(id, _, _)| *id).collect();
-    let texts: Vec<String> = triples
+    let ids: Vec<i64> = rows.iter().map(|(id, _, _, _, _)| *id).collect();
+    let texts: Vec<String> = rows
         .into_iter()
-        .map(|(_, content, chunk_type)| {
-            enrich_for_embedding(file_path, &chunk_type, &imports, &content)
+        .map(|(_, content, chunk_type, name, parent_name)| {
+            enrich_for_embedding(
+                file_path,
+                &chunk_type,
+                name.as_deref(),
+                parent_name.as_deref(),
+                &imports,
+                &content,
+            )
         })
         .collect();
     Ok((ids, texts))

--- a/src/indexer/embed.rs
+++ b/src/indexer/embed.rs
@@ -47,10 +47,14 @@ pub(super) fn enrich_for_embedding(
 ) -> String {
     let mut result = format!("// File: {file_path}\n// Type: {chunk_type}\n");
     if let Some(n) = name {
-        result.push_str(&format!("// Name: {n}\n"));
+        result.push_str("// Name: ");
+        result.push_str(n);
+        result.push('\n');
     }
     if let Some(p) = parent_name {
-        result.push_str(&format!("// Parent: {p}\n"));
+        result.push_str("// Parent: ");
+        result.push_str(p);
+        result.push('\n');
     }
     if !imports.is_empty() {
         for line in imports.lines() {
@@ -137,7 +141,9 @@ pub(super) fn embed_and_store(
             .iter()
             .filter(|c| c.chunk_type != storage::ChunkType::InnerFn)
             .map(|c| {
-                let parent_name = c.parent_index.and_then(|i| pf.raw_chunks[i].name.as_deref());
+                let parent_name = c
+                    .parent_index
+                    .and_then(|i| pf.raw_chunks[i].name.as_deref());
                 enrich_for_embedding(
                     &pf.rel_path,
                     c.chunk_type.as_str(),
@@ -226,17 +232,17 @@ fn fetch_unembedded_file(
     let conn_guard = conn.lock().unwrap();
     let rows = storage::get_unembedded_chunks_for_file(&conn_guard, file_path)?;
     let imports = storage::get_imports_for_file(&conn_guard, file_path)?;
-    let ids: Vec<i64> = rows.iter().map(|(id, _, _, _, _)| *id).collect();
+    let ids: Vec<i64> = rows.iter().map(|r| r.id).collect();
     let texts: Vec<String> = rows
         .into_iter()
-        .map(|(_, content, chunk_type, name, parent_name)| {
+        .map(|r| {
             enrich_for_embedding(
                 file_path,
-                &chunk_type,
-                name.as_deref(),
-                parent_name.as_deref(),
+                &r.chunk_type,
+                r.name.as_deref(),
+                r.parent_name.as_deref(),
                 &imports,
-                &content,
+                &r.content,
             )
         })
         .collect();

--- a/src/indexer/tests.rs
+++ b/src/indexer/tests.rs
@@ -23,6 +23,8 @@ fn enrich_for_embedding_with_imports() {
     let result = enrich_for_embedding(
         "src/App.tsx",
         "component",
+        None,
+        None,
         "import { useState } from 'react'\nimport { Button } from './Button'",
         "function App() {}",
     );
@@ -35,7 +37,7 @@ fn enrich_for_embedding_with_imports() {
 
 #[test]
 fn enrich_for_embedding_without_imports() {
-    let result = enrich_for_embedding("src/utils.ts", "function", "", "function add() {}");
+    let result = enrich_for_embedding("src/utils.ts", "function", None, None, "", "function add() {}");
     assert_eq!(
         result,
         "// File: src/utils.ts\n// Type: function\nfunction add() {}"
@@ -44,8 +46,39 @@ fn enrich_for_embedding_without_imports() {
 
 #[test]
 fn enrich_for_embedding_empty_content() {
-    let result = enrich_for_embedding("src/empty.ts", "other", "", "");
+    let result = enrich_for_embedding("src/empty.ts", "other", None, None, "", "");
     assert_eq!(result, "// File: src/empty.ts\n// Type: other\n");
+}
+
+#[test]
+fn enrich_for_embedding_with_name() {
+    let result = enrich_for_embedding(
+        "src/slack.rs",
+        "rust_fn",
+        Some("handle_rate_limit"),
+        None,
+        "",
+        "fn handle_rate_limit() {}",
+    );
+    assert!(result.contains("// Name: handle_rate_limit\n"));
+    assert!(!result.contains("// Parent:"));
+}
+
+#[test]
+fn enrich_for_embedding_with_name_and_parent() {
+    let result = enrich_for_embedding(
+        "src/client.rs",
+        "rust_fn",
+        Some("handle_rate_limit"),
+        Some("SlackClient"),
+        "",
+        "fn handle_rate_limit() {}",
+    );
+    assert!(result.contains("// Name: handle_rate_limit\n"));
+    assert!(result.contains("// Parent: SlackClient\n"));
+    let name_pos = result.find("// Name:").unwrap();
+    let parent_pos = result.find("// Parent:").unwrap();
+    assert!(name_pos < parent_pos);
 }
 
 #[test]

--- a/src/indexer/tests.rs
+++ b/src/indexer/tests.rs
@@ -37,7 +37,14 @@ fn enrich_for_embedding_with_imports() {
 
 #[test]
 fn enrich_for_embedding_without_imports() {
-    let result = enrich_for_embedding("src/utils.ts", "function", None, None, "", "function add() {}");
+    let result = enrich_for_embedding(
+        "src/utils.ts",
+        "function",
+        None,
+        None,
+        "",
+        "function add() {}",
+    );
     assert_eq!(
         result,
         "// File: src/utils.ts\n// Type: function\nfunction add() {}"

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -52,9 +52,11 @@ fn existing_embedded_ids(
 pub fn get_unembedded_chunks_for_file(
     conn: &Connection,
     file_path: &str,
-) -> Result<Vec<(i64, String, String)>, StorageError> {
+) -> Result<Vec<(i64, String, String, Option<String>, Option<String>)>, StorageError> {
     let mut stmt = conn.prepare_cached(
-        "SELECT c.id, c.content, c.chunk_type FROM chunks c
+        "SELECT c.id, c.content, c.chunk_type, c.name, p.name
+         FROM chunks c
+         LEFT JOIN chunks p ON c.parent_chunk_id = p.id
          LEFT JOIN embedded_chunk_ids e ON c.id = e.chunk_id
          WHERE c.file_path = ?1 AND e.chunk_id IS NULL AND c.chunk_type != 'inner_fn'",
     )?;
@@ -63,6 +65,8 @@ pub fn get_unembedded_chunks_for_file(
             row.get::<_, i64>(0)?,
             row.get::<_, String>(1)?,
             row.get::<_, String>(2)?,
+            row.get::<_, Option<String>>(3)?,
+            row.get::<_, Option<String>>(4)?,
         ))
     })?;
     rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -49,10 +49,18 @@ fn existing_embedded_ids(
     Ok(ids)
 }
 
+pub struct UnembeddedChunk {
+    pub id: i64,
+    pub content: String,
+    pub chunk_type: String,
+    pub name: Option<String>,
+    pub parent_name: Option<String>,
+}
+
 pub fn get_unembedded_chunks_for_file(
     conn: &Connection,
     file_path: &str,
-) -> Result<Vec<(i64, String, String, Option<String>, Option<String>)>, StorageError> {
+) -> Result<Vec<UnembeddedChunk>, StorageError> {
     let mut stmt = conn.prepare_cached(
         "SELECT c.id, c.content, c.chunk_type, c.name, p.name
          FROM chunks c
@@ -61,13 +69,13 @@ pub fn get_unembedded_chunks_for_file(
          WHERE c.file_path = ?1 AND e.chunk_id IS NULL AND c.chunk_type != 'inner_fn'",
     )?;
     let rows = stmt.query_map([file_path], |row| {
-        Ok((
-            row.get::<_, i64>(0)?,
-            row.get::<_, String>(1)?,
-            row.get::<_, String>(2)?,
-            row.get::<_, Option<String>>(3)?,
-            row.get::<_, Option<String>>(4)?,
-        ))
+        Ok(UnembeddedChunk {
+            id: row.get(0)?,
+            content: row.get(1)?,
+            chunk_type: row.get(2)?,
+            name: row.get(3)?,
+            parent_name: row.get(4)?,
+        })
     })?;
     rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
 }

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -1562,15 +1562,15 @@ fn get_unembedded_chunks_for_file_returns_triple() {
     ];
     replace_file_chunks_only(&conn, "src/Card.tsx", &chunks, "hash_card", "", &[], None).unwrap();
 
-    let triples = get_unembedded_chunks_for_file(&conn, "src/Card.tsx").unwrap();
-    assert_eq!(triples.len(), 2);
+    let rows = get_unembedded_chunks_for_file(&conn, "src/Card.tsx").unwrap();
+    assert_eq!(rows.len(), 2);
 
-    let types: Vec<&str> = triples.iter().map(|(_, _, t)| t.as_str()).collect();
+    let types: Vec<&str> = rows.iter().map(|(_, _, t, _, _)| t.as_str()).collect();
     assert!(types.contains(&"component"));
     assert!(types.contains(&"hook"));
 
     // Verify content is returned correctly
-    let contents: Vec<&str> = triples.iter().map(|(_, c, _)| c.as_str()).collect();
+    let contents: Vec<&str> = rows.iter().map(|(_, c, _, _, _)| c.as_str()).collect();
     assert!(contents.contains(&"function Card() {}"));
     assert!(contents.contains(&"function useCard() {}"));
 }
@@ -1597,8 +1597,8 @@ fn get_unembedded_chunks_for_file_excludes_embedded() {
     )
     .unwrap();
 
-    let triples = get_unembedded_chunks_for_file(&conn, "src/Nav.tsx").unwrap();
-    assert!(triples.is_empty());
+    let rows = get_unembedded_chunks_for_file(&conn, "src/Nav.tsx").unwrap();
+    assert!(rows.is_empty());
 }
 
 #[test]

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -1539,7 +1539,7 @@ fn fts5_handles_special_characters_in_content() {
 }
 
 #[test]
-fn get_unembedded_chunks_for_file_returns_triple() {
+fn get_unembedded_chunks_for_file_returns_rows() {
     let (conn, _dir) = test_db();
 
     let chunks = vec![
@@ -1565,12 +1565,11 @@ fn get_unembedded_chunks_for_file_returns_triple() {
     let rows = get_unembedded_chunks_for_file(&conn, "src/Card.tsx").unwrap();
     assert_eq!(rows.len(), 2);
 
-    let types: Vec<&str> = rows.iter().map(|(_, _, t, _, _)| t.as_str()).collect();
+    let types: Vec<&str> = rows.iter().map(|r| r.chunk_type.as_str()).collect();
     assert!(types.contains(&"component"));
     assert!(types.contains(&"hook"));
 
-    // Verify content is returned correctly
-    let contents: Vec<&str> = rows.iter().map(|(_, c, _, _, _)| c.as_str()).collect();
+    let contents: Vec<&str> = rows.iter().map(|r| r.content.as_str()).collect();
     assert!(contents.contains(&"function Card() {}"));
     assert!(contents.contains(&"function useCard() {}"));
 }


### PR DESCRIPTION
## 概要

`// Name:` と `// Parent:` ヘッダーを埋め込みテキストの先頭に追加し、シンボル名や親コンテキスト（Rust の `impl` ブロックなど）をモデルに明示的に伝えることで、名前ベースのクエリに対する検索精度を改善する。

## 変更内容

- **`enrich_for_embedding` にヘッダー追加** (`src/indexer/embed.rs`): `name` / `parent_name` を受け取り、`// Type:` の後に `// Name:` と `// Parent:` 行を出力するよう拡張。フルインデックスとインクリメンタルの両パスを更新
- **Rust chunker で impl メソッドをサブチャンクとして抽出** (`src/indexer/chunker/rust.rs`): `impl` ブロック全体を1チャンクとして扱っていた既存実装を変更し、各メソッドを `parent_index` 付きの `RustFn` サブチャンクとして生成。これにより `// Parent: Config` 等のヘッダーが実際に出力されるようになる
- **インクリメンタルパスで親名を取得** (`src/storage/embed.rs`): `get_unembedded_chunks_for_file` の SQL に `LEFT JOIN chunks p ON c.parent_chunk_id = p.id` を追加し、DB 経由でも親名を解決
- **`UnembeddedChunk` 構造体の導入** (`src/storage/embed.rs`): 5要素タプルの戻り値を named struct に置き換え、呼び出し側の可読性を向上。動作変更なし

## スコープ

- **含まない**: 既存 DB の自動再インデックス（下記 制約事項 参照）

## 制約事項

既存のインデックス済み DB には新しいヘッダーが自動的には反映されない。新しいヘッダーを既存コードベースに適用するには手動で再インデックスが必要。この対応は本 PR のスコープ外とする。

## テスト手順

1. 新規ファイルをインデックスし、`yomu search "<impl メソッド名>"` で検索する
2. 結果に `impl` ブロックのメソッドが上位に含まれることを確認する
3. `cargo test` が全テスト通過することを確認する（`enrich_for_embedding_with_name`, `enrich_for_embedding_with_name_and_parent` を含む）
4. インクリメンタルインデックス（差分追加）後にも同様の結果が得られることを確認する

## 関連

Closes #81