### PR TITLE
impact コマンドに --semantic フラグを追加（構造依存 + embedding 複合分析）

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,9 @@ enum Command {
         /// Max traversal depth (default: 3)
         #[arg(long, default_value_t = 3, value_parser = clap::value_parser!(u32).range(0..=MAX_IMPACT_DEPTH as i64))]
         depth: u32,
+        /// Include semantically related files via embedding search (in addition to import graph)
+        #[arg(long)]
+        semantic: bool,
     },
     /// Show index statistics.
     Status,
@@ -218,7 +221,8 @@ fn main() -> ExitCode {
             target,
             symbol,
             depth,
-        } => yomu.impact(&target, symbol.as_deref(), depth, json),
+            semantic,
+        } => yomu.impact(&target, symbol.as_deref(), depth, json, semantic),
         Command::Status => yomu.status(json),
         Command::Model { .. } => unreachable!("handled before Yomu::new()"),
     };
@@ -515,6 +519,33 @@ mod tests {
                 assert_eq!(from.as_deref(), Some("src/foo.rs"));
             }
             other => panic!("expected Search, got {other:?}"),
+        }
+    }
+
+    // T-078: --semantic flag on impact parses to semantic=true
+    #[test]
+    fn impact_semantic_flag_parses() {
+        let cli = parse_cli_args(["yomu", "impact", "src/foo.rs", "--semantic"]).unwrap();
+        match cli.command.unwrap() {
+            Command::Impact {
+                target, semantic, ..
+            } => {
+                assert_eq!(target, "src/foo.rs");
+                assert!(semantic, "expected semantic=true");
+            }
+            other => panic!("expected Impact, got {other:?}"),
+        }
+    }
+
+    // T-079: impact without --semantic defaults to semantic=false
+    #[test]
+    fn impact_no_semantic_flag_defaults_false() {
+        let cli = parse_cli_args(["yomu", "impact", "src/foo.rs"]).unwrap();
+        match cli.command.unwrap() {
+            Command::Impact { semantic, .. } => {
+                assert!(!semantic, "expected semantic=false by default");
+            }
+            other => panic!("expected Impact, got {other:?}"),
         }
     }
 

--- a/src/tools/format.rs
+++ b/src/tools/format.rs
@@ -58,9 +58,21 @@ pub(super) fn format_dependents_by_depth(
     }
 }
 
