### PR TITLE
SIGINT中断時のhf-hubダウンロード安全性をドキュメント化

### DIFF
--- a/src/tools/embedder.rs
+++ b/src/tools/embedder.rs
@@ -103,6 +103,13 @@ pub(super) fn parse_auto_download(value: Option<&str>) -> bool {
     }
 }
 
+/// Load the embedding model, downloading it if `YOMU_AUTO_DOWNLOAD_MODEL=1`.
+///
+/// # Interruption Safety
+///
+/// If a download is interrupted (e.g. SIGINT), hf-hub leaves only a `.part`
+/// file in the cache and no corrupted blob is written. The next call detects no
+/// cached artifacts and retries the download cleanly.
 fn try_load_embedder(disabled: bool) -> Result<Arc<dyn Embed>, DegradedReason> {
     if disabled {
         tracing::info!("Embedding disabled via YOMU_EMBED=0");


### PR DESCRIPTION
closes #62

## 背景

Issue #62 は、SIGINT（Ctrl+C）でダウンロードが中断された場合にhf-hubのキャッシュが汚染されるリスクを懸念していた。

## 調査結果

hf-hub 0.5.0 のソースを調査した結果、ダウンロードは `.part` 一時ファイルへの書き込み後に `std::fs::rename` でアトミックに確定する実装になっていることを確認した（POSIX上でアトミック）。

- 中断時はキャッシュに `.part` ファイルのみ残り、不完全なblobは書き込まれない
- 次回起動時にキャッシュ済みアーティファクトが検出されず、ダウンロードが再試行される
- コードの修正は不要

## 変更内容

`try_load_embedder` 関数に `# Interruption Safety` セクションを追記し、上記の安全性を文書化した。

## 関連

ruricoリポジトリの `model_io.rs::download_artifacts` にも同様のドキュメントを追加（companion change）。