### PR TITLE
is_test_pathのパラメータ化テストを追加

### DIFF
--- a/src/query/tests.rs
+++ b/src/query/tests.rs
@@ -2132,6 +2132,9 @@ fn is_test_path_returns_false_for_source_files() {
         "src/query/mod.rs",
     ];
     for path in cases {
-        assert!(!is_test_path(path), "expected is_test_path false for: {path}");
+        assert!(
+            !is_test_path(path),
+            "expected is_test_path false for: {path}"
+        );
     }
 }

--- a/src/query/tests.rs
+++ b/src/query/tests.rs
@@ -2100,3 +2100,38 @@ fn search_pipeline_offset_beyond_results_returns_empty() {
         "[TC-5] offset >= results.len() should return empty Vec, got: {results:?}"
     );
 }
+
+// === is_test_path pattern coverage ===
+
+#[test]
+fn is_test_path_returns_true_for_all_patterns() {
+    let cases = [
+        "src/__tests__/foo.ts",
+        "src/__mocks__/foo.ts",
+        "src/__fixtures__/foo.ts",
+        "src/foo.test.ts",
+        "src/foo.spec.ts",
+        "src/foo.stories.ts",
+        "src/test/foo.ts",
+        "test/foo.ts",
+        "src/examples/foo.ts",
+        "examples/foo.ts",
+        "src/fixtures/foo.ts",
+        "src/e2e/foo.ts",
+    ];
+    for path in cases {
+        assert!(is_test_path(path), "expected is_test_path true for: {path}");
+    }
+}
+
+#[test]
+fn is_test_path_returns_false_for_source_files() {
+    let cases = [
+        "src/components/Button.tsx",
+        "src/utils/helpers.ts",
+        "src/query/mod.rs",
+    ];
+    for path in cases {
+        assert!(!is_test_path(path), "expected is_test_path false for: {path}");
+    }
+}


### PR DESCRIPTION
## 概要

- `is_test_path` 関数に対するパラメータ化テストを追加
- `is_test_path_returns_true_for_all_patterns`: `__tests__`、`__mocks__`、`__fixtures__`、`.test.`、`.spec.`、`.stories.`、`/test/`、`test/`、`/examples/`、`examples/`、`/fixtures/`、`/e2e/` の 12 パターンを網羅
- `is_test_path_returns_false_for_source_files`: 通常のソースファイルパス 3 件で偽陰性がないことを確認

Closes #48

## テスト計画

- [ ] `cargo test` がすべてパスすること
- [ ] `is_test_path_returns_true_for_all_patterns` の 12 ケースが全件 `true` を返すこと
- [ ] `is_test_path_returns_false_for_source_files` の 3 ケースが全件 `false` を返すこと