-pub(super) fn format_impact_all(target: &str, dependents: &[storage::Dependent]) -> String {
+pub(super) fn format_impact_all(
+    target: &str,
+    dependents: &[storage::Dependent],
+    semantic_related: &[storage::SearchResult],
+) -> String {
     let mut output = format!("## Impact analysis: `{}`\n\n", target);
-    format_dependents_by_depth(&mut output, dependents, "###");
+
+    if semantic_related.is_empty() {
+        format_dependents_by_depth(&mut output, dependents, "###");
+    } else {
+        output.push_str("### Structural dependents (import graph)\n");
+        format_dependents_by_depth(&mut output, dependents, "####");
+        format_semantic_section(&mut output, semantic_related);
+    }
+
     output.push_str(&format!(
         "\nTotal: {} dependent file(s)\n",
         dependents.len()
@@ -72,6 +84,7 @@ pub(super) fn format_impact_results(
     target: &str,
     symbol_refs: &[String],
     all_dependents: &[storage::Dependent],
+    semantic_related: &[storage::SearchResult],
 ) -> String {
     let mut output = format!("## Impact analysis: `{}`\n\n", target);
 
@@ -84,11 +97,26 @@ pub(super) fn format_impact_results(
 
     output.push_str("\n### All transitive dependents\n");
     format_dependents_by_depth(&mut output, all_dependents, "####");
+
+    if !semantic_related.is_empty() {
+        format_semantic_section(&mut output, semantic_related);
+    }
+
     output.push_str(&format!(
         "\nTotal: {} dependent file(s)\n",
         all_dependents.len()
     ));
     output
+}
+
+fn format_semantic_section(output: &mut String, semantic_related: &[storage::SearchResult]) {
+    output.push_str("\n### Semantic related (embedding search)\n");
+    for r in semantic_related {
+        output.push_str(&format!(
+            "- {} (similarity: {:.2})\n",
+            r.chunk.file_path, r.score
+        ));
+    }
 }
 
 pub(super) fn format_results_grouped(
@@ -303,11 +331,19 @@ struct JsonDependent<'a> {
 }
 
 #[derive(Serialize)]
+struct JsonSemanticRelated<'a> {
+    file_path: &'a str,
+    score: f32,
+}
+
+#[derive(Serialize)]
 struct JsonImpactResult<'a> {
     target: &'a str,
     in_index: bool,
     dependents: Vec<JsonDependent<'a>>,
     symbol_refs: &'a [String],
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    semantic_related: Vec<JsonSemanticRelated<'a>>,
     total: usize,
 }
 
@@ -316,6 +352,7 @@ pub(super) fn format_impact_json(
     file_in_index: bool,
     dependents: &[storage::Dependent],
     symbol_refs: &[String],
+    semantic_related: &[storage::SearchResult],
 ) -> String {
     let deps: Vec<JsonDependent> = dependents
         .iter()
@@ -324,11 +361,19 @@ pub(super) fn format_impact_json(
             depth: d.depth,
         })
         .collect();
+    let sem: Vec<JsonSemanticRelated> = semantic_related
+        .iter()
+        .map(|r| JsonSemanticRelated {
+            file_path: &r.chunk.file_path,
+            score: r.score,
+        })
+        .collect();
     let resp = JsonImpactResult {
         target,
         in_index: file_in_index,
         dependents: deps,
         symbol_refs,
+        semantic_related: sem,
         total: dependents.len(),
     };
     serde_json::to_string(&resp).unwrap()

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -24,6 +24,8 @@ use format::{
     format_status_json,
 };
 
+const SEMANTIC_THRESHOLD: f32 = 0.7;
+
 const INDEX_FRESHNESS_SECS: u32 = 60;
 const MAX_QUERY_LENGTH: usize = 2000;
 
@@ -338,6 +340,7 @@ impl Yomu {
         symbol: Option<&str>,
         depth: u32,
         json: bool,
+        semantic: bool,
     ) -> Result<String, YomuError> {
         if target.is_empty() {
             return Err(YomuError::InvalidInput("target must not be empty".into()));
@@ -357,6 +360,17 @@ impl Yomu {
 
         let symbol_filter = symbol.or(parsed_symbol);
         let max_depth = depth.min(MAX_IMPACT_DEPTH);
+        // Clone for semantic path before moving into first closure
+        let fp_sem = if semantic {
+            Some(file_path.to_string())
+        } else {
+            None
+        };
+        let sym_sem = if semantic {
+            symbol_filter.map(|s| s.to_string())
+        } else {
+            None
+        };
         let fp = file_path.to_string();
         let sym_owned = symbol_filter.map(|s| s.to_string());
 
@@ -370,16 +384,48 @@ impl Yomu {
             Ok((exists, dependents, refs))
         })?;
 
+        let semantic_related: Vec<storage::SearchResult> = if semantic {
+            let embedder = self.get_embedder();
+            let state = determine_index_state(&stats);
+            self.ensure_indexed(embedder, state, None)?;
+
+            let fp_for_emb = fp_sem.unwrap();
+            let sym_for_emb = sym_sem;
+            let (chunk_ids, embedding_bytes) = self.with_db(move |c| {
+                let ids =
+                    storage::get_chunks_for_from_target(c, &fp_for_emb, sym_for_emb.as_deref())?;
+                let raw = storage::get_sub_embeddings_for_chunks(c, &ids)?;
+                let bytes: Vec<Vec<u8>> = raw.into_iter().map(|(_, b)| b).collect();
+                Ok((ids, bytes))
+            })?;
+
+            if embedding_bytes.is_empty() {
+                vec![]
+            } else {
+                let source_ids: HashSet<i64> = chunk_ids.into_iter().collect();
+                let mut results = self.with_db(|conn| {
+                    query::search_from_file(conn, &embedding_bytes, &source_ids, None, 20, &[])
+                })?;
+                results.retain(|r| r.score >= SEMANTIC_THRESHOLD);
+                let mut seen: HashSet<String> = HashSet::new();
+                results.retain(|r| seen.insert(r.chunk.file_path.clone()));
+                results
+            }
+        } else {
+            vec![]
+        };
+
         if json {
             return Ok(format_impact_json(
                 target,
                 file_in_index,
                 &dependents,
                 &symbol_refs,
+                &semantic_related,
             ));
         }
 
-        if dependents.is_empty() {
+        if dependents.is_empty() && semantic_related.is_empty() {
             return Ok(if file_in_index {
                 format!("No dependents found for `{}`.", target)
             } else {
@@ -391,9 +437,9 @@ impl Yomu {
         }
 
         let text = if symbol_filter.is_some() {
-            format_impact_results(target, &symbol_refs, &dependents)
+            format_impact_results(target, &symbol_refs, &dependents, &semantic_related)
         } else {
-            format_impact_all(target, &dependents)
+            format_impact_all(target, &dependents, &semantic_related)
         };
 
         Ok(text)

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -360,17 +360,6 @@ impl Yomu {
 
         let symbol_filter = symbol.or(parsed_symbol);
         let max_depth = depth.min(MAX_IMPACT_DEPTH);
-        // Clone for semantic path before moving into first closure
-        let fp_sem = if semantic {
-            Some(file_path.to_string())
-        } else {
-            None
-        };
-        let sym_sem = if semantic {
-            symbol_filter.map(|s| s.to_string())
-        } else {
-            None
-        };
         let fp = file_path.to_string();
         let sym_owned = symbol_filter.map(|s| s.to_string());
 
@@ -384,33 +373,9 @@ impl Yomu {
             Ok((exists, dependents, refs))
         })?;
 
-        let semantic_related: Vec<storage::SearchResult> = if semantic {
-            let embedder = self.get_embedder();
+        let semantic_related = if semantic {
             let state = determine_index_state(&stats);
-            self.ensure_indexed(embedder, state, None)?;
-
-            let fp_for_emb = fp_sem.unwrap();
-            let sym_for_emb = sym_sem;
-            let (chunk_ids, embedding_bytes) = self.with_db(move |c| {
-                let ids =
-                    storage::get_chunks_for_from_target(c, &fp_for_emb, sym_for_emb.as_deref())?;
-                let raw = storage::get_sub_embeddings_for_chunks(c, &ids)?;
-                let bytes: Vec<Vec<u8>> = raw.into_iter().map(|(_, b)| b).collect();
-                Ok((ids, bytes))
-            })?;
-
-            if embedding_bytes.is_empty() {
-                vec![]
-            } else {
-                let source_ids: HashSet<i64> = chunk_ids.into_iter().collect();
-                let mut results = self.with_db(|conn| {
-                    query::search_from_file(conn, &embedding_bytes, &source_ids, None, 20, &[])
-                })?;
-                results.retain(|r| r.score >= SEMANTIC_THRESHOLD);
-                let mut seen: HashSet<String> = HashSet::new();
-                results.retain(|r| seen.insert(r.chunk.file_path.clone()));
-                results
-            }
+            self.semantic_search(file_path, symbol_filter, state)?
         } else {
             vec![]
         };
@@ -588,6 +553,35 @@ impl Yomu {
             return Ok(std::collections::HashMap::new());
         }
         self.with_db(move |conn| storage::get_chunks_by_ids(conn, &parent_ids))
+    }
+
+    fn semantic_search(
+        &self,
+        file_path: &str,
+        symbol: Option<&str>,
+        state: IndexState,
+    ) -> Result<Vec<storage::SearchResult>, YomuError> {
+        let embedder = self.get_embedder();
+        self.ensure_indexed(embedder, state, None)?;
+
+        let fp = file_path.to_string();
+        let sym = symbol.map(|s| s.to_string());
+        let mut results = self.with_db(move |c| {
+            let ids = storage::get_chunks_for_from_target(c, &fp, sym.as_deref())?;
+            let bytes: Vec<Vec<u8>> = storage::get_sub_embeddings_for_chunks(c, &ids)?
+                .into_iter()
+                .map(|(_, b)| b)
+                .collect();
+            if bytes.is_empty() {
+                return Ok(vec![]);
+            }
+            let source_ids: HashSet<i64> = ids.into_iter().collect();
+            query::search_from_file(c, &bytes, &source_ids, None, 20, &[])
+        })?;
+        results.retain(|r| r.score >= SEMANTIC_THRESHOLD);
+        let mut seen: HashSet<String> = HashSet::new();
+        results.retain(|r| seen.insert(r.chunk.file_path.clone()));
+        Ok(results)
     }
 
     fn with_db<T, F>(&self, f: F) -> Result<T, YomuError>

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -813,7 +813,9 @@ fn impact_lists_dependents() {
         .unwrap();
     }
 
-    let text = y.impact("src/hooks/useAuth.ts", None, 3, false).unwrap();
+    let text = y
+        .impact("src/hooks/useAuth.ts", None, 3, false, false)
+        .unwrap();
     assert!(text.contains("src/A.tsx"), "expected A.tsx: {text}");
     assert!(text.contains("src/C.tsx"), "expected C.tsx: {text}");
     assert!(
@@ -857,7 +859,7 @@ fn impact_filters_by_symbol() {
     }
 
     let text = y
-        .impact("src/hooks/useAuth.ts:useAuth", None, 3, false)
+        .impact("src/hooks/useAuth.ts:useAuth", None, 3, false, false)
         .unwrap();
     assert!(
         text.contains("Direct symbol references"),
@@ -872,7 +874,7 @@ fn impact_filters_by_symbol() {
 #[test]
 fn impact_rejects_empty_target() {
     let (y, _dir) = test_yomu();
-    let err = y.impact("", None, 3, false).unwrap_err();
+    let err = y.impact("", None, 3, false, false).unwrap_err();
     assert!(
         err.to_string().contains("empty"),
         "expected empty error, got: {err}"
@@ -882,7 +884,7 @@ fn impact_rejects_empty_target() {
 #[test]
 fn impact_errors_on_empty_index() {
     let (y, _dir) = test_yomu();
-    let err = y.impact("src/A.tsx", None, 3, false).unwrap_err();
+    let err = y.impact("src/A.tsx", None, 3, false, false).unwrap_err();
     assert!(
         err.to_string().contains("index is empty"),
         "expected empty index error, got: {err}"
@@ -896,7 +898,9 @@ fn impact_distinguishes_missing_file() {
         let conn = y.conn.lock().unwrap();
         seed_index(&conn);
     }
-    let text = y.impact("src/nonexistent.tsx", None, 3, false).unwrap();
+    let text = y
+        .impact("src/nonexistent.tsx", None, 3, false, false)
+        .unwrap();
     assert!(
         text.contains("not found in index"),
         "expected file-not-found message: {text}"
@@ -910,7 +914,9 @@ fn impact_rejects_path_traversal() {
         let conn = y.conn.lock().unwrap();
         seed_index(&conn);
     }
-    let err = y.impact("../etc/passwd", None, 3, false).unwrap_err();
+    let err = y
+        .impact("../etc/passwd", None, 3, false, false)
+        .unwrap_err();
     assert!(
         err.to_string().contains(".."),
         "expected path traversal error, got: {err}"
@@ -924,7 +930,7 @@ fn impact_rejects_absolute_path() {
         let conn = y.conn.lock().unwrap();
         seed_index(&conn);
     }
-    let err = y.impact("/etc/passwd", None, 3, false).unwrap_err();
+    let err = y.impact("/etc/passwd", None, 3, false, false).unwrap_err();
     assert!(
         err.to_string().contains("relative"),
         "expected rejection of absolute path, got: {err}"
@@ -967,6 +973,7 @@ fn impact_symbol_flag_overrides_colon_syntax() {
             Some("AuthProvider"),
             3,
             false,
+            false,
         )
         .unwrap();
     assert!(
@@ -997,7 +1004,7 @@ fn integration_index_then_impact() {
     )
     .unwrap();
 
-    let text = y.impact("src/C.tsx", None, 3, false).unwrap();
+    let text = y.impact("src/C.tsx", None, 3, false, false).unwrap();
     assert!(
         text.contains("src/B.tsx"),
         "expected B.tsx as direct dependent: {text}"
@@ -2034,7 +2041,9 @@ fn impact_json_with_dependents() {
         .unwrap();
     }
 
-    let json = y.impact("src/hooks/useAuth.ts", None, 3, true).unwrap();
+    let json = y
+        .impact("src/hooks/useAuth.ts", None, 3, true, false)
+        .unwrap();
     let parsed = parse_json(&json);
     assert_eq!(parsed["target"], "src/hooks/useAuth.ts");
     assert_eq!(
@@ -2057,7 +2066,9 @@ fn impact_json_not_in_index() {
         seed_index(&conn);
     }
 
-    let json = y.impact("src/nonexistent.tsx", None, 3, true).unwrap();
+    let json = y
+        .impact("src/nonexistent.tsx", None, 3, true, false)
+        .unwrap();
     let parsed = parse_json(&json);
     assert_eq!(parsed["in_index"], false);
     assert_eq!(parsed["total"], 0);
@@ -2098,7 +2109,7 @@ fn impact_json_with_symbol_refs() {
     }
 
     let json = y
-        .impact("src/hooks/useAuth.ts:useAuth", None, 3, true)
+        .impact("src/hooks/useAuth.ts:useAuth", None, 3, true, false)
         .unwrap();
     let parsed = parse_json(&json);
     let refs = parsed["symbol_refs"]
@@ -2107,6 +2118,78 @@ fn impact_json_with_symbol_refs() {
     assert!(
         refs.iter().any(|r| r == "src/A.tsx"),
         "should reference A.tsx: {json}"
+    );
+}
+
+// T-078: --semantic with no stored embeddings returns empty semantic_related
+#[test]
+fn impact_semantic_no_embeddings_returns_empty() {
+    let (y, _dir) = test_yomu();
+    {
+        let conn = y.conn.lock().unwrap();
+        seed_index(&conn);
+        storage::replace_file_references(
+            &conn,
+            "src/A.tsx",
+            &[storage::Reference {
+                source_file: "src/A.tsx".into(),
+                target_file: "src/hooks/useAuth.ts".into(),
+                symbol_name: Some("useAuth".into()),
+                ref_kind: storage::RefKind::Named,
+            }],
+        )
+        .unwrap();
+    }
+
+    // no stored embeddings for the target → semantic_related is empty, structural still works
+    let text = y
+        .impact("src/hooks/useAuth.ts", None, 3, false, true)
+        .unwrap();
+    assert!(
+        text.contains("src/A.tsx"),
+        "structural dependents should still appear: {text}"
+    );
+    assert!(
+        !text.contains("Semantic related"),
+        "no semantic section expected when embeddings are absent: {text}"
+    );
+}
+
+// T-079: --semantic JSON output omits semantic_related when empty
+#[test]
+fn impact_semantic_json_field_absent_when_empty() {
+    let (y, _dir) = test_yomu();
+    {
+        let conn = y.conn.lock().unwrap();
+        seed_index(&conn);
+    }
+
+    let json = y
+        .impact("src/hooks/useAuth.ts", None, 3, true, true)
+        .unwrap();
+    let parsed = parse_json(&json);
+    assert!(
+        parsed.get("semantic_related").is_none(),
+        "semantic_related should be absent when empty: {json}"
+    );
+}
+
+// T-079b: --semantic=false JSON output never has semantic_related
+#[test]
+fn impact_no_semantic_json_field_absent() {
+    let (y, _dir) = test_yomu();
+    {
+        let conn = y.conn.lock().unwrap();
+        seed_index(&conn);
+    }
+
+    let json = y
+        .impact("src/hooks/useAuth.ts", None, 3, true, false)
+        .unwrap();
+    let parsed = parse_json(&json);
+    assert!(
+        parsed.get("semantic_related").is_none(),
+        "semantic_related should be absent without --semantic: {json}"
     );
 }
 


### PR DESCRIPTION
## 概要

- `yomu impact` に `--semantic` フラグを追加し、import グラフによる構造的依存に加えて embedding 検索による意味的関連ファイルを同時出力
- 類似度しきい値 0.7、上位 20 件でベクトル検索し、ファイル単位で重複排除
- テキスト・JSON 双方の出力に対応。JSON は `semantic_related` フィールドが空のとき `skip_serializing_if` で省略し後方互換を維持

Closes #78

## 変更内容

| ファイル | 変更 |
|---|---|
| `src/main.rs` | `--semantic` フラグを clap に追加。CLI パーステスト T-078/T-079 を追加 |
| `src/tools/mod.rs` | `impact()` に embedding 検索分岐を実装。`with_db` クロージャ分割パターンで構造クエリ → `ensure_indexed` → embedding クエリ |
| `src/tools/format.rs` | `format_impact_all` / `format_impact_results` / `format_impact_json` を拡張。`format_semantic_section` ヘルパー追加 |
| `src/tools/tests.rs` | 既存 12 call site に `semantic` 引数追加。新規テスト 3 件（no-embeddings / JSON field absent when empty / JSON field absent without --semantic） |

## テスト計画

- [ ] `cargo test` が全件パスすること
- [ ] `yomu impact <file> --semantic` でテキスト出力に構造的依存 + 意味的関連セクションが両方表示されること
- [ ] `yomu impact <file> --semantic --json` で `semantic_related` フィールドが出力されること
- [ ] `yomu impact <file>` （`--semantic` なし）で出力・JSON が従来と同一であること
- [ ] embedding 未インデックスのファイルで `--semantic` 指定時にクラッシュせず空セクションが返ること