### PR TITLE
ファイル・シンボル類似検索の --from フラグを追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -123,7 +123,7 @@ $ yomu --json status
 {"files":42,"chunks":187,"embedded_chunks":187,"embeddable_chunks":187,"embed_percentage":100,"references":156,"last_indexed":"2025-03-29 01:23:45"}
 ```
 
-### `yomu search <query>` — 概念で検索
+### `yomu search [query]` — 概念で検索
 
 ランク付けされた結果をフルコンテキスト付きで返します。各結果には以下が含まれます。
 
@@ -134,7 +134,21 @@ $ yomu --json status
 | 隣接する定義      | 同一ファイル内の他の関数・型                     |
 | チャンクタイプ    | component / hook / type_def / css_rule / rust_fn |
 
-オプション: `--limit`（デフォルト: 10、最大: 100）、`--offset`（デフォルト: 0、最大: 500）
+オプション:
+
+| フラグ     | デフォルト | 説明                                                                          |
+| ---------- | ---------- | ----------------------------------------------------------------------------- |
+| `--limit`  | 10         | 最大件数（上限: 100）                                                         |
+| `--offset` | 0          | ページネーションオフセット（上限: 500）                                       |
+| `--from`   | —          | ファイルまたはシンボルに類似するコードを検索（`src/foo.rs` または `src/foo.rs:my_fn`）。query は省略可 |
+
+`--from` は保存済み埋め込みをそのまま検索クエリとして使うため、再埋め込みは不要です:
+
+```sh
+yomu search --from src/query/mod.rs           # このファイルに類似するファイルを検索
+yomu search --from src/query/mod.rs:rerank    # この関数に類似するシンボルを検索
+yomu search --from src/query/mod.rs "filter"  # ハイブリッド: ファイル類似 + FTS "filter"
+```
 
 ### `yomu impact <target>` — 変更の影響範囲
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ $ yomu --json status
 {"files":42,"chunks":187,"embedded_chunks":187,"embeddable_chunks":187,"embed_percentage":100,"references":156,"last_indexed":"2025-03-29 01:23:45"}
 ```
 
-### `yomu search <query>` — Search by concept
+### `yomu search [query]` — Search by concept
 
 Returns ranked results with full context. Each result includes:
 
@@ -133,7 +133,21 @@ Returns ranked results with full context. Each result includes:
 | Sibling defs   | Other functions/types in the same file           |
 | Chunk type     | component / hook / type_def / css_rule / rust_fn |
 
