### PR TITLE
search pipeline のエラーパス・境界テスト追加

### DIFF
--- a/src/query/tests.rs
+++ b/src/query/tests.rs
@@ -2034,3 +2034,69 @@ fn search_from_file_stopword_query_falls_back_to_semantic() {
         "stopword-only query should return semantic results, not []"
     );
 }
+
+// === TC-1: keyword_hit_ratio IDF-weighted branch ===
+
+#[test]
+fn keyword_hit_ratio_uses_idf_weights() {
+    let result = storage::SearchResult {
+        chunk: storage::Chunk {
+            file_path: "src/auth.ts".to_string(),
+            chunk_type: storage::ChunkType::Other,
+            name: Some("authenticate".to_string()),
+            content: "function authenticate() {}".to_string(),
+            start_line: 1,
+            end_line: 1,
+            parent_chunk_id: None,
+        },
+        chunk_id: None,
+        distance: f32::INFINITY,
+        match_source: storage::MatchSource::Fts,
+        score: 0.0,
+    };
+    let keywords = vec!["auth".to_string(), "form".to_string()];
+    let idfs = [1.0_f32, 2.0_f32];
+    // "auth" matches name "authenticate" (contains "auth"); "form" does not match.
+    // total_idf = 3.0 >= 1e-6 → IDF-weighted branch executes.
+    // hit_idf = 1.0, total_idf = 3.0 → expected ratio = 1.0/3.0.
+    let ratio = keyword_hit_ratio(&result, &keywords, &idfs, false);
+    let expected = 1.0_f32 / 3.0;
+    assert!(
+        (ratio - expected).abs() < 1e-5,
+        "[TC-1] IDF-weighted branch: expected {expected:.6}, got {ratio:.6}"
+    );
+}
+
+// === TC-5: search_pipeline offset boundary ===
+
+#[test]
+fn search_pipeline_offset_beyond_results_returns_empty() {
+    let (conn, _dir) = from_test_db();
+
+    for (i, name) in ["WidgetA", "WidgetB"].iter().enumerate() {
+        storage::replace_file_chunks_only(
+            &conn,
+            &format!("src/{name}.tsx"),
+            &[storage::NewChunk {
+                chunk_type: &storage::ChunkType::Component,
+                name: Some(name),
+                content: &format!("function {name}() {{ return <div/>; }}"),
+                start_line: 1,
+                end_line: 1,
+                parent_index: None,
+            }],
+            &format!("h{i}"),
+            "",
+            &[],
+            None,
+        )
+        .unwrap();
+    }
+
+    // offset=10 exceeds the 2-result set → empty Vec expected.
+    let results = search_pipeline(&conn, "widget", None, 10, 10, None, &[]).unwrap();
+    assert!(
+        results.is_empty(),
+        "[TC-5] offset >= results.len() should return empty Vec, got: {results:?}"
+    );
+}

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -127,7 +127,10 @@ pub fn search_by_fts(
         .iter()
         .filter_map(|k| match rurico::storage::prepare_match_query(conn, k) {
             Ok(m) if !m.as_str().is_empty() => Some(m.into_string()),
-            Err(_) if !k.trim().is_empty() => Some(rurico::storage::fts_quote(k)),
+            Err(e) if !k.trim().is_empty() => {
+                tracing::debug!(keyword = %k, error = %e, "prepare_match_query failed, falling back to fts_quote");
+                Some(rurico::storage::fts_quote(k))
+            }
             _ => None,
         })
         .collect();

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -3098,3 +3098,39 @@ fn vec_search_multi_returns_union() {
     assert!(names.contains(&"fn_a"));
     assert!(names.contains(&"fn_b"));
 }
+
+// === SF-3: FTS prefix query fallback ===
+
+#[test]
+fn search_by_fts_fallback_to_quoted_literal_on_sanitize_error() {
+    let (conn, _dir) = test_db();
+
+    // Insert a chunk with "NOT" as a standalone word in content.
+    // FTS5 unicode61 tokenizer splits on whitespace → "not" token exists in the index.
+    replace_file_chunks_only(
+        &conn,
+        "src/guard.ts",
+        &[NewChunk {
+            chunk_type: &ChunkType::Other,
+            name: Some("shouldNotCall"),
+            content: "do NOT call this function directly",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        }],
+        "h1",
+        "",
+        &[],
+        None,
+    )
+    .unwrap();
+
+    // "NOT" is an FTS5 operator → sanitize_fts_query returns NoSearchableTerms.
+    // search_by_fts must fall back to fts_quote("NOT") = "\"NOT\"" and still find the chunk.
+    let results = search_by_fts(&conn, &["NOT"], None, &HashSet::new(), None, 10, &[])
+        .expect("fts fallback should succeed without error");
+    assert!(
+        !results.is_empty(),
+        "[SF-3] fts_quote fallback should find content containing 'NOT', got empty"
+    );
+}


### PR DESCRIPTION
## 概要

search pipeline にテストされていなかった 3 つのパス（FTS フォールバック、IDF 重み付きブランチ、offset 境界）を網羅するユニットテストを追加する。
これにより、回帰が発生したときに検出可能になる。

## 変更内容

- `src/storage/search.rs`: `prepare_match_query` 失敗時のフォールバックパスに `tracing::debug!` ログを追加 — フォールバック発生をサイレントでなく観測可能にするため
- `src/storage/tests.rs`: SF-3 テスト追加 — FTS キーワードが FTS5 演算子（`NOT` など）のとき `fts_quote` にフォールバックしてチャンクが取得できることを検証
- `src/query/tests.rs`: TC-1 テスト追加 — `idfs` が非空の場合に IDF 重み付きブランチが正しい比率を返すことを検証；TC-5 テスト追加 — `offset >= results.len()` のとき空の `Vec` が返ることを検証

## スコープ

- **対象外**: FTS フォールバックのエラー種別ごとの挙動変更（本 PR はログ追加のみ）

## 設計判断

- `tracing::debug!` を選択 — フォールバックは異常ではなくフォールバックが意図した動作のため、`warn!` より `debug!` が適切

## テスト方法

1. `cargo test search_by_fts_fallback_to_quoted_literal_on_sanitize_error` — pass
2. `cargo test keyword_hit_ratio_uses_idf_weights` — pass
3. `cargo test search_pipeline_offset_beyond_results_returns_empty` — pass

## 関連

- Closes #47