### PR TITLE
extract_keywordsのstemming抽出とstem_keyword純粋関数化

### DIFF
--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -48,7 +48,7 @@ const S_DENY: &[&str] = &[
     "express", "progress",
 ];
 
-fn stem_keyword(kw: &str, seen: &HashSet<String>) -> Option<String> {
+fn stem_keyword(kw: &str) -> Option<&str> {
     let stem = if kw.len() > 5 && kw.ends_with("ing") && !ING_DENY.contains(&kw) {
         Some(&kw[..kw.len() - 3])
     } else if kw.len() > 3 && kw.ends_with('s') && !kw.ends_with("ss") && !S_DENY.contains(&kw) {
@@ -56,8 +56,7 @@ fn stem_keyword(kw: &str, seen: &HashSet<String>) -> Option<String> {
     } else {
         None
     };
-    stem.filter(|s| s.len() >= 2 && !seen.contains(*s))
-        .map(|s| s.to_string())
+    stem.filter(|s| s.len() >= 2)
 }
 
 pub fn extract_keywords(query: &str) -> Vec<String> {
@@ -84,7 +83,9 @@ pub fn extract_keywords(query: &str) -> Vec<String> {
 
     let stems: Vec<String> = base
         .iter()
-        .filter_map(|kw| stem_keyword(kw, &seen))
+        .filter_map(|kw| stem_keyword(kw))
+        .filter(|s| !seen.contains(*s))
+        .map(|s| s.to_string())
         .collect();
     let mut all = base;
     for s in stems {

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -25,6 +25,41 @@ const STOP_WORDS: &[&str] = &["the", "a", "an", "in", "for", "of", "with", "and"
 
 use crate::text::split_identifier;
 
+// Words ending in -ing that are not gerunds (stripping -ing produces a non-word).
+const ING_DENY: &[&str] = &[
+    "string",
+    "bring",
+    "thing",
+    "nothing",
+    "something",
+    "everything",
+    "ring",
+    "king",
+    "spring",
+    "swing",
+    "sing",
+    "sting",
+    "wing",
+];
+
+// Words ending in -s that are not plurals (stripping -s produces a non-word).
+const S_DENY: &[&str] = &[
+    "class", "this", "alias", "canvas", "focus", "status", "bus", "process", "address", "access",
+    "express", "progress",
+];
+
+fn stem_keyword(kw: &str, seen: &HashSet<String>) -> Option<String> {
+    let stem = if kw.len() > 5 && kw.ends_with("ing") && !ING_DENY.contains(&kw) {
+        Some(&kw[..kw.len() - 3])
+    } else if kw.len() > 3 && kw.ends_with('s') && !kw.ends_with("ss") && !S_DENY.contains(&kw) {
+        Some(&kw[..kw.len() - 1])
+    } else {
+        None
+    };
+    stem.filter(|s| s.len() >= 2 && !seen.contains(*s))
+        .map(|s| s.to_string())
+}
+
 pub fn extract_keywords(query: &str) -> Vec<String> {
     let mut base: Vec<String> = Vec::new();
     let mut seen: HashSet<String> = HashSet::new();
@@ -47,45 +82,9 @@ pub fn extract_keywords(query: &str) -> Vec<String> {
         }
     }
 
-    // Words ending in -ing that are not gerunds (stripping -ing produces a non-word or keyword).
-    const ING_DENY: &[&str] = &[
-        "string",
-        "bring",
-        "thing",
-        "nothing",
-        "something",
-        "everything",
-        "ring",
-        "king",
-        "spring",
-        "swing",
-        "sing",
-        "sting",
-        "wing",
-    ];
-    // Words ending in -s that are not plurals (stripping -s produces a non-word).
-    const S_DENY: &[&str] = &[
-        "class", "this", "alias", "canvas", "focus", "status", "bus", "process", "address",
-        "access", "express", "progress",
-    ];
-
     let stems: Vec<String> = base
         .iter()
-        .filter_map(|kw| {
-            let stem = if kw.len() > 5 && kw.ends_with("ing") && !ING_DENY.contains(&kw.as_str()) {
-                Some(&kw[..kw.len() - 3])
-            } else if kw.len() > 3
-                && kw.ends_with('s')
-                && !kw.ends_with("ss")
-                && !S_DENY.contains(&kw.as_str())
-            {
-                Some(&kw[..kw.len() - 1])
-            } else {
-                None
-            };
-            stem.filter(|s| s.len() >= 2 && !seen.contains(*s))
-                .map(|s| s.to_string())
-        })
+        .filter_map(|kw| stem_keyword(kw, &seen))
         .collect();
     let mut all = base;
     for s in stems {


### PR DESCRIPTION
closes #46

## 変更内容

- `ING_DENY` / `S_DENY` を `extract_keywords` 内のローカル定数からモジュールレベル定数へ移動
- ステミングロジックを `fn stem_keyword(kw: &str) -> Option<&str>` に抽出
- `stem_keyword` から `seen` パラメータを除去して純粋関数化 — dedup は呼び出し側に分離
- `extract_keywords` を 66 行から 30 行に削減（目標 ≤40）

## 設計判断

`seen` を `stem_keyword` から除いたのは、dedup の責務をステミング変換と分離するため。純粋関数化によりテストが容易になり、不要な `String` アロケーションも除去。

## テスト

- `cargo test query` — 既存 11 テスト全通過
- codex review — 問題なし