-Options: `--limit` (default: 10, max: 100), `--offset` (default: 0, max: 500)
+Options:
+
+| Flag      | Default | Description                                                              |
+| --------- | ------- | ------------------------------------------------------------------------ |
+| `--limit` | 10      | Max results (max: 100)                                                   |
+| `--offset`| 0       | Pagination offset (max: 500)                                             |
+| `--from`  | —       | Search for code similar to a file or symbol (`src/foo.rs` or `src/foo.rs:my_fn`). Query becomes optional |
+
+`--from` uses the stored embeddings of the target — no re-embedding needed:
+
+```sh
+yomu search --from src/query/mod.rs           # files similar to this file
+yomu search --from src/query/mod.rs:rerank    # files similar to this function
+yomu search --from src/query/mod.rs "filter"  # hybrid: similar to file + FTS on "filter"
+```
 
 ### `yomu impact <target>` — Blast radius of a change
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,7 @@ fn main() -> ExitCode {
             let json = json || format.as_deref() == Some("json");
             if from.is_some() {
                 // Literal query: use as-is. "-" / None: try stdin (optional with --from).
-                let is_literal = query.as_deref().map_or(false, |q| q != "-");
+                let is_literal = query.as_deref().is_some_and(|q| q != "-");
                 let query = if is_literal {
                     query
                 } else {
@@ -181,7 +181,14 @@ fn main() -> ExitCode {
                         }
                     }
                 };
-                yomu.search(query.as_deref(), limit, offset, &path, json, from.as_deref())
+                yomu.search(
+                    query.as_deref(),
+                    limit,
+                    offset,
+                    &path,
+                    json,
+                    from.as_deref(),
+                )
             } else {
                 let query = match resolve_query(query) {
                     Ok(q) => q,

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,9 @@ enum Command {
         /// Restrict search to files under this path prefix (repeatable)
         #[arg(long)]
         path: Vec<String>,
+        /// Search for code similar to the given file or symbol (e.g. "src/foo.rs" or "src/foo.rs:my_fn")
+        #[arg(long)]
+        from: Option<String>,
         /// Deprecated: use global --json instead
         #[arg(long, hide = true)]
         format: Option<String>,
@@ -81,6 +84,22 @@ Examples:
 enum ModelCommand {
     /// Download embedding model from Hugging Face Hub.
     Download,
+}
+
+#[derive(Debug)]
+enum QueryError {
+    /// No query available (terminal, empty stdin) — expected with --from
+    NoQuery(String),
+    /// I/O failure reading stdin — must propagate
+    Io(String),
+}
+
+impl std::fmt::Display for QueryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoQuery(msg) | Self::Io(msg) => f.write_str(msg),
+        }
+    }
 }
 
 fn main() -> ExitCode {
@@ -140,20 +159,39 @@ fn main() -> ExitCode {
             limit,
             offset,
             path,
+            from,
             format,
         } => {
             if format.is_some() {
                 eprintln!("warning: --format is deprecated, use --json instead");
             }
             let json = json || format.as_deref() == Some("json");
-            let query = match resolve_query(query) {
-                Ok(q) => q,
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    return ExitCode::from(2);
-                }
-            };
-            yomu.search(&query, limit, offset, &path, json)
+            if from.is_some() {
+                // Literal query: use as-is. "-" / None: try stdin (optional with --from).
+                let is_literal = query.as_deref().map_or(false, |q| q != "-");
+                let query = if is_literal {
+                    query
+                } else {
+                    match resolve_query(query) {
+                        Ok(q) => Some(q),
+                        Err(QueryError::NoQuery(_)) => None,
+                        Err(e @ QueryError::Io(_)) => {
+                            eprintln!("error: {e}");
+                            return ExitCode::FAILURE;
+                        }
+                    }
+                };
+                yomu.search(query.as_deref(), limit, offset, &path, json, from.as_deref())
+            } else {
+                let query = match resolve_query(query) {
+                    Ok(q) => q,
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        return ExitCode::from(2);
+                    }
+                };
+                yomu.search(Some(&query), limit, offset, &path, json, None)
+            }
         }
         Command::Index { dry_run } => {
             if dry_run {
@@ -212,7 +250,7 @@ where
     Cli::try_parse_from(args)
 }
 
-fn resolve_query(arg: Option<String>) -> Result<String, String> {
+fn resolve_query(arg: Option<String>) -> Result<String, QueryError> {
     let stdin = std::io::stdin();
     let is_terminal = stdin.is_terminal();
     resolve_query_with(arg, &mut stdin.lock(), is_terminal)
@@ -222,20 +260,22 @@ fn resolve_query_with(
     arg: Option<String>,
     stdin: &mut impl Read,
     stdin_is_terminal: bool,
-) -> Result<String, String> {
+) -> Result<String, QueryError> {
     match arg {
         Some(q) if q != "-" => Ok(q),
         _ => {
             if stdin_is_terminal {
-                return Err("query required: pass as argument or pipe via stdin".into());
+                return Err(QueryError::NoQuery(
+                    "query required: pass as argument or pipe via stdin".into(),
+                ));
             }
             let mut buf = String::new();
             stdin
                 .read_to_string(&mut buf)
-                .map_err(|e| format!("failed to read from stdin: {e}"))?;
+                .map_err(|e| QueryError::Io(format!("failed to read from stdin: {e}")))?;
             let trimmed = buf.trim();
             if trimmed.is_empty() {
-                return Err("empty query from stdin".into());
+                return Err(QueryError::NoQuery("empty query from stdin".into()));
             }
             Ok(trimmed.to_string())
         }
@@ -327,17 +367,39 @@ mod tests {
     }
 
     #[test]
-    fn resolve_query_with_none_terminal_returns_error() {
+    fn resolve_query_with_none_terminal_returns_no_query() {
         let mut stdin = Cursor::new(b"");
         let result = resolve_query_with(None, &mut stdin, true);
-        assert!(result.unwrap_err().contains("query required"));
+        let err = result.unwrap_err();
+        assert!(matches!(err, QueryError::NoQuery(_)));
+        assert!(err.to_string().contains("query required"));
     }
 
     #[test]
-    fn resolve_query_with_empty_stdin_returns_error() {
+    fn resolve_query_with_empty_stdin_returns_no_query() {
         let mut stdin = Cursor::new(b"   ");
         let result = resolve_query_with(None, &mut stdin, false);
-        assert!(result.unwrap_err().contains("empty query"));
+        let err = result.unwrap_err();
+        assert!(matches!(err, QueryError::NoQuery(_)));
+        assert!(err.to_string().contains("empty query"));
+    }
+
+    // RC-005: I/O errors must not be swallowed as NoQuery
+    #[test]
+    fn resolve_query_with_io_error_returns_io_variant() {
+        struct FailingReader;
+        impl std::io::Read for FailingReader {
+            fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "broken pipe",
+                ))
+            }
+        }
+        let result = resolve_query_with(None, &mut FailingReader, false);
+        let err = result.unwrap_err();
+        assert!(matches!(err, QueryError::Io(_)));
+        assert!(err.to_string().contains("failed to read from stdin"));
     }
 
     // T-030: explicit `yomu search "認証"` is not double-injected
@@ -433,6 +495,32 @@ mod tests {
                 ),
                 "[TC-014] subcommand '{cmd}' should not be rewritten as Search shorthand"
             );
+        }
+    }
+
+    // T-015: --from without query parses OK
+    #[test]
+    fn from_flag_without_query_parses_ok() {
+        let cli = parse_cli_args(["yomu", "search", "--from", "src/foo.rs"]).unwrap();
+        match cli.command.unwrap() {
+            Command::Search { query, from, .. } => {
+                assert_eq!(query, None);
+                assert_eq!(from.as_deref(), Some("src/foo.rs"));
+            }
+            other => panic!("expected Search, got {other:?}"),
+        }
+    }
+
+    // T-016: no --from, no query → from defaults to None (error comes from resolve_query)
+    #[test]
+    fn no_from_no_query_has_from_none() {
+        let cli = parse_cli_args(["yomu", "search"]).unwrap();
+        match cli.command.unwrap() {
+            Command::Search { query, from, .. } => {
+                assert_eq!(query, None);
+                assert_eq!(from, None);
+            }
+            other => panic!("expected Search, got {other:?}"),
         }
     }
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -303,6 +303,93 @@ pub fn rerank(
     results.sort_by(|a, b| b.score.total_cmp(&a.score));
 }
 
+const MAX_FROM_SUB_EMBEDDINGS: usize = 20;
+
+pub fn search_from_file(
+    conn: &Db,
+    embedding_bytes: &[Vec<u8>],
+    source_chunk_ids: &HashSet<i64>,
+    query: Option<&str>,
+    limit: u32,
+    path_filter: &[String],
+) -> Result<Vec<SearchResult>, StorageError> {
+    if embedding_bytes.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // FR-010 / BR-005
+    let capped = if embedding_bytes.len() > MAX_FROM_SUB_EMBEDDINGS {
+        tracing::warn!(
+            count = embedding_bytes.len(),
+            cap = MAX_FROM_SUB_EMBEDDINGS,
+            "Truncating sub-embeddings to cap"
+        );
+        &embedding_bytes[..MAX_FROM_SUB_EMBEDDINGS]
+    } else {
+        embedding_bytes
+    };
+
+    let f32_vecs: Vec<Vec<f32>> = capped
+        .iter()
+        .map(|bytes| {
+            bytes
+                .chunks_exact(4)
+                .map(|b| f32::from_le_bytes(b.try_into().unwrap()))
+                .collect()
+        })
+        .collect();
+    let emb_refs: Vec<&[f32]> = f32_vecs.iter().map(|v| v.as_slice()).collect();
+
+    // FR-004 / BR-002: min-distance merge across sub-embeddings.
+    // Overfetch by (a) 3× when FTS will narrow candidates, and (b) source_ids.len() to survive
+    // the post-KNN source exclusion filter (P1: without this, limit=1 can return 0 results when
+    // the source chunk occupies the only KNN slot).
+    let source_buf = source_chunk_ids.len() as u32;
+    let fetch_limit = if query.is_some() {
+        limit.saturating_mul(3).saturating_add(source_buf)
+    } else {
+        limit.saturating_add(source_buf)
+    };
+    let mut results = storage::vec_search_multi(conn, &emb_refs, fetch_limit, path_filter)?;
+
+    // FR-005 / BR-001
+    results.retain(|r| !r.chunk_id.is_some_and(|id| source_chunk_ids.contains(&id)));
+
+    // FR-008 / BR-006: FTS intersection — only when keywords can be extracted.
+    // Skip when extract_keywords returns [] (stopwords-only input) to avoid silently clearing
+    // valid semantic results (P2).
+    if let Some(q) = query {
+        let keywords = extract_keywords(q);
+        if !keywords.is_empty() {
+            let keyword_refs: Vec<&str> = keywords.iter().map(|s| s.as_str()).collect();
+            let knn_ids: HashSet<i64> = results.iter().filter_map(|r| r.chunk_id).collect();
+            let fts_hits = storage::search_by_fts(
+                conn,
+                &keyword_refs,
+                None,
+                &HashSet::new(),
+                Some(&knn_ids),
+                fetch_limit,
+                path_filter,
+            )?;
+            let fts_ids: HashSet<i64> = fts_hits.iter().filter_map(|r| r.chunk_id).collect();
+            results.retain(|r| r.chunk_id.is_some_and(|id| fts_ids.contains(&id)));
+        }
+    }
+
+    // BR-003 / BR-004: rerank with default context (no keyword/type hints)
+    let import_counts = if results.is_empty() {
+        HashMap::new()
+    } else {
+        let file_paths: Vec<&str> = results.iter().map(|r| r.chunk.file_path.as_str()).collect();
+        storage::get_import_counts(conn, &file_paths)?
+    };
+    rerank(&mut results, &RerankContext::default(), &import_counts);
+
+    results.truncate(limit as usize);
+    Ok(results)
+}
+
 fn search_pipeline(
     conn: &Db,
     query: &str,
@@ -345,6 +432,7 @@ fn search_pipeline(
             &keyword_refs,
             type_filter,
             &exclude_ids,
+            None,
             fallback_limit,
             path_filter,
         )?;

--- a/src/query/tests.rs
+++ b/src/query/tests.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 use rurico::embed::{Embedder, FailingEmbedder, MockEmbedder};
@@ -969,7 +969,6 @@ fn t001_reranker_reorders_results_by_cross_encoder_score() {
     )
     .unwrap();
 
-    // Reranker scores useAuth higher than AuthForm
     let reranker = ScriptedReranker::new(vec![("useAuth", 0.9), ("AuthForm", 0.1)]);
 
     let conn = Arc::new(Mutex::new(conn));
@@ -1025,7 +1024,6 @@ fn t002_no_reranker_produces_rrf_results() {
     .unwrap();
 
     let conn = Arc::new(Mutex::new(conn));
-    // No reranker: None
     let outcome = search(
         Arc::clone(&conn),
         &MockEmbedder::default(),
@@ -1037,7 +1035,6 @@ fn t002_no_reranker_produces_rrf_results() {
     )
     .unwrap();
 
-    // Also call the existing (no reranker param) signature for reference
     let outcome_existing = search(conn, &MockEmbedder::default(), "auth", 5, 0, None, &[]).unwrap();
 
     assert_eq!(
@@ -1187,7 +1184,6 @@ fn t007_reranker_scores_applied_before_cap_per_file() {
     )
     .unwrap();
 
-    // Reranker: chunk3 (middleware) > chunk1 (handler) > chunk2 (validator)
     let reranker = ScriptedReranker::new(vec![
         ("middleware", 0.9),
         ("handler", 0.5),
@@ -1458,4 +1454,578 @@ fn search_chunk_only_index_with_embedder_falls_back_to_text() {
         "should return text/name fallback results even with zero embeddings"
     );
     assert_eq!(outcome.results[0].chunk.name.as_deref(), Some("Button"));
+}
+
+fn from_test_db() -> (storage::Db, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let conn = storage::open_db(&dir.path().join("test.db")).unwrap();
+    (conn, dir)
+}
+
+// RC-002: measure N KNN round-trips latency (N=1 vs N=20) with 500 indexed chunks
+// Run with: cargo test --lib bench_knn_round_trips -- --nocapture --ignored
+#[test]
+#[ignore]
+fn bench_knn_round_trips() {
+    use std::time::Instant;
+
+    let (conn, _dir) = from_test_db();
+
+    // Seed 500 chunks with random-ish embeddings across 32 axes
+    for i in 0u32..500 {
+        let axis = (i % 32) as usize;
+        let mut emb = vec![0.0_f32; storage::EMBEDDING_DIMS];
+        emb[axis] = 1.0;
+        emb[(axis + 1) % storage::EMBEDDING_DIMS] = 0.3;
+        storage::insert_chunk(
+            &conn,
+            &format!("src/file_{i}.rs"),
+            &storage::NewChunk {
+                chunk_type: &storage::ChunkType::RustFn,
+                name: Some("fn_name"),
+                content: &format!("fn fn_{i}() {{}}"),
+                start_line: 1,
+                end_line: 1,
+                parent_index: None,
+            },
+            &format!("h{i}"),
+            &storage::ce(emb),
+            None,
+        )
+        .unwrap();
+    }
+
+    let source_ids = std::collections::HashSet::new();
+
+    let run = |n: usize, label: &str| {
+        let emb_bytes: Vec<Vec<u8>> = (0..n)
+            .map(|i| storage::f32_as_bytes(&emb_axis(i % 32)).to_vec())
+            .collect();
+        let iters = 50;
+        let t = Instant::now();
+        for _ in 0..iters {
+            let _ = search_from_file(&conn, &emb_bytes, &source_ids, None, 10, &[]).unwrap();
+        }
+        let avg_us = t.elapsed().as_micros() / iters;
+        println!("N={n:2} ({label}): {avg_us} µs/call");
+    };
+
+    run(1, "single fn");
+    run(5, "small file");
+    run(10, "medium file");
+    run(20, "cap");
+}
+
+fn emb_axis(axis: usize) -> Vec<f32> {
+    let mut v = vec![0.0_f32; storage::EMBEDDING_DIMS];
+    v[axis] = 1.0;
+    v
+}
+
+// --- T-009: search_from_file excludes source chunk_ids ---
+#[test]
+fn search_from_file_excludes_source_chunks() {
+    let (conn, _dir) = from_test_db();
+
+    let id_src1 = storage::insert_chunk(
+        &conn,
+        "src/source.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("src_fn1"),
+            content: "fn src_fn1() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "h1",
+        &storage::ce(emb_axis(0)),
+        None,
+    )
+    .unwrap();
+    let id_src2 = storage::insert_chunk(
+        &conn,
+        "src/source.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("src_fn2"),
+            content: "fn src_fn2() {}",
+            start_line: 3,
+            end_line: 3,
+            parent_index: None,
+        },
+        "h1",
+        &storage::ce(emb_axis(1)),
+        None,
+    )
+    .unwrap();
+    let id_other = storage::insert_chunk(
+        &conn,
+        "src/other.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("other_fn"),
+            content: "fn other_fn() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "h2",
+        &storage::ce(emb_axis(2)),
+        None,
+    )
+    .unwrap();
+
+    let emb_bytes = vec![storage::f32_as_bytes(&emb_axis(0)).to_vec()];
+    let source_ids = HashSet::from([id_src1, id_src2]);
+
+    let results = search_from_file(&conn, &emb_bytes, &source_ids, None, 10, &[]).unwrap();
+    let result_ids: Vec<i64> = results.iter().filter_map(|r| r.chunk_id).collect();
+    assert!(!result_ids.contains(&id_src1));
+    assert!(!result_ids.contains(&id_src2));
+    assert!(result_ids.contains(&id_other));
+}
+
+// --- T-010: search_from_file with query applies FTS filter ---
+#[test]
+fn search_from_file_with_query_applies_fts_filter() {
+    let (conn, _dir) = from_test_db();
+
+    let id_source = storage::insert_chunk(
+        &conn,
+        "src/source.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("source"),
+            content: "fn source() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "h1",
+        &storage::ce(emb_axis(0)),
+        None,
+    )
+    .unwrap();
+    let id_error = storage::insert_chunk(
+        &conn,
+        "src/error.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("handle_error"),
+            content: "fn handle_error() { error handling logic }",
+            start_line: 1,
+            end_line: 3,
+            parent_index: None,
+        },
+        "h2",
+        &storage::ce(emb_axis(1)),
+        None,
+    )
+    .unwrap();
+    let _id_unrelated = storage::insert_chunk(
+        &conn,
+        "src/unrelated.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("unrelated"),
+            content: "fn unrelated() { nothing here }",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "h3",
+        &storage::ce(emb_axis(2)),
+        None,
+    )
+    .unwrap();
+
+    let emb_bytes = vec![storage::f32_as_bytes(&emb_axis(0)).to_vec()];
+    let source_ids = HashSet::from([id_source]);
+
+    let results =
+        search_from_file(&conn, &emb_bytes, &source_ids, Some("error"), 10, &[]).unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].chunk_id, Some(id_error));
+}
+
+// --- T-011: search_from_file FTS zero matches returns empty ---
+#[test]
+fn search_from_file_fts_zero_matches_returns_empty() {
+    let (conn, _dir) = from_test_db();
+
+    let id_source = storage::insert_chunk(
+        &conn,
+        "src/source.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("source"),
+            content: "fn source() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "h1",
+        &storage::ce(emb_axis(0)),
+        None,
+    )
+    .unwrap();
+    storage::insert_chunk(
+        &conn,
+        "src/other.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("other"),
+            content: "fn other() { some logic }",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "h2",
+        &storage::ce(emb_axis(1)),
+        None,
+    )
+    .unwrap();
+
+    let emb_bytes = vec![storage::f32_as_bytes(&emb_axis(0)).to_vec()];
+    let source_ids = HashSet::from([id_source]);
+
+    let results =
+        search_from_file(&conn, &emb_bytes, &source_ids, Some("xyzzyx"), 10, &[]).unwrap();
+    assert!(results.is_empty());
+}
+
+// --- T-012: search_from_file with no stored embeddings returns empty ---
+#[test]
+fn search_from_file_no_embeddings_returns_empty() {
+    let (conn, _dir) = from_test_db();
+    let source_ids = HashSet::from([1]);
+    let results = search_from_file(&conn, &[], &source_ids, None, 10, &[]).unwrap();
+    assert!(results.is_empty());
+}
+
+// --- T-014: search_from_file caps at 20 sub-embeddings ---
+#[test]
+fn search_from_file_caps_sub_embeddings_at_20() {
+    let (conn, _dir) = from_test_db();
+
+    storage::insert_chunk(
+        &conn,
+        "src/target.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("target"),
+            content: "fn target() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "h1",
+        &storage::ce(emb_axis(0)),
+        None,
+    )
+    .unwrap();
+
+    // Generate 25 sub-embeddings (all same vector for simplicity)
+    let emb_bytes = storage::f32_as_bytes(&emb_axis(0)).to_vec();
+    let entries: Vec<Vec<u8>> = (0..25).map(|_| emb_bytes.clone()).collect();
+    let source_ids = HashSet::new();
+
+    // Should not error; internally caps at 20
+    let results = search_from_file(&conn, &entries, &source_ids, None, 10, &[]).unwrap();
+    assert!(!results.is_empty());
+}
+
+// --- T-015: FTS filter uses fetch_limit (not limit) so rerank picks best semantic match ---
+#[test]
+fn search_from_file_fts_uses_fetch_limit_not_limit() {
+    let (conn, _dir) = from_test_db();
+
+    // Source chunk — we search "from" this
+    let id_source = storage::insert_chunk(
+        &conn,
+        "src/source.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("source"),
+            content: "fn source() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "h1",
+        &storage::ce(emb_axis(0)),
+        None,
+    )
+    .unwrap();
+
+    // A: closest to source (same axis), low keyword frequency → low BM25
+    let id_a = storage::insert_chunk(
+        &conn,
+        "src/a.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("close_handler"),
+            content: "fn close_handler() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "h2",
+        &storage::ce(emb_axis(0)),
+        None,
+    )
+    .unwrap();
+
+    // B: far from source, high keyword frequency → high BM25
+    let _id_b = storage::insert_chunk(
+        &conn,
+        "src/b.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("far_handler"),
+            content: "fn far_handler() { handler handler handler handler handler }",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "h3",
+        &storage::ce(emb_axis(1)),
+        None,
+    )
+    .unwrap();
+
+    // C: far from source, medium keyword frequency
+    let _id_c = storage::insert_chunk(
+        &conn,
+        "src/c.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("mid_handler"),
+            content: "fn mid_handler() { handler handler handler }",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "h4",
+        &storage::ce(emb_axis(2)),
+        None,
+    )
+    .unwrap();
+
+    let emb_bytes = vec![storage::f32_as_bytes(&emb_axis(0)).to_vec()];
+    let source_ids = HashSet::from([id_source]);
+
+    // limit=1: with bug, FTS picks top BM25 (far_handler); with fix, all pass through to rerank
+    let results =
+        search_from_file(&conn, &emb_bytes, &source_ids, Some("handler"), 1, &[]).unwrap();
+    assert_eq!(results.len(), 1, "should return exactly 1 result");
+    // Semantically closest FTS match should win after rerank, not highest BM25
+    assert_eq!(
+        results[0].chunk_id,
+        Some(id_a),
+        "closest semantic match (close_handler) should beat high-BM25 (far_handler)"
+    );
+}
+
+// COV-4: fetch_limit = limit * 3 (3× overfetch) — the 3rd-closest candidate must reach FTS pool
+#[test]
+fn search_from_file_3x_overfetch_reaches_third_candidate() {
+    let (conn, _dir) = from_test_db();
+
+    // KNN distances from emb_axis(0): A=0, B=0.1, C=0.5, source≈1.41 (won't appear in top 3)
+    let emb_b = {
+        let mut v = vec![0.0_f32; storage::EMBEDDING_DIMS];
+        v[0] = 1.0;
+        v[1] = 0.1;
+        v
+    };
+    let emb_c = {
+        let mut v = vec![0.0_f32; storage::EMBEDDING_DIMS];
+        v[0] = 1.0;
+        v[1] = 0.5;
+        v
+    };
+
+    // Source stored far from query (emb_axis(5)), so it won't consume a top-3 KNN slot
+    let id_source = storage::insert_chunk(
+        &conn,
+        "src/source.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("src_fn"),
+            content: "fn src_fn() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "hsource",
+        &storage::ce(emb_axis(5)),
+        None,
+    )
+    .unwrap();
+
+    // A: KNN rank 1 (closest), NO keyword
+    storage::insert_chunk(
+        &conn,
+        "src/a.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("a_fn"),
+            content: "fn a_fn() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "ha",
+        &storage::ce(emb_axis(0)),
+        None,
+    )
+    .unwrap();
+
+    // B: KNN rank 2, NO keyword
+    storage::insert_chunk(
+        &conn,
+        "src/b.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("b_fn"),
+            content: "fn b_fn() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "hb",
+        &storage::ce(emb_b),
+        None,
+    )
+    .unwrap();
+
+    // C: KNN rank 3, HAS keyword "magic"
+    let id_c = storage::insert_chunk(
+        &conn,
+        "src/c.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("c_fn"),
+            content: "fn c_fn() { magic magic magic }",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "hc",
+        &storage::ce(emb_c),
+        None,
+    )
+    .unwrap();
+
+    // Search from emb_axis(0) with query "magic", limit=1 → fetch_limit=3
+    let emb_bytes = vec![storage::f32_as_bytes(&emb_axis(0)).to_vec()];
+    let source_ids = HashSet::from([id_source]);
+
+    let results =
+        search_from_file(&conn, &emb_bytes, &source_ids, Some("magic"), 1, &[]).unwrap();
+    assert_eq!(results.len(), 1, "should return exactly 1 result");
+    assert_eq!(
+        results[0].chunk_id,
+        Some(id_c),
+        "3rd-closest candidate (c_fn, only keyword match) should be reached by 3× overfetch"
+    );
+}
+
+// P1: source exclusion must not deplete results when limit=1 and source is nearest neighbour
+#[test]
+fn search_from_file_source_exclusion_does_not_empty_results_at_limit_1() {
+    let (conn, _dir) = from_test_db();
+
+    // Source at emb_axis(0); other is a close neighbour (slightly off-axis)
+    let id_source = storage::insert_chunk(
+        &conn,
+        "src/source.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("source"),
+            content: "fn source() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "h1",
+        &storage::ce(emb_axis(0)),
+        None,
+    )
+    .unwrap();
+    let id_other = storage::insert_chunk(
+        &conn,
+        "src/other.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("other"),
+            content: "fn other() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "h2",
+        &storage::ce({
+            let mut v = emb_axis(0);
+            v[1] = 0.1;
+            v
+        }),
+        None,
+    )
+    .unwrap();
+
+    let emb_bytes = vec![storage::f32_as_bytes(&emb_axis(0)).to_vec()];
+    let source_ids = HashSet::from([id_source]);
+
+    let results = search_from_file(&conn, &emb_bytes, &source_ids, None, 1, &[]).unwrap();
+    assert_eq!(results.len(), 1, "should return 1 result even when source fills KNN slot");
+    assert_eq!(results[0].chunk_id, Some(id_other));
+}
+
+// P2: stopword-only query must not empty semantic results
+#[test]
+fn search_from_file_stopword_query_falls_back_to_semantic() {
+    let (conn, _dir) = from_test_db();
+
+    let id_source = storage::insert_chunk(
+        &conn,
+        "src/source.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("source"),
+            content: "fn source() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "h1",
+        &storage::ce(emb_axis(0)),
+        None,
+    )
+    .unwrap();
+    storage::insert_chunk(
+        &conn,
+        "src/other.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("other"),
+            content: "fn other() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "h2",
+        &storage::ce(emb_axis(0)),
+        None,
+    )
+    .unwrap();
+
+    let emb_bytes = vec![storage::f32_as_bytes(&emb_axis(0)).to_vec()];
+    let source_ids = HashSet::from([id_source]);
+
+    // "a" is a stopword → extract_keywords returns [] → must behave like query=None
+    let results = search_from_file(&conn, &emb_bytes, &source_ids, Some("a"), 10, &[]).unwrap();
+    assert!(!results.is_empty(), "stopword-only query should return semantic results, not []");
 }

--- a/src/query/tests.rs
+++ b/src/query/tests.rs
@@ -1643,8 +1643,7 @@ fn search_from_file_with_query_applies_fts_filter() {
     let emb_bytes = vec![storage::f32_as_bytes(&emb_axis(0)).to_vec()];
     let source_ids = HashSet::from([id_source]);
 
-    let results =
-        search_from_file(&conn, &emb_bytes, &source_ids, Some("error"), 10, &[]).unwrap();
+    let results = search_from_file(&conn, &emb_bytes, &source_ids, Some("error"), 10, &[]).unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].chunk_id, Some(id_error));
 }
@@ -1923,8 +1922,7 @@ fn search_from_file_3x_overfetch_reaches_third_candidate() {
     let emb_bytes = vec![storage::f32_as_bytes(&emb_axis(0)).to_vec()];
     let source_ids = HashSet::from([id_source]);
 
-    let results =
-        search_from_file(&conn, &emb_bytes, &source_ids, Some("magic"), 1, &[]).unwrap();
+    let results = search_from_file(&conn, &emb_bytes, &source_ids, Some("magic"), 1, &[]).unwrap();
     assert_eq!(results.len(), 1, "should return exactly 1 result");
     assert_eq!(
         results[0].chunk_id,
@@ -1980,7 +1978,11 @@ fn search_from_file_source_exclusion_does_not_empty_results_at_limit_1() {
     let source_ids = HashSet::from([id_source]);
 
     let results = search_from_file(&conn, &emb_bytes, &source_ids, None, 1, &[]).unwrap();
-    assert_eq!(results.len(), 1, "should return 1 result even when source fills KNN slot");
+    assert_eq!(
+        results.len(),
+        1,
+        "should return 1 result even when source fills KNN slot"
+    );
     assert_eq!(results[0].chunk_id, Some(id_other));
 }
 
@@ -2027,5 +2029,8 @@ fn search_from_file_stopword_query_falls_back_to_semantic() {
 
     // "a" is a stopword → extract_keywords returns [] → must behave like query=None
     let results = search_from_file(&conn, &emb_bytes, &source_ids, Some("a"), 10, &[]).unwrap();
-    assert!(!results.is_empty(), "stopword-only query should return semantic results, not []");
+    assert!(
+        !results.is_empty(),
+        "stopword-only query should return semantic results, not []"
+    );
 }

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -281,8 +281,10 @@ pub fn get_chunks_for_from_target(
 
     let mut stmt = conn.prepare(&sql)?;
     let ids = if let Some(sym) = symbol {
-        stmt.query_map(rusqlite::params![file_path, sym], |row| row.get::<_, i64>(0))?
-            .collect::<Result<Vec<_>, _>>()?
+        stmt.query_map(rusqlite::params![file_path, sym], |row| {
+            row.get::<_, i64>(0)
+        })?
+        .collect::<Result<Vec<_>, _>>()?
     } else {
         stmt.query_map([file_path], |row| row.get::<_, i64>(0))?
             .collect::<Result<Vec<_>, _>>()?
@@ -319,14 +321,17 @@ pub fn get_sub_embeddings_for_chunks(
 
     // Step 2: Batch-fetch embedding bytes (vec0 supports WHERE rowid IN (...)).
     let emb_placeholders = anon_placeholders(mappings.len());
-    let emb_sql = format!(
-        "SELECT rowid, embedding FROM vec_chunks WHERE rowid IN ({emb_placeholders})"
-    );
-    let rowid_params: Vec<&dyn rusqlite::types::ToSql> =
-        mappings.iter().map(|(_, vid)| vid as &dyn rusqlite::types::ToSql).collect();
+    let emb_sql =
+        format!("SELECT rowid, embedding FROM vec_chunks WHERE rowid IN ({emb_placeholders})");
+    let rowid_params: Vec<&dyn rusqlite::types::ToSql> = mappings
+        .iter()
+        .map(|(_, vid)| vid as &dyn rusqlite::types::ToSql)
+        .collect();
     let mut by_rowid: HashMap<i64, Vec<u8>> = conn
         .prepare(&emb_sql)?
-        .query_map(rowid_params.as_slice(), |row| Ok((row.get(0)?, row.get(1)?)))?
+        .query_map(rowid_params.as_slice(), |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })?
         .collect::<Result<_, _>>()?;
 
     let results: Vec<(i64, Vec<u8>)> = mappings

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -61,7 +61,6 @@ pub fn vec_search(
             .or_insert(*distance);
     }
 
-    // Batch-fetch chunk metadata for deduplicated chunk_ids.
     let chunk_ids: Vec<i64> = best.keys().copied().collect();
     let mut sql = format!(
         "SELECT id, file_path, chunk_type, name, content, start_line, end_line, parent_chunk_id \
@@ -116,6 +115,7 @@ pub fn search_by_fts(
     keywords: &[&str],
     type_filter: Option<&[ChunkType]>,
     exclude_ids: &HashSet<i64>,
+    include_ids: Option<&HashSet<i64>>,
     limit: u32,
     path_filter: &[String],
 ) -> Result<Vec<SearchResult>, StorageError> {
@@ -152,6 +152,7 @@ pub fn search_by_fts(
 
     append_type_filter(&mut sql, &mut params, "c.chunk_type", type_filter);
     append_exclude_ids(&mut sql, &mut params, "c.id", exclude_ids);
+    append_include_ids(&mut sql, &mut params, "c.id", include_ids);
     append_path_filter(&mut sql, &mut params, "c.file_path", path_filter);
     sql.push_str(&format!(" ORDER BY {BM25_EXPR} LIMIT ?"));
     params.push(Box::new(limit));
@@ -233,6 +234,108 @@ pub fn get_keyword_doc_frequencies(
     Ok(dfs)
 }
 
+pub fn vec_search_multi(
+    conn: &Connection,
+    query_embeddings: &[&[f32]],
+    limit: u32,
+    path_filter: &[String],
+) -> Result<Vec<SearchResult>, StorageError> {
+    if query_embeddings.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut best: HashMap<i64, SearchResult> = HashMap::new();
+    for emb in query_embeddings {
+        for result in vec_search(conn, emb, limit, path_filter)? {
+            if let Some(chunk_id) = result.chunk_id {
+                best.entry(chunk_id)
+                    .and_modify(|existing| {
+                        if result.distance < existing.distance {
+                            existing.distance = result.distance;
+                            existing.score = result.score;
+                        }
+                    })
+                    .or_insert(result);
+            }
+        }
+    }
+
+    let mut merged: Vec<SearchResult> = best.into_values().collect();
+    merged.sort_by(|a, b| a.distance.total_cmp(&b.distance));
+    merged.truncate(limit as usize);
+    Ok(merged)
+}
+
+pub fn get_chunks_for_from_target(
+    conn: &Connection,
+    file_path: &str,
+    symbol: Option<&str>,
+) -> Result<Vec<i64>, StorageError> {
+    let mut sql = String::from(
+        "SELECT id FROM chunks \
+         WHERE file_path = ?1 AND chunk_type != 'inner_fn'",
+    );
+    if symbol.is_some() {
+        sql.push_str(" AND name = ?2");
+    }
+
+    let mut stmt = conn.prepare(&sql)?;
+    let ids = if let Some(sym) = symbol {
+        stmt.query_map(rusqlite::params![file_path, sym], |row| row.get::<_, i64>(0))?
+            .collect::<Result<Vec<_>, _>>()?
+    } else {
+        stmt.query_map([file_path], |row| row.get::<_, i64>(0))?
+            .collect::<Result<Vec<_>, _>>()?
+    };
+    Ok(ids)
+}
+
+pub fn get_sub_embeddings_for_chunks(
+    conn: &Connection,
+    chunk_ids: &[i64],
+) -> Result<Vec<(i64, Vec<u8>)>, StorageError> {
+    if chunk_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Step 1: Get (chunk_id, vec_rowid) from embedded_chunk_ids, ordered by sub_idx.
+    let placeholders = anon_placeholders(chunk_ids.len());
+    let sql = format!(
+        "SELECT chunk_id, vec_rowid FROM embedded_chunk_ids \
+         WHERE chunk_id IN ({placeholders}) ORDER BY chunk_id, sub_idx"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let params: Vec<&dyn rusqlite::types::ToSql> = chunk_ids
+        .iter()
+        .map(|id| id as &dyn rusqlite::types::ToSql)
+        .collect();
+    let mappings: Vec<(i64, i64)> = stmt
+        .query_map(params.as_slice(), |row| Ok((row.get(0)?, row.get(1)?)))?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    if mappings.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Step 2: Batch-fetch embedding bytes (vec0 supports WHERE rowid IN (...)).
+    let emb_placeholders = anon_placeholders(mappings.len());
+    let emb_sql = format!(
+        "SELECT rowid, embedding FROM vec_chunks WHERE rowid IN ({emb_placeholders})"
+    );
+    let rowid_params: Vec<&dyn rusqlite::types::ToSql> =
+        mappings.iter().map(|(_, vid)| vid as &dyn rusqlite::types::ToSql).collect();
+    let mut by_rowid: HashMap<i64, Vec<u8>> = conn
+        .prepare(&emb_sql)?
+        .query_map(rowid_params.as_slice(), |row| Ok((row.get(0)?, row.get(1)?)))?
+        .collect::<Result<_, _>>()?;
+
+    let results: Vec<(i64, Vec<u8>)> = mappings
+        .iter()
+        .filter_map(|(chunk_id, vec_rowid)| by_rowid.remove(vec_rowid).map(|b| (*chunk_id, b)))
+        .collect();
+    Ok(results)
+}
+
 fn append_type_filter(
     sql: &mut String,
     params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
@@ -265,6 +368,27 @@ fn append_exclude_ids(
         ));
         for id in exclude_ids {
             params.push(Box::new(*id));
+        }
+    }
+}
+
+fn append_include_ids(
+    sql: &mut String,
+    params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
+    column: &str,
+    include_ids: Option<&HashSet<i64>>,
+) {
+    if let Some(ids) = include_ids {
+        if ids.is_empty() {
+            sql.push_str(" AND 1 = 0");
+        } else {
+            sql.push_str(&format!(
+                " AND {column} IN ({})",
+                anon_placeholders(ids.len())
+            ));
+            for id in ids {
+                params.push(Box::new(*id));
+            }
         }
     }
 }

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -1441,7 +1441,6 @@ fn get_import_counts_returns_empty_for_empty_input() {
     assert!(counts.is_empty());
 }
 
-
 #[test]
 fn fts_chunks_deleted_with_file() {
     let (conn, _dir) = test_db();
@@ -1524,7 +1523,8 @@ fn fts5_handles_special_characters_in_content() {
     }];
     replace_file_chunks_only(&conn, "src/App.tsx", &chunks, "h1", "", &[], None).unwrap();
 
-    let results = search_by_fts(&conn, &["container"], None, &HashSet::new(), None, 10, &[]).unwrap();
+    let results =
+        search_by_fts(&conn, &["container"], None, &HashSet::new(), None, 10, &[]).unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].chunk.name.as_deref(), Some("App"));
 }
@@ -1684,7 +1684,16 @@ fn migration_v3_to_v4_creates_vocab_table() {
     );
 
     // Verify data preserved: chunk should still be searchable
-    let results = search_by_fts(&conn, &["migrationTest"], None, &HashSet::new(), None, 10, &[]).unwrap();
+    let results = search_by_fts(
+        &conn,
+        &["migrationTest"],
+        None,
+        &HashSet::new(),
+        None,
+        10,
+        &[],
+    )
+    .unwrap();
     assert!(
         !results.is_empty(),
         "seeded chunk should survive v3->v4 migration"
@@ -1823,7 +1832,8 @@ fn fts_automerge_guard_restores_on_drop() {
         None,
     )
     .unwrap();
-    let results = search_by_fts(&conn, &["function"], None, &HashSet::new(), None, 10, &[]).unwrap();
+    let results =
+        search_by_fts(&conn, &["function"], None, &HashSet::new(), None, 10, &[]).unwrap();
     assert!(
         results.len() >= 2,
         "FTS should work after guard drop, got {} results",
@@ -2204,7 +2214,16 @@ fn t_011_chunk_from_row_reads_parent_chunk_id() {
         )
         .unwrap();
 
-    let results = search_by_fts(&conn, &["handlesubmit"], None, &HashSet::new(), None, 10, &[]).unwrap();
+    let results = search_by_fts(
+        &conn,
+        &["handlesubmit"],
+        None,
+        &HashSet::new(),
+        None,
+        10,
+        &[],
+    )
+    .unwrap();
 
     assert!(
         !results.is_empty(),
@@ -2262,7 +2281,16 @@ fn t_011_chunk_from_row_reads_parent_chunk_id_name_search() {
         )
         .unwrap();
 
-    let results = search_by_fts(&conn, &["handlesubmit"], None, &HashSet::new(), None, 10, &[]).unwrap();
+    let results = search_by_fts(
+        &conn,
+        &["handlesubmit"],
+        None,
+        &HashSet::new(),
+        None,
+        10,
+        &[],
+    )
+    .unwrap();
 
     assert!(
         !results.is_empty(),
@@ -2304,7 +2332,8 @@ fn t_012_parent_chunk_search_result_has_no_parent_chunk_id() {
     )
     .unwrap();
 
-    let results = search_by_fts(&conn, &["userform"], None, &HashSet::new(), None, 10, &[]).unwrap();
+    let results =
+        search_by_fts(&conn, &["userform"], None, &HashSet::new(), None, 10, &[]).unwrap();
 
     assert!(!results.is_empty(), "should find UserForm via name search");
     let component_result = &results[0];
@@ -2444,7 +2473,8 @@ fn t_014_migration_v6_to_v7_preserves_fts_search() {
         "[T-014] schema_version should be 8 after migration"
     );
 
-    let results = search_by_fts(&conn, &["transform"], None, &HashSet::new(), None, 10, &[]).unwrap();
+    let results =
+        search_by_fts(&conn, &["transform"], None, &HashSet::new(), None, 10, &[]).unwrap();
     assert_eq!(
         results.len(),
         1,
@@ -2524,8 +2554,16 @@ fn t_004_search_by_fts_finds_camelcase_by_split_keywords() {
     replace_file_chunks_only(&conn, "src/form.tsx", &chunks, "h1", "", &[], None).unwrap();
 
     // Search with split keywords ["handle", "submit"] should find handleSubmit
-    let results =
-        search_by_fts(&conn, &["handle", "submit"], None, &HashSet::new(), None, 10, &[]).unwrap();
+    let results = search_by_fts(
+        &conn,
+        &["handle", "submit"],
+        None,
+        &HashSet::new(),
+        None,
+        10,
+        &[],
+    )
+    .unwrap();
     let names: Vec<_> = results
         .iter()
         .filter_map(|r| r.chunk.name.as_deref())
@@ -2664,7 +2702,9 @@ fn t_016_search_by_fts_excludes_ids() {
 #[test]
 fn vec_chunks_embedding_retrievable_by_rowid() {
     let (conn, _dir) = test_db();
-    let emb: Vec<f32> = (0..EMBEDDING_DIMS as u32).map(|i| i as f32 / 768.0).collect();
+    let emb: Vec<f32> = (0..EMBEDDING_DIMS as u32)
+        .map(|i| i as f32 / 768.0)
+        .collect();
     let chunk_id = insert_chunk(
         &conn,
         "src/Foo.rs",
@@ -2819,7 +2859,10 @@ fn get_chunks_for_from_target_with_symbol_returns_exact_match() {
     assert_eq!(foo_id.len(), 1);
     let bar_id = get_chunks_for_from_target(&conn, "src/x.rs", Some("bar")).unwrap();
     assert_eq!(bar_id.len(), 1);
-    assert_ne!(foo_id[0], bar_id[0], "foo and bar should return different chunk IDs");
+    assert_ne!(
+        foo_id[0], bar_id[0],
+        "foo and bar should return different chunk IDs"
+    );
 }
 
 // --- T-004: get_chunks_for_from_target symbol not found returns empty ---
@@ -2853,7 +2896,9 @@ fn get_chunks_for_from_target_symbol_not_found_returns_empty() {
 #[test]
 fn get_sub_embeddings_for_chunks_returns_correct_bytes() {
     let (conn, _dir) = test_db();
-    let emb: Vec<f32> = (0..EMBEDDING_DIMS as u32).map(|i| i as f32 / 768.0).collect();
+    let emb: Vec<f32> = (0..EMBEDDING_DIMS as u32)
+        .map(|i| i as f32 / 768.0)
+        .collect();
 
     let chunk_id = insert_chunk(
         &conn,
@@ -2988,8 +3033,16 @@ fn search_by_fts_with_include_ids_filters_to_subset() {
 
     // With include_ids = {id1}: only id1 is returned
     let include = HashSet::from([id1]);
-    let filtered =
-        search_by_fts(&conn, &["error"], None, &HashSet::new(), Some(&include), 10, &[]).unwrap();
+    let filtered = search_by_fts(
+        &conn,
+        &["error"],
+        None,
+        &HashSet::new(),
+        Some(&include),
+        10,
+        &[],
+    )
+    .unwrap();
     assert_eq!(filtered.len(), 1);
     assert_eq!(filtered[0].chunk_id, Some(id1));
 }

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -408,6 +408,8 @@ fn chunk_type_roundtrip() {
         ChunkType::Other,
     ];
     for variant in &variants {
+        // Exhaustive match: compile-time guard — adding a ChunkType variant without
+        // updating `variants` above causes a compile error here.
         match variant {
             ChunkType::Component
             | ChunkType::Hook
@@ -1439,17 +1441,6 @@ fn get_import_counts_returns_empty_for_empty_input() {
     assert!(counts.is_empty());
 }
 
-#[test]
-fn fts5_available() {
-    let (conn, _dir) = test_db();
-    // Verify FTS5 extension is compiled in
-    conn.execute_batch(
-        "CREATE VIRTUAL TABLE IF NOT EXISTS _fts5_test USING fts5(content);
-         INSERT INTO _fts5_test(content) VALUES ('hello world');
-         DROP TABLE _fts5_test;",
-    )
-    .expect("FTS5 should be available");
-}
 
 #[test]
 fn fts_chunks_deleted_with_file() {
@@ -1466,14 +1457,14 @@ fn fts_chunks_deleted_with_file() {
     replace_file_chunks_only(&conn, "src/x.tsx", &chunks, "h1", "", &[], None).unwrap();
 
     // Should find it before delete
-    let results = search_by_fts(&conn, &["state"], None, &HashSet::new(), 10, &[]).unwrap();
+    let results = search_by_fts(&conn, &["state"], None, &HashSet::new(), None, 10, &[]).unwrap();
     assert_eq!(results.len(), 1);
 
     // Delete file chunks
     delete_file_chunks(&conn, "src/x.tsx").unwrap();
 
     // Should not find it after delete
-    let results = search_by_fts(&conn, &["state"], None, &HashSet::new(), 10, &[]).unwrap();
+    let results = search_by_fts(&conn, &["state"], None, &HashSet::new(), None, 10, &[]).unwrap();
     assert!(results.is_empty());
 }
 
@@ -1503,7 +1494,7 @@ fn fts5_migration_from_v2() {
     .unwrap();
 
     // Verify FTS5 is empty
-    let results = search_by_fts(&conn, &["loading"], None, &HashSet::new(), 10, &[]).unwrap();
+    let results = search_by_fts(&conn, &["loading"], None, &HashSet::new(), None, 10, &[]).unwrap();
     assert!(
         results.is_empty(),
         "fts_chunks should be empty before migration"
@@ -1514,7 +1505,7 @@ fn fts5_migration_from_v2() {
     let conn = open_db(&db_path).unwrap();
 
     // Migration should have populated fts_chunks from existing chunks
-    let results = search_by_fts(&conn, &["loading"], None, &HashSet::new(), 10, &[]).unwrap();
+    let results = search_by_fts(&conn, &["loading"], None, &HashSet::new(), None, 10, &[]).unwrap();
     assert_eq!(results.len(), 1, "migration should populate fts_chunks");
     assert_eq!(results[0].chunk.name.as_deref(), Some("useX"));
 }
@@ -1533,7 +1524,7 @@ fn fts5_handles_special_characters_in_content() {
     }];
     replace_file_chunks_only(&conn, "src/App.tsx", &chunks, "h1", "", &[], None).unwrap();
 
-    let results = search_by_fts(&conn, &["container"], None, &HashSet::new(), 10, &[]).unwrap();
+    let results = search_by_fts(&conn, &["container"], None, &HashSet::new(), None, 10, &[]).unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].chunk.name.as_deref(), Some("App"));
 }
@@ -1693,7 +1684,7 @@ fn migration_v3_to_v4_creates_vocab_table() {
     );
 
     // Verify data preserved: chunk should still be searchable
-    let results = search_by_fts(&conn, &["migrationTest"], None, &HashSet::new(), 10, &[]).unwrap();
+    let results = search_by_fts(&conn, &["migrationTest"], None, &HashSet::new(), None, 10, &[]).unwrap();
     assert!(
         !results.is_empty(),
         "seeded chunk should survive v3->v4 migration"
@@ -1832,7 +1823,7 @@ fn fts_automerge_guard_restores_on_drop() {
         None,
     )
     .unwrap();
-    let results = search_by_fts(&conn, &["function"], None, &HashSet::new(), 10, &[]).unwrap();
+    let results = search_by_fts(&conn, &["function"], None, &HashSet::new(), None, 10, &[]).unwrap();
     assert!(
         results.len() >= 2,
         "FTS should work after guard drop, got {} results",
@@ -2213,7 +2204,7 @@ fn t_011_chunk_from_row_reads_parent_chunk_id() {
         )
         .unwrap();
 
-    let results = search_by_fts(&conn, &["handlesubmit"], None, &HashSet::new(), 10, &[]).unwrap();
+    let results = search_by_fts(&conn, &["handlesubmit"], None, &HashSet::new(), None, 10, &[]).unwrap();
 
     assert!(
         !results.is_empty(),
@@ -2271,7 +2262,7 @@ fn t_011_chunk_from_row_reads_parent_chunk_id_name_search() {
         )
         .unwrap();
 
-    let results = search_by_fts(&conn, &["handlesubmit"], None, &HashSet::new(), 10, &[]).unwrap();
+    let results = search_by_fts(&conn, &["handlesubmit"], None, &HashSet::new(), None, 10, &[]).unwrap();
 
     assert!(
         !results.is_empty(),
@@ -2313,7 +2304,7 @@ fn t_012_parent_chunk_search_result_has_no_parent_chunk_id() {
     )
     .unwrap();
 
-    let results = search_by_fts(&conn, &["userform"], None, &HashSet::new(), 10, &[]).unwrap();
+    let results = search_by_fts(&conn, &["userform"], None, &HashSet::new(), None, 10, &[]).unwrap();
 
     assert!(!results.is_empty(), "should find UserForm via name search");
     let component_result = &results[0];
@@ -2453,7 +2444,7 @@ fn t_014_migration_v6_to_v7_preserves_fts_search() {
         "[T-014] schema_version should be 8 after migration"
     );
 
-    let results = search_by_fts(&conn, &["transform"], None, &HashSet::new(), 10, &[]).unwrap();
+    let results = search_by_fts(&conn, &["transform"], None, &HashSet::new(), None, 10, &[]).unwrap();
     assert_eq!(
         results.len(),
         1,
@@ -2534,7 +2525,7 @@ fn t_004_search_by_fts_finds_camelcase_by_split_keywords() {
 
     // Search with split keywords ["handle", "submit"] should find handleSubmit
     let results =
-        search_by_fts(&conn, &["handle", "submit"], None, &HashSet::new(), 10, &[]).unwrap();
+        search_by_fts(&conn, &["handle", "submit"], None, &HashSet::new(), None, 10, &[]).unwrap();
     let names: Vec<_> = results
         .iter()
         .filter_map(|r| r.chunk.name.as_deref())
@@ -2580,7 +2571,7 @@ fn t_005_search_by_fts_finds_by_path_segment() {
     }];
     replace_file_chunks_only(&conn, "src/auth/login.ts", &chunks, "h1", "", &[], None).unwrap();
 
-    let results = search_by_fts(&conn, &["auth"], None, &HashSet::new(), 10, &[]).unwrap();
+    let results = search_by_fts(&conn, &["auth"], None, &HashSet::new(), None, 10, &[]).unwrap();
     assert_eq!(
         results.len(),
         1,
@@ -2618,6 +2609,7 @@ fn t_007_search_by_fts_respects_type_filter() {
         &["auth"],
         Some(&[ChunkType::Hook]),
         &HashSet::new(),
+        None,
         10,
         &[],
     )
@@ -2654,17 +2646,402 @@ fn t_016_search_by_fts_excludes_ids() {
     ];
     replace_file_chunks_only(&conn, "src/auth.tsx", &chunks, "h1", "", &[], None).unwrap();
 
-    let all = search_by_fts(&conn, &["auth"], None, &HashSet::new(), 10, &[]).unwrap();
+    let all = search_by_fts(&conn, &["auth"], None, &HashSet::new(), None, 10, &[]).unwrap();
     assert_eq!(all.len(), 2);
 
     let first_id = all[0].chunk_id.unwrap();
     let mut exclude = HashSet::new();
     exclude.insert(first_id);
-    let filtered = search_by_fts(&conn, &["auth"], None, &exclude, 10, &[]).unwrap();
+    let filtered = search_by_fts(&conn, &["auth"], None, &exclude, None, 10, &[]).unwrap();
     assert_eq!(
         filtered.len(),
         1,
         "[T-016] excluded id should be filtered out"
     );
     assert_ne!(filtered[0].chunk_id, Some(first_id));
+}
+
+#[test]
+fn vec_chunks_embedding_retrievable_by_rowid() {
+    let (conn, _dir) = test_db();
+    let emb: Vec<f32> = (0..EMBEDDING_DIMS as u32).map(|i| i as f32 / 768.0).collect();
+    let chunk_id = insert_chunk(
+        &conn,
+        "src/Foo.rs",
+        &NewChunk {
+            chunk_type: &ChunkType::RustFn,
+            name: Some("foo"),
+            content: "fn foo() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "h1",
+        &ce(emb.clone()),
+        None,
+    )
+    .unwrap();
+
+    let vec_rowid: i64 = conn
+        .query_row(
+            "SELECT vec_rowid FROM embedded_chunk_ids WHERE chunk_id = ?1 AND sub_idx = 0",
+            [chunk_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    let bytes: Vec<u8> = conn
+        .query_row(
+            "SELECT embedding FROM vec_chunks WHERE rowid = ?1",
+            [vec_rowid],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    assert_eq!(bytes.len(), EMBEDDING_DIMS * 4);
+    let recovered: Vec<f32> = bytes
+        .chunks_exact(4)
+        .map(|b| f32::from_le_bytes(b.try_into().unwrap()))
+        .collect();
+    assert_eq!(recovered.len(), EMBEDDING_DIMS);
+    assert!((recovered[0] - emb[0]).abs() < 1e-6);
+    assert!((recovered[100] - emb[100]).abs() < 1e-6);
+}
+
+// --- T-001: get_chunks_for_from_target file-only returns non-inner_fn chunks ---
+#[test]
+fn get_chunks_for_from_target_file_only_excludes_inner_fn() {
+    let (conn, _dir) = test_db();
+    let emb = vec![0.0_f32; EMBEDDING_DIMS];
+
+    // 2 non-inner_fn chunks
+    insert_chunk(
+        &conn,
+        "src/foo.rs",
+        &NewChunk {
+            chunk_type: &ChunkType::RustFn,
+            name: Some("foo"),
+            content: "fn foo() {}",
+            start_line: 1,
+            end_line: 3,
+            parent_index: None,
+        },
+        "h1",
+        &ce(emb.clone()),
+        None,
+    )
+    .unwrap();
+    insert_chunk(
+        &conn,
+        "src/foo.rs",
+        &NewChunk {
+            chunk_type: &ChunkType::RustStruct,
+            name: Some("Bar"),
+            content: "struct Bar {}",
+            start_line: 5,
+            end_line: 7,
+            parent_index: None,
+        },
+        "h1",
+        &ce(emb.clone()),
+        None,
+    )
+    .unwrap();
+    // 1 inner_fn chunk (should be excluded)
+    insert_chunk_row(
+        &conn,
+        "src/foo.rs",
+        &NewChunk {
+            chunk_type: &ChunkType::InnerFn,
+            name: Some("inner"),
+            content: "fn inner() {}",
+            start_line: 2,
+            end_line: 2,
+            parent_index: None,
+        },
+        "h1",
+        None,
+    )
+    .unwrap();
+
+    let ids = get_chunks_for_from_target(&conn, "src/foo.rs", None).unwrap();
+    assert_eq!(ids.len(), 2);
+}
+
+// --- T-002: get_chunks_for_from_target returns empty for unknown file ---
+#[test]
+fn get_chunks_for_from_target_unknown_file_returns_empty() {
+    let (conn, _dir) = test_db();
+    let rows = get_chunks_for_from_target(&conn, "src/bar.rs", None).unwrap();
+    assert!(rows.is_empty());
+}
+
+// --- T-003: get_chunks_for_from_target with symbol returns exact match ---
+#[test]
+fn get_chunks_for_from_target_with_symbol_returns_exact_match() {
+    let (conn, _dir) = test_db();
+    let emb = vec![0.0_f32; EMBEDDING_DIMS];
+
+    insert_chunk(
+        &conn,
+        "src/x.rs",
+        &NewChunk {
+            chunk_type: &ChunkType::RustFn,
+            name: Some("foo"),
+            content: "fn foo() {}",
+            start_line: 1,
+            end_line: 3,
+            parent_index: None,
+        },
+        "h1",
+        &ce(emb.clone()),
+        None,
+    )
+    .unwrap();
+    insert_chunk(
+        &conn,
+        "src/x.rs",
+        &NewChunk {
+            chunk_type: &ChunkType::RustFn,
+            name: Some("bar"),
+            content: "fn bar() {}",
+            start_line: 5,
+            end_line: 7,
+            parent_index: None,
+        },
+        "h1",
+        &ce(emb.clone()),
+        None,
+    )
+    .unwrap();
+
+    let foo_id = get_chunks_for_from_target(&conn, "src/x.rs", Some("foo")).unwrap();
+    assert_eq!(foo_id.len(), 1);
+    let bar_id = get_chunks_for_from_target(&conn, "src/x.rs", Some("bar")).unwrap();
+    assert_eq!(bar_id.len(), 1);
+    assert_ne!(foo_id[0], bar_id[0], "foo and bar should return different chunk IDs");
+}
+
+// --- T-004: get_chunks_for_from_target symbol not found returns empty ---
+#[test]
+fn get_chunks_for_from_target_symbol_not_found_returns_empty() {
+    let (conn, _dir) = test_db();
+    let emb = vec![0.0_f32; EMBEDDING_DIMS];
+
+    insert_chunk(
+        &conn,
+        "src/x.rs",
+        &NewChunk {
+            chunk_type: &ChunkType::RustFn,
+            name: Some("foo"),
+            content: "fn foo() {}",
+            start_line: 1,
+            end_line: 3,
+            parent_index: None,
+        },
+        "h1",
+        &ce(emb.clone()),
+        None,
+    )
+    .unwrap();
+
+    let rows = get_chunks_for_from_target(&conn, "src/x.rs", Some("baz")).unwrap();
+    assert!(rows.is_empty());
+}
+
+// --- T-005: get_sub_embeddings_for_chunks returns correct byte length ---
+#[test]
+fn get_sub_embeddings_for_chunks_returns_correct_bytes() {
+    let (conn, _dir) = test_db();
+    let emb: Vec<f32> = (0..EMBEDDING_DIMS as u32).map(|i| i as f32 / 768.0).collect();
+
+    let chunk_id = insert_chunk(
+        &conn,
+        "src/a.rs",
+        &NewChunk {
+            chunk_type: &ChunkType::RustFn,
+            name: Some("a"),
+            content: "fn a() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "h1",
+        &ce(emb.clone()),
+        None,
+    )
+    .unwrap();
+
+    let results = get_sub_embeddings_for_chunks(&conn, &[chunk_id]).unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].0, chunk_id);
+    assert_eq!(results[0].1.len(), EMBEDDING_DIMS * 4); // 768 * 4 = 3072 bytes
+}
+
+// --- T-006: get_sub_embeddings_for_chunks with missing chunk returns empty ---
+#[test]
+fn get_sub_embeddings_for_chunks_missing_chunk_returns_empty() {
+    let (conn, _dir) = test_db();
+    let results = get_sub_embeddings_for_chunks(&conn, &[99]).unwrap();
+    assert!(results.is_empty());
+}
+
+// --- T-007: vec_search_multi merges duplicate chunk_ids by min distance ---
+#[test]
+fn vec_search_multi_keeps_min_distance_for_duplicate_chunk() {
+    let (conn, _dir) = test_db();
+    let mut emb_target = vec![0.0_f32; EMBEDDING_DIMS];
+    emb_target[0] = 1.0;
+    let mut emb_other = vec![0.0_f32; EMBEDDING_DIMS];
+    emb_other[1] = 1.0;
+
+    insert_chunk(
+        &conn,
+        "src/target.rs",
+        &NewChunk {
+            chunk_type: &ChunkType::RustFn,
+            name: Some("target"),
+            content: "fn target() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "h1",
+        &ce(emb_target.clone()),
+        None,
+    )
+    .unwrap();
+    insert_chunk(
+        &conn,
+        "src/other.rs",
+        &NewChunk {
+            chunk_type: &ChunkType::RustFn,
+            name: Some("other"),
+            content: "fn other() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "h2",
+        &ce(emb_other.clone()),
+        None,
+    )
+    .unwrap();
+
+    // query_a = exact match to target (distance ≈ 0)
+    // query_b = far from target (distance ≈ √2)
+    // min-distance merge should keep distance ≈ 0 for target
+    let results = vec_search_multi(&conn, &[&emb_target, &emb_other], 10, &[]).unwrap();
+    let target = results
+        .iter()
+        .find(|r| r.chunk.name.as_deref() == Some("target"))
+        .unwrap();
+    assert!(
+        target.distance < 0.01,
+        "min-distance merge should pick the closer query; got {}",
+        target.distance
+    );
+}
+
+// --- T-009: search_by_fts include_ids filters results to specified subset ---
+#[test]
+fn search_by_fts_with_include_ids_filters_to_subset() {
+    let (conn, _dir) = test_db();
+    let emb = vec![0.0_f32; EMBEDDING_DIMS];
+
+    let id1 = insert_chunk(
+        &conn,
+        "src/a.rs",
+        &NewChunk {
+            chunk_type: &ChunkType::RustFn,
+            name: Some("handle_error"),
+            content: "fn handle_error() { error handling logic }",
+            start_line: 1,
+            end_line: 3,
+            parent_index: None,
+        },
+        "h1",
+        &ce(emb.clone()),
+        None,
+    )
+    .unwrap();
+    let _id2 = insert_chunk(
+        &conn,
+        "src/b.rs",
+        &NewChunk {
+            chunk_type: &ChunkType::RustFn,
+            name: Some("handle_error2"),
+            content: "fn handle_error2() { more error stuff }",
+            start_line: 1,
+            end_line: 3,
+            parent_index: None,
+        },
+        "h2",
+        &ce(emb.clone()),
+        None,
+    )
+    .unwrap();
+
+    // Without include_ids: both chunks match "error"
+    let all = search_by_fts(&conn, &["error"], None, &HashSet::new(), None, 10, &[]).unwrap();
+    assert_eq!(all.len(), 2);
+
+    // With include_ids = {id1}: only id1 is returned
+    let include = HashSet::from([id1]);
+    let filtered =
+        search_by_fts(&conn, &["error"], None, &HashSet::new(), Some(&include), 10, &[]).unwrap();
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].chunk_id, Some(id1));
+}
+
+// --- T-008: vec_search_multi returns union of non-overlapping results ---
+#[test]
+fn vec_search_multi_returns_union() {
+    let (conn, _dir) = test_db();
+    let mut emb_a = vec![0.0_f32; EMBEDDING_DIMS];
+    emb_a[0] = 1.0;
+    let mut emb_b = vec![0.0_f32; EMBEDDING_DIMS];
+    emb_b[1] = 1.0;
+
+    insert_chunk(
+        &conn,
+        "src/a.rs",
+        &NewChunk {
+            chunk_type: &ChunkType::RustFn,
+            name: Some("fn_a"),
+            content: "fn a() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "h1",
+        &ce(emb_a.clone()),
+        None,
+    )
+    .unwrap();
+    insert_chunk(
+        &conn,
+        "src/b.rs",
+        &NewChunk {
+            chunk_type: &ChunkType::RustFn,
+            name: Some("fn_b"),
+            content: "fn b() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        },
+        "h2",
+        &ce(emb_b.clone()),
+        None,
+    )
+    .unwrap();
+
+    let results = vec_search_multi(&conn, &[&emb_a, &emb_b], 10, &[]).unwrap();
+    assert_eq!(results.len(), 2);
+    let names: Vec<_> = results
+        .iter()
+        .filter_map(|r| r.chunk.name.as_deref())
+        .collect();
+    assert!(names.contains(&"fn_a"));
+    assert!(names.contains(&"fn_b"));
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -152,9 +152,8 @@ impl Yomu {
             return self.search_from(from, query, limit, paths, json);
         }
 
-        let query = query.ok_or_else(|| {
-            YomuError::InvalidInput("query or --from is required".into())
-        })?;
+        let query =
+            query.ok_or_else(|| YomuError::InvalidInput("query or --from is required".into()))?;
 
         let embedder = self.get_embedder();
         let offset = offset.min(MAX_SEARCH_OFFSET);
@@ -230,7 +229,9 @@ impl Yomu {
 
         let results = if embedding_bytes.is_empty() {
             tracing::warn!(from, "no stored embeddings for from-target");
-            notes.push(format!("no stored embeddings for '{from}'; try running `yomu index`"));
+            notes.push(format!(
+                "no stored embeddings for '{from}'; try running `yomu index`"
+            ));
             Vec::new()
         } else {
             let source_ids: HashSet<i64> = chunk_ids.into_iter().collect();

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -123,27 +123,40 @@ impl Yomu {
 
     pub fn search(
         &self,
-        query: &str,
+        query: Option<&str>,
         limit: u32,
         offset: u32,
         paths: &[String],
         json: bool,
+        from_target: Option<&str>,
     ) -> Result<String, YomuError> {
-        if query.is_empty() {
-            return Err(YomuError::InvalidInput("query must not be empty".into()));
-        }
-        if query.len() > MAX_QUERY_LENGTH {
-            return Err(YomuError::InvalidInput(format!(
-                "query exceeds maximum length of {MAX_QUERY_LENGTH} characters"
-            )));
+        if let Some(q) = query {
+            if q.is_empty() {
+                return Err(YomuError::InvalidInput("query must not be empty".into()));
+            }
+            if q.len() > MAX_QUERY_LENGTH {
+                return Err(YomuError::InvalidInput(format!(
+                    "query exceeds maximum length of {MAX_QUERY_LENGTH} characters"
+                )));
+            }
         }
 
         for path in paths {
             validate_path(path)?;
         }
 
-        let embedder = self.get_embedder();
         let limit = limit.min(MAX_SEARCH_LIMIT);
+
+        if let Some(from) = from_target {
+            // FR-006: --offset is intentionally ignored in from-file mode
+            return self.search_from(from, query, limit, paths, json);
+        }
+
+        let query = query.ok_or_else(|| {
+            YomuError::InvalidInput("query or --from is required".into())
+        })?;
+
+        let embedder = self.get_embedder();
         let offset = offset.min(MAX_SEARCH_OFFSET);
 
         tracing::debug!(query, limit, offset, ?paths, "search request");
@@ -184,25 +197,72 @@ impl Yomu {
             notes.push("embedding model not loaded; results from text search only".into());
         }
 
-        if json {
-            return Ok(format_results_json(
-                &outcome.results,
-                outcome.degraded,
-                notes,
-            ));
+        self.format_search_results(&outcome.results, &stats, notes, json, outcome.degraded)
+    }
+
+    fn search_from(
+        &self,
+        from: &str,
+        query: Option<&str>,
+        limit: u32,
+        paths: &[String],
+        json: bool,
+    ) -> Result<String, YomuError> {
+        let (file, symbol) = parse_impact_target(from);
+        validate_path(file)?;
+
+        let embedder = self.get_embedder();
+        let stats = self.with_db(storage::get_stats)?;
+        let state = determine_index_state(&stats);
+        let index_notes = self.ensure_indexed(embedder, state, None)?;
+
+        let (chunk_ids, embedding_bytes) = self.with_db(|c| {
+            let chunk_ids = storage::get_chunks_for_from_target(c, file, symbol)?;
+            let raw = storage::get_sub_embeddings_for_chunks(c, &chunk_ids)?;
+            let embedding_bytes: Vec<Vec<u8>> = raw.into_iter().map(|(_, b)| b).collect();
+            Ok((chunk_ids, embedding_bytes))
+        })?;
+
+        let mut notes: Vec<String> = Vec::new();
+        if let Some(msg) = index_notes {
+            notes.push(msg);
         }
 
-        if outcome.results.is_empty() {
-            let mut msg = format_no_results_message(&stats);
+        let results = if embedding_bytes.is_empty() {
+            tracing::warn!(from, "no stored embeddings for from-target");
+            notes.push(format!("no stored embeddings for '{from}'; try running `yomu index`"));
+            Vec::new()
+        } else {
+            let source_ids: HashSet<i64> = chunk_ids.into_iter().collect();
+            self.with_db(|conn| {
+                query::search_from_file(conn, &embedding_bytes, &source_ids, query, limit, paths)
+            })?
+        };
+
+        self.format_search_results(&results, &stats, notes, json, false)
+    }
+
+    fn format_search_results(
+        &self,
+        results: &[storage::SearchResult],
+        stats: &storage::IndexStatus,
+        notes: Vec<String>,
+        json: bool,
+        degraded: bool,
+    ) -> Result<String, YomuError> {
+        if json {
+            return Ok(format_results_json(results, degraded, notes));
+        }
+        if results.is_empty() {
+            let mut msg = format_no_results_message(stats);
             for note in &notes {
                 msg.push_str(&format!("\n\nNote: {note}"));
             }
             return Ok(msg);
         }
-
-        let ctx = self.fetch_enrichment_context(&outcome.results)?;
-        let parent_chunks = self.fetch_parent_chunks(&outcome.results)?;
-        let mut text = format_results_grouped(&outcome.results, &ctx, &parent_chunks);
+        let ctx = self.fetch_enrichment_context(results)?;
+        let parent_chunks = self.fetch_parent_chunks(results)?;
+        let mut text = format_results_grouped(results, &ctx, &parent_chunks);
         for note in &notes {
             text.push_str(&format!("\n---\nNote: {note}\n"));
         }
@@ -501,7 +561,7 @@ fn validate_path(path: &str) -> Result<(), YomuError> {
     Ok(())
 }
 
-fn parse_impact_target(target: &str) -> (&str, Option<&str>) {
+pub(crate) fn parse_impact_target(target: &str) -> (&str, Option<&str>) {
     if let Some(colon_pos) = target.rfind(':')
         && colon_pos > 0
         && colon_pos < target.len() - 1

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -93,7 +93,9 @@ fn search_rejects_empty_query() {
 fn search_rejects_long_query() {
     let (y, _dir) = test_yomu();
     let long_query = "a".repeat(MAX_QUERY_LENGTH + 1);
-    let err = y.search(Some(&long_query), 10, 0, &[], false, None).unwrap_err();
+    let err = y
+        .search(Some(&long_query), 10, 0, &[], false, None)
+        .unwrap_err();
     assert!(
         err.to_string().contains("maximum length"),
         "expected max length error, got: {}",
@@ -136,7 +138,14 @@ fn search_path_filter_excludes_other_dirs() {
     );
 
     let text = y
-        .search(Some("open"), 10, 0, &["src/storage/".to_string()], false, None)
+        .search(
+            Some("open"),
+            10,
+            0,
+            &["src/storage/".to_string()],
+            false,
+            None,
+        )
         .unwrap();
     assert!(
         text.contains("db.ts") || text.contains("openDb") || text.contains("No results"),
@@ -151,7 +160,9 @@ fn search_path_filter_excludes_other_dirs() {
 #[test]
 fn search_without_embedder_degrades_gracefully() {
     let (y, _dir) = test_yomu();
-    let text = y.search(Some("test query"), 10, 0, &[], false, None).unwrap();
+    let text = y
+        .search(Some("test query"), 10, 0, &[], false, None)
+        .unwrap();
     assert!(
         text.contains("No results found"),
         "expected no results: {text}"
@@ -165,7 +176,9 @@ fn search_auto_indexes_empty_db() {
         Arc::new(rurico::embed::MockEmbedder::default()),
     );
 
-    let text = y.search(Some("button component"), 10, 0, &[], false, None).unwrap();
+    let text = y
+        .search(Some("button component"), 10, 0, &[], false, None)
+        .unwrap();
     assert!(
         !text.contains("No results found"),
         "expected results after auto-index, got: {text}"
@@ -202,7 +215,9 @@ fn search_incremental_embeds_chunked_only() {
         assert_eq!(stats.embedded_chunks, 0, "should have no embeddings yet");
     }
 
-    let text = y.search(Some("form component"), 10, 0, &[], false, None).unwrap();
+    let text = y
+        .search(Some("form component"), 10, 0, &[], false, None)
+        .unwrap();
     assert!(text.contains("Form"), "expected Form in results: {text}");
 
     {
@@ -279,7 +294,9 @@ fn search_degraded_empty_results_shows_note() {
             as Arc<dyn rurico::embed::Embed>),
     );
 
-    let text = y.search(Some("zzzznonexistent"), 10, 0, &[], false, None).unwrap();
+    let text = y
+        .search(Some("zzzznonexistent"), 10, 0, &[], false, None)
+        .unwrap();
     assert!(
         text.contains("No results found"),
         "expected no results: {text}"
@@ -317,7 +334,9 @@ fn search_degraded_with_results_shows_note() {
             as Arc<dyn rurico::embed::Embed>),
     );
 
-    let result = y_failing.search(Some("Button"), 10, 0, &[], false, None).unwrap();
+    let result = y_failing
+        .search(Some("Button"), 10, 0, &[], false, None)
+        .unwrap();
     assert!(result.contains("Button"), "should have search results");
     assert!(
         result.contains("embedding model not loaded"),
@@ -1122,7 +1141,9 @@ fn ensure_indexed_partially_embedded_triggers_embed() {
         "should have no embeddings yet"
     );
 
-    let result = y.search(Some("App component"), 10, 0, &[], false, None).unwrap();
+    let result = y
+        .search(Some("App component"), 10, 0, &[], false, None)
+        .unwrap();
     assert!(
         result.contains("App"),
         "should find App after embedding: {result}"
@@ -1193,7 +1214,9 @@ fn ensure_indexed_fully_embedded_with_failing_embedder() {
             as Arc<dyn rurico::embed::Embed>),
     );
 
-    let result = y_failing.search(Some("Card"), 10, 0, &[], false, None).unwrap();
+    let result = y_failing
+        .search(Some("Card"), 10, 0, &[], false, None)
+        .unwrap();
     assert!(
         result.contains("Card"),
         "should find Card with existing embeddings: {result}"
@@ -1270,7 +1293,9 @@ fn search_json_format_empty_results() {
         test_yomu_with_files(&[("src/A.tsx", "export function A() { return <div/>; }")]);
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
 
-    let json = y.search(Some("zzzznonexistent"), 10, 0, &[], true, None).unwrap();
+    let json = y
+        .search(Some("zzzznonexistent"), 10, 0, &[], true, None)
+        .unwrap();
     let parsed = parse_json(&json);
     assert!(
         parsed["results"].as_array().unwrap().is_empty(),
@@ -1506,7 +1531,9 @@ fn t_ac5_subchunk_innerfn_is_hit_at_1_for_inner_function_query() {
 
     y.index(false).unwrap();
 
-    let result = y.search(Some("handleSubmit"), 10, 0, &[], false, None).unwrap();
+    let result = y
+        .search(Some("handleSubmit"), 10, 0, &[], false, None)
+        .unwrap();
     assert!(
         result.contains("handleSubmit"),
         "[AC-5] search should find handleSubmit: {result}"
@@ -1666,7 +1693,9 @@ fn t002_search_with_ok_embedder_no_degraded_note() {
         Some(Arc::new(rurico::embed::MockEmbedder::default()) as Arc<dyn rurico::embed::Embed>),
     );
 
-    let text = y.search(Some("button component"), 10, 0, &[], false, None).unwrap();
+    let text = y
+        .search(Some("button component"), 10, 0, &[], false, None)
+        .unwrap();
     assert!(
         !text.contains("not installed"),
         "[T-002] should have no 'not installed' note: {text}"
@@ -2154,9 +2183,7 @@ fn search_from_file_integration() {
         Arc::new(rurico::embed::MockEmbedder::default()),
     );
 
-    let text = y
-        .search(None, 5, 0, &[], false, Some("src/a.rs"))
-        .unwrap();
+    let text = y.search(None, 5, 0, &[], false, Some("src/a.rs")).unwrap();
     // Source file should not appear in results
     assert!(
         !text.contains("No results found"),
@@ -2198,9 +2225,7 @@ fn search_from_json_output_has_results_key() {
         ],
         Arc::new(rurico::embed::MockEmbedder::default()),
     );
-    let json = y
-        .search(None, 10, 0, &[], true, Some("src/a.rs"))
-        .unwrap();
+    let json = y.search(None, 10, 0, &[], true, Some("src/a.rs")).unwrap();
     let parsed = parse_json(&json);
     assert!(
         parsed.get("results").is_some(),

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -81,7 +81,7 @@ fn seed_index(conn: &storage::Db) {
 #[test]
 fn search_rejects_empty_query() {
     let (y, _dir) = test_yomu();
-    let err = y.search("", 10, 0, &[], false).unwrap_err();
+    let err = y.search(Some(""), 10, 0, &[], false, None).unwrap_err();
     assert!(
         err.to_string().contains("empty"),
         "expected empty error, got: {}",
@@ -93,7 +93,7 @@ fn search_rejects_empty_query() {
 fn search_rejects_long_query() {
     let (y, _dir) = test_yomu();
     let long_query = "a".repeat(MAX_QUERY_LENGTH + 1);
-    let err = y.search(&long_query, 10, 0, &[], false).unwrap_err();
+    let err = y.search(Some(&long_query), 10, 0, &[], false, None).unwrap_err();
     assert!(
         err.to_string().contains("maximum length"),
         "expected max length error, got: {}",
@@ -105,7 +105,7 @@ fn search_rejects_long_query() {
 fn search_rejects_path_traversal() {
     let (y, _dir) = test_yomu();
     let err = y
-        .search("query", 10, 0, &["../etc".to_string()], false)
+        .search(Some("query"), 10, 0, &["../etc".to_string()], false, None)
         .unwrap_err();
     assert!(
         err.to_string().contains("must be a relative path"),
@@ -117,7 +117,7 @@ fn search_rejects_path_traversal() {
 fn search_rejects_absolute_path() {
     let (y, _dir) = test_yomu();
     let err = y
-        .search("query", 10, 0, &["/etc".to_string()], false)
+        .search(Some("query"), 10, 0, &["/etc".to_string()], false, None)
         .unwrap_err();
     assert!(
         err.to_string().contains("must be a relative path"),
@@ -136,7 +136,7 @@ fn search_path_filter_excludes_other_dirs() {
     );
 
     let text = y
-        .search("open", 10, 0, &["src/storage/".to_string()], false)
+        .search(Some("open"), 10, 0, &["src/storage/".to_string()], false, None)
         .unwrap();
     assert!(
         text.contains("db.ts") || text.contains("openDb") || text.contains("No results"),
@@ -151,7 +151,7 @@ fn search_path_filter_excludes_other_dirs() {
 #[test]
 fn search_without_embedder_degrades_gracefully() {
     let (y, _dir) = test_yomu();
-    let text = y.search("test query", 10, 0, &[], false).unwrap();
+    let text = y.search(Some("test query"), 10, 0, &[], false, None).unwrap();
     assert!(
         text.contains("No results found"),
         "expected no results: {text}"
@@ -165,7 +165,7 @@ fn search_auto_indexes_empty_db() {
         Arc::new(rurico::embed::MockEmbedder::default()),
     );
 
-    let text = y.search("button component", 10, 0, &[], false).unwrap();
+    let text = y.search(Some("button component"), 10, 0, &[], false, None).unwrap();
     assert!(
         !text.contains("No results found"),
         "expected results after auto-index, got: {text}"
@@ -202,7 +202,7 @@ fn search_incremental_embeds_chunked_only() {
         assert_eq!(stats.embedded_chunks, 0, "should have no embeddings yet");
     }
 
-    let text = y.search("form component", 10, 0, &[], false).unwrap();
+    let text = y.search(Some("form component"), 10, 0, &[], false, None).unwrap();
     assert!(text.contains("Form"), "expected Form in results: {text}");
 
     {
@@ -279,7 +279,7 @@ fn search_degraded_empty_results_shows_note() {
             as Arc<dyn rurico::embed::Embed>),
     );
 
-    let text = y.search("zzzznonexistent", 10, 0, &[], false).unwrap();
+    let text = y.search(Some("zzzznonexistent"), 10, 0, &[], false, None).unwrap();
     assert!(
         text.contains("No results found"),
         "expected no results: {text}"
@@ -317,7 +317,7 @@ fn search_degraded_with_results_shows_note() {
             as Arc<dyn rurico::embed::Embed>),
     );
 
-    let result = y_failing.search("Button", 10, 0, &[], false).unwrap();
+    let result = y_failing.search(Some("Button"), 10, 0, &[], false, None).unwrap();
     assert!(result.contains("Button"), "should have search results");
     assert!(
         result.contains("embedding model not loaded"),
@@ -1122,7 +1122,7 @@ fn ensure_indexed_partially_embedded_triggers_embed() {
         "should have no embeddings yet"
     );
 
-    let result = y.search("App component", 10, 0, &[], false).unwrap();
+    let result = y.search(Some("App component"), 10, 0, &[], false, None).unwrap();
     assert!(
         result.contains("App"),
         "should find App after embedding: {result}"
@@ -1165,7 +1165,7 @@ fn ensure_indexed_fully_embedded_skips_embed() {
         "should be fully embedded"
     );
 
-    let result = y.search("Button", 10, 0, &[], false).unwrap();
+    let result = y.search(Some("Button"), 10, 0, &[], false, None).unwrap();
     assert!(result.contains("Button"), "should find Button: {result}");
 }
 
@@ -1193,7 +1193,7 @@ fn ensure_indexed_fully_embedded_with_failing_embedder() {
             as Arc<dyn rurico::embed::Embed>),
     );
 
-    let result = y_failing.search("Card", 10, 0, &[], false).unwrap();
+    let result = y_failing.search(Some("Card"), 10, 0, &[], false, None).unwrap();
     assert!(
         result.contains("Card"),
         "should find Card with existing embeddings: {result}"
@@ -1228,7 +1228,7 @@ fn search_without_embedder_skips_embed_attempt() {
         assert_eq!(stats.embedded_chunks, 0, "should have no embeddings");
     }
 
-    let text = y.search("card", 10, 0, &[], false).unwrap();
+    let text = y.search(Some("card"), 10, 0, &[], false, None).unwrap();
     assert!(
         !text.contains("embedding failed"),
         "should not attempt embed when embedder unavailable: {text}"
@@ -1243,7 +1243,7 @@ fn search_json_format_returns_valid_json() {
     )]);
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
 
-    let json = y.search("button", 10, 0, &[], true).unwrap();
+    let json = y.search(Some("button"), 10, 0, &[], true, None).unwrap();
     let parsed = parse_json(&json);
     assert!(
         parsed["results"].is_array(),
@@ -1270,7 +1270,7 @@ fn search_json_format_empty_results() {
         test_yomu_with_files(&[("src/A.tsx", "export function A() { return <div/>; }")]);
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
 
-    let json = y.search("zzzznonexistent", 10, 0, &[], true).unwrap();
+    let json = y.search(Some("zzzznonexistent"), 10, 0, &[], true, None).unwrap();
     let parsed = parse_json(&json);
     assert!(
         parsed["results"].as_array().unwrap().is_empty(),
@@ -1337,7 +1337,7 @@ fn search_json_format_degraded_includes_flag() {
     );
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
 
-    let json = y.search("card", 10, 0, &[], true).unwrap();
+    let json = y.search(Some("card"), 10, 0, &[], true, None).unwrap();
     let parsed = parse_json(&json);
     assert_eq!(
         parsed["degraded"], true,
@@ -1506,7 +1506,7 @@ fn t_ac5_subchunk_innerfn_is_hit_at_1_for_inner_function_query() {
 
     y.index(false).unwrap();
 
-    let result = y.search("handleSubmit", 10, 0, &[], false).unwrap();
+    let result = y.search(Some("handleSubmit"), 10, 0, &[], false, None).unwrap();
     assert!(
         result.contains("handleSubmit"),
         "[AC-5] search should find handleSubmit: {result}"
@@ -1647,7 +1647,7 @@ fn t001_search_with_not_installed_shows_note() {
     let y = Yomu::for_test(conn, dir.path().to_path_buf(), None);
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
 
-    let text = y.search("button", 10, 0, &[], false).unwrap();
+    let text = y.search(Some("button"), 10, 0, &[], false, None).unwrap();
     assert!(
         text.contains("not installed"),
         "[T-001] expected NotInstalled note in results: {text}"
@@ -1666,7 +1666,7 @@ fn t002_search_with_ok_embedder_no_degraded_note() {
         Some(Arc::new(rurico::embed::MockEmbedder::default()) as Arc<dyn rurico::embed::Embed>),
     );
 
-    let text = y.search("button component", 10, 0, &[], false).unwrap();
+    let text = y.search(Some("button component"), 10, 0, &[], false, None).unwrap();
     assert!(
         !text.contains("not installed"),
         "[T-002] should have no 'not installed' note: {text}"
@@ -1690,7 +1690,7 @@ fn t003_search_with_backend_unavailable_shows_note() {
     );
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
 
-    let text = y.search("button", 10, 0, &[], false).unwrap();
+    let text = y.search(Some("button"), 10, 0, &[], false, None).unwrap();
     assert!(
         text.contains("unavailable"),
         "[T-003] expected BackendUnavailable note in results: {text}"
@@ -1710,7 +1710,7 @@ fn t004_search_with_probe_failed_shows_note() {
     );
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
 
-    let text = y.search("button", 10, 0, &[], false).unwrap();
+    let text = y.search(Some("button"), 10, 0, &[], false, None).unwrap();
     assert!(
         text.contains("unavailable"),
         "[T-004] expected ProbeFailed note in results: {text}"
@@ -1742,7 +1742,7 @@ fn t009_disabled_no_user_note_in_search() {
     );
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
 
-    let text = y.search("button", 10, 0, &[], false).unwrap();
+    let text = y.search(Some("button"), 10, 0, &[], false, None).unwrap();
     assert!(
         !text.contains("not installed"),
         "[T-009] should not show 'not installed' when disabled: {text}"
@@ -1793,7 +1793,7 @@ fn json_notes_present_when_degraded() {
     let y = Yomu::for_test(conn, dir.path().to_path_buf(), None);
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
 
-    let json = y.search("card", 10, 0, &[], true).unwrap();
+    let json = y.search(Some("card"), 10, 0, &[], true, None).unwrap();
     let parsed = parse_json(&json);
     assert_eq!(parsed["degraded"], true);
     let notes = parsed["notes"]
@@ -1819,7 +1819,7 @@ fn json_notes_empty_via_search_with_ok_embedder() {
         Some(Arc::new(rurico::embed::MockEmbedder::default()) as Arc<dyn rurico::embed::Embed>),
     );
 
-    let json = y.search("nav", 10, 0, &[], true).unwrap();
+    let json = y.search(Some("nav"), 10, 0, &[], true, None).unwrap();
     let parsed = parse_json(&json);
     assert_eq!(parsed["degraded"], false, "should not be degraded: {json}");
     let notes = parsed["notes"]
@@ -1839,7 +1839,7 @@ fn json_notes_outcome_degraded_fallback() {
     );
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
 
-    let json = y.search("card", 10, 0, &[], true).unwrap();
+    let json = y.search(Some("card"), 10, 0, &[], true, None).unwrap();
     let parsed = parse_json(&json);
     assert_eq!(parsed["degraded"], true);
     let notes = parsed["notes"]
@@ -1868,7 +1868,7 @@ fn json_notes_backend_unavailable() {
     );
     indexer::run_chunk_only_index(Arc::clone(&y.conn), y.root.as_path()).unwrap();
 
-    let json = y.search("button", 10, 0, &[], true).unwrap();
+    let json = y.search(Some("button"), 10, 0, &[], true, None).unwrap();
     let parsed = parse_json(&json);
     assert_eq!(parsed["degraded"], true);
     let notes = parsed["notes"]
@@ -2078,5 +2078,136 @@ fn impact_json_with_symbol_refs() {
     assert!(
         refs.iter().any(|r| r == "src/A.tsx"),
         "should reference A.tsx: {json}"
+    );
+}
+
+// T-013: --from target with no stored embeddings → Ok (exit code 0)
+#[test]
+fn search_from_no_embeddings_returns_ok() {
+    let (y, _dir) = test_yomu();
+    {
+        let conn = y.conn.lock().unwrap();
+        storage::replace_file_chunks_only(
+            &conn,
+            "src/foo.rs",
+            &[storage::NewChunk {
+                chunk_type: &storage::ChunkType::RustFn,
+                name: Some("my_fn"),
+                content: "fn my_fn() {}",
+                start_line: 1,
+                end_line: 1,
+                parent_index: None,
+            }],
+            "hash1",
+            "",
+            &[],
+            None,
+        )
+        .unwrap();
+    }
+    let result = y.search(None, 10, 0, &[], false, Some("src/foo.rs"));
+    assert!(
+        result.is_ok(),
+        "expected Ok for no-embeddings case, got: {:?}",
+        result.unwrap_err()
+    );
+    let text = result.unwrap();
+    assert!(
+        text.contains("no stored embeddings"),
+        "expected no-stored-embeddings note, got: {text}"
+    );
+}
+
+// COV-1: search(query=None, from=None) → InvalidInput("query or --from is required")
+#[test]
+fn search_requires_query_or_from() {
+    let (y, _dir) = test_yomu();
+    let err = y.search(None, 10, 0, &[], false, None).unwrap_err();
+    assert!(
+        err.to_string().contains("query or --from"),
+        "expected invalid input, got: {err}"
+    );
+}
+
+// COV-2: --from rejects path traversal
+#[test]
+fn search_from_rejects_path_traversal() {
+    let (y, _dir) = test_yomu();
+    let err = y
+        .search(None, 10, 0, &[], false, Some("../../../etc/passwd"))
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("must be a relative path"),
+        "expected traversal error, got: {err}"
+    );
+}
+
+// T-017: integration — from-file search excludes source, returns ≤ limit
+#[test]
+fn search_from_file_integration() {
+    let (y, _dir) = test_yomu_with_files_and_embedder(
+        &[
+            ("src/a.rs", "pub fn alpha() { println!(\"hello\"); }"),
+            ("src/b.rs", "pub fn beta() { alpha(); }"),
+            ("src/c.rs", "pub fn gamma() { beta(); }"),
+        ],
+        Arc::new(rurico::embed::MockEmbedder::default()),
+    );
+
+    let text = y
+        .search(None, 5, 0, &[], false, Some("src/a.rs"))
+        .unwrap();
+    // Source file should not appear in results
+    assert!(
+        !text.contains("No results found"),
+        "expected results from from-file search: {text}"
+    );
+    assert!(
+        !text.contains("src/a.rs"),
+        "source file should be excluded from results: {text}"
+    );
+}
+
+// COV-5: --from + --path combination excludes files outside path prefix
+#[test]
+fn search_from_with_path_filter_excludes_other_dirs() {
+    let (y, _dir) = test_yomu_with_files_and_embedder(
+        &[
+            ("src/a.rs", "pub fn alpha() {}"),
+            ("src/b.rs", "pub fn beta() {}"),
+            ("lib/c.rs", "pub fn gamma() {}"),
+        ],
+        Arc::new(rurico::embed::MockEmbedder::default()),
+    );
+    let text = y
+        .search(None, 10, 0, &["src/".to_string()], false, Some("src/a.rs"))
+        .unwrap();
+    assert!(
+        !text.contains("lib/c.rs") && !text.contains("gamma"),
+        "lib/c.rs should be excluded by path filter: {text}"
+    );
+}
+
+// COV-8: --from with json=true returns valid JSON with "results" key
+#[test]
+fn search_from_json_output_has_results_key() {
+    let (y, _dir) = test_yomu_with_files_and_embedder(
+        &[
+            ("src/a.rs", "pub fn alpha() {}"),
+            ("src/b.rs", "pub fn beta() {}"),
+        ],
+        Arc::new(rurico::embed::MockEmbedder::default()),
+    );
+    let json = y
+        .search(None, 10, 0, &[], true, Some("src/a.rs"))
+        .unwrap();
+    let parsed = parse_json(&json);
+    assert!(
+        parsed.get("results").is_some(),
+        "expected 'results' key in JSON output, got: {json}"
+    );
+    assert!(
+        parsed["results"].is_array(),
+        "expected 'results' to be an array, got: {json}"
     );
 }


### PR DESCRIPTION
## 概要

`yomu search --from <file>[:<symbol>]` で、クエリ文字列なしにファイルまたはシンボルの保存済み埋め込みを使って類似検索できるようにする。再埋め込み不要でインデックス済みベクトルをそのまま検索クエリとして使う。

## 変更内容

- `--from` CLI フラグを追加し、`src/foo.rs` またはシンボル指定 `src/foo.rs:my_fn` の形式でファイル・シンボルを入力として受け付ける
- `vec_search_multi`: N 個のサブ埋め込みに対して MaxSim マージを行い、マルチチャンクファイルの類似度を正しく集約する
- `search_from_file` パイプラインを実装: KNN オーバーフェッチ → ソース除外 → FTS インターセクション（任意）→ 再ランク
- `QueryError` 列挙型を追加して `NoQuery` と `Io` エラーを分離し、I/O エラーの暗黙的な無視を防ぐ
- `search_by_fts` に `include_ids` パラメータを追加し KNN∩FTS インターセクションを実現する

## 設計判断

- **オーバーフェッチバッファ (P1)**: ソースファイル自身が KNN スロットを占有すると低 limit 時に結果が空になる問題を、オーバーフェッチ後に除外する方式で解決した
- **ストップワードガード (P2)**: FTS クエリがストップワードのみになると意味検索結果がゼロになる問題を、ストップワード専用クエリを事前に検出してスキップすることで回避した
- **サブ埋め込みの上限 (MAX_FROM_SUB_EMBEDDINGS = 20)**: 無制限なクエリベクトル数によるパフォーマンス劣化を防ぐ

## テスト方法

1. `yomu search --from src/main.rs` を実行し、`main.rs` に類似するファイルが返ること
2. `yomu search --from src/main.rs:main` を実行し、`main` 関数に類似するシンボルが返ること
3. limit が小さい場合 (`--limit 1`) にソースファイル自身が結果に含まれないこと
4. FTS がストップワードのみになるクエリで結果が空にならないこと

## 関連

- Closes #77