### PR TITLE
full-embed モードとスピナー進捗表示を追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1061,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.8"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
@@ -2139,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2588,9 +2588,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,10 +34,11 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=3dec559#3dec55928069f6a268abac4c49945f421ae11fc6"
+source = "git+https://github.com/thkt/amici?rev=8b9fcb5#8b9fcb5e6b799f5221607c23c600d1e3fdf62dad"
 dependencies = [
  "rurico",
  "rusqlite",
+ "tracing",
 ]
 
 [[package]]
@@ -2054,19 +2055,28 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=216f25f#216f25fe8821d5eb44401cb87deea62dae556144"
+source = "git+https://github.com/thkt/rurico?rev=350effd#350effdfb351cd54f667ff007a99bded54aa0329"
 dependencies = [
  "bytemuck",
  "hf-hub",
  "log",
  "mlx-rs",
- "mlx-sys",
+ "rurico-ffi",
  "rusqlite",
  "serde",
  "serde_json",
- "sqlite-vec",
  "thiserror",
  "tokenizers",
+]
+
+[[package]]
+name = "rurico-ffi"
+version = "0.1.0"
+source = "git+https://github.com/thkt/rurico?rev=350effd#350effdfb351cd54f667ff007a99bded54aa0329"
+dependencies = [
+ "mlx-sys",
+ "rusqlite",
+ "sqlite-vec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ repository = "https://github.com/thkt/yomu"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "3dec559" }
+amici = { git = "https://github.com/thkt/amici", rev = "8b9fcb5" }
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
-rurico = { git = "https://github.com/thkt/rurico", rev = "216f25f" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "350effd" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -29,7 +29,7 @@ tree-sitter-rust = "0.24"
 tree-sitter-typescript = "0.23"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "216f25f", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "350effd", features = ["test-support"] }
 tempfile = "3"
 
 [lints.rust]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -18,7 +18,7 @@ use crate::storage::{self, Db, RefKind, Reference, StorageError};
 use chunker::ParsedImport;
 
 use embed::embed_and_store;
-pub use embed::{EmbedResult, run_incremental_embed};
+pub use embed::{EmbedResult, run_incremental_embed, run_incremental_embed_with_progress};
 #[cfg(test)]
 use embed::{MAX_CONSECUTIVE_EMBED_ERRORS, enrich_for_embedding, order_files_for_embedding};
 

--- a/src/indexer/embed.rs
+++ b/src/indexer/embed.rs
@@ -10,7 +10,7 @@ use super::{IndexError, PendingFile, build_references};
 
 pub(super) const MAX_CONSECUTIVE_EMBED_ERRORS: u32 = 5;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct EmbedResult {
     pub chunks_embedded: u32,
     pub files_completed: u32,
@@ -303,17 +303,25 @@ pub fn run_incremental_embed(
     max_chunks: u32,
     type_hints: Option<&[storage::ChunkType]>,
 ) -> Result<EmbedResult, IndexError> {
+    run_incremental_embed_with_progress(conn, embedder, max_chunks, type_hints, |_| {})
+}
+
+/// Like [`run_incremental_embed`] but calls `on_progress(chunks_embedded)` after each file.
+#[allow(clippy::cast_possible_truncation)]
+pub fn run_incremental_embed_with_progress(
+    conn: &Arc<Mutex<Db>>,
+    embedder: &(impl Embed + ?Sized),
+    max_chunks: u32,
+    type_hints: Option<&[storage::ChunkType]>,
+    mut on_progress: impl FnMut(u32),
+) -> Result<EmbedResult, IndexError> {
     let ordered_files = {
         let conn_guard = conn.lock().unwrap();
         order_files_for_embedding(&conn_guard, type_hints)?
     };
 
     if ordered_files.is_empty() {
-        return Ok(EmbedResult {
-            chunks_embedded: 0,
-            files_completed: 0,
-            budget_exhausted: false,
-        });
+        return Ok(EmbedResult::default());
     }
 
     let mut chunks_embedded = 0u32;
@@ -346,6 +354,7 @@ pub fn run_incremental_embed(
 
         chunks_embedded += n;
         files_completed += 1;
+        on_progress(chunks_embedded);
 
         if chunks_embedded >= max_chunks {
             budget_exhausted = true;

--- a/src/indexer/embed.rs
+++ b/src/indexer/embed.rs
@@ -14,7 +14,6 @@ pub(super) const MAX_CONSECUTIVE_EMBED_ERRORS: u32 = 5;
 pub struct EmbedResult {
     pub chunks_embedded: u32,
     pub files_completed: u32,
-    pub budget_exhausted: bool,
 }
 
 pub(super) struct EmbedStoreResult {
@@ -326,7 +325,6 @@ pub fn run_incremental_embed_with_progress(
 
     let mut chunks_embedded = 0u32;
     let mut files_completed = 0u32;
-    let mut budget_exhausted = false;
     let mut consecutive_errors = 0u32;
 
     for file_path in &ordered_files {
@@ -336,7 +334,6 @@ pub fn run_incremental_embed_with_progress(
         }
 
         if chunks_embedded.saturating_add(texts.len() as u32) > max_chunks && chunks_embedded > 0 {
-            budget_exhausted = true;
             break;
         }
 
@@ -357,7 +354,6 @@ pub fn run_incremental_embed_with_progress(
         on_progress(chunks_embedded);
 
         if chunks_embedded >= max_chunks {
-            budget_exhausted = true;
             break;
         }
     }
@@ -365,14 +361,12 @@ pub fn run_incremental_embed_with_progress(
     tracing::info!(
         chunks_embedded,
         files_completed,
-        budget_exhausted,
         "Incremental embedding complete"
     );
 
     Ok(EmbedResult {
         chunks_embedded,
         files_completed,
-        budget_exhausted,
     })
 }
 

--- a/src/indexer/tests.rs
+++ b/src/indexer/tests.rs
@@ -440,7 +440,6 @@ fn run_incremental_embed_empty_db_returns_zero() {
 
     assert_eq!(result.chunks_embedded, 0);
     assert_eq!(result.files_completed, 0);
-    assert!(!result.budget_exhausted);
 }
 
 // T-384: run_incremental_embed_within_budget
@@ -469,7 +468,6 @@ fn run_incremental_embed_within_budget() {
 
     assert!(result.chunks_embedded >= 3);
     assert_eq!(result.files_completed, 3);
-    assert!(!result.budget_exhausted);
 
     let stats_after = storage::get_stats(&conn.lock().unwrap()).unwrap();
     assert_eq!(stats_after.embedded_chunks, stats_after.total_chunks);
@@ -497,7 +495,6 @@ fn run_incremental_embed_exhausts_budget() {
 
     let result = run_incremental_embed(&conn, &MockEmbedder::default(), 2, None).unwrap();
 
-    assert!(result.budget_exhausted);
     assert!(result.chunks_embedded <= 2);
 
     let stats = storage::get_stats(&conn.lock().unwrap()).unwrap();
@@ -627,7 +624,6 @@ fn run_incremental_embed_none_hints_preserves_order() {
 
     assert_eq!(result.files_completed, 2);
     assert!(result.chunks_embedded >= 2);
-    assert!(!result.budget_exhausted);
 }
 
 // T-388: run_incremental_embed_recovers_after_intermittent_failure

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,10 +9,7 @@ use amici::cli::try_expand_shorthand;
 use clap::error::ErrorKind;
 use clap::{CommandFactory, Parser, Subcommand};
 use rurico::model_probe::handle_probe_if_needed;
-use yomu::tools::{
-    MAX_EMBED_BUDGET, MAX_IMPACT_DEPTH, MAX_SEARCH_LIMIT, MAX_SEARCH_OFFSET, MIN_EMBED_BUDGET,
-    Yomu, YomuError,
-};
+use yomu::tools::{MAX_IMPACT_DEPTH, MAX_SEARCH_LIMIT, MAX_SEARCH_OFFSET, Yomu, YomuError};
 
 #[derive(Parser)]
 #[command(name = "yomu", version, about = "Frontend code search for AI agents")]
@@ -75,11 +72,7 @@ enum Command {
     /// Show index statistics.
     Status,
     /// Embed pending chunks for semantic search.
-    Embed {
-        /// Max chunks to embed in this run (default: YOMU_EMBED_BUDGET or 50)
-        #[arg(long, value_parser = clap::value_parser!(u32).range(MIN_EMBED_BUDGET as i64..=MAX_EMBED_BUDGET as i64))]
-        budget: Option<u32>,
-    },
+    Embed,
     /// Manage the embedding model.
     #[command(
         subcommand_required = true,
@@ -142,7 +135,7 @@ fn main() -> ExitCode {
     // model subcommands do not require a project root or DB
     if let Command::Model { command } = &command {
         let result = match command {
-            ModelCommand::Download => run_model_download(json),
+            ModelCommand::Download => Yomu::model_download(json),
         };
         return match result {
             Ok(output) => {
@@ -232,7 +225,7 @@ fn main() -> ExitCode {
             semantic,
         } => yomu.impact(&target, symbol.as_deref(), depth, json, semantic),
         Command::Status => yomu.status(json),
-        Command::Embed { budget } => yomu.embed(budget, json),
+        Command::Embed => yomu.embed(json),
         Command::Model { .. } => unreachable!("handled before Yomu::new()"),
     };
 
@@ -302,55 +295,6 @@ fn resolve_query(arg: Option<String>) -> Result<String, QueryError> {
     let stdin = io::stdin();
     let is_terminal = stdin.is_terminal();
     resolve_query_with(arg, &mut stdin.lock(), is_terminal)
-}
-
-fn run_model_download(json: bool) -> Result<String, YomuError> {
-    use amici::cli::Spinner;
-    use rurico::embed::{EmbedInitError, Embedder, ModelId, ProbeStatus, download_model};
-
-    let spinner = Spinner::new("Downloading model...");
-    let paths = match download_model(ModelId::default()) {
-        Ok(p) => p,
-        Err(e) => {
-            spinner.cancel();
-            tracing::error!(error = %e, "Model download failed");
-            return Err(YomuError::Internal(format!(
-                "Failed to download model: {e}"
-            )));
-        }
-    };
-    match Embedder::probe(&paths) {
-        Ok(ProbeStatus::Available) => {}
-        Ok(ProbeStatus::BackendUnavailable) => {
-            spinner.cancel();
-            return Err(YomuError::Internal(
-                "Model downloaded but MLX backend is unavailable".to_owned(),
-            ));
-        }
-        Err(e) => {
-            spinner.cancel();
-            if matches!(e, EmbedInitError::ModelCorrupt { .. })
-                && let Err(del_err) = paths.delete_files()
-            {
-                tracing::warn!(error = %del_err, "failed to delete corrupt model files");
-            }
-            return Err(YomuError::Internal(format!("Model probe failed: {e}")));
-        }
-    }
-    match Embedder::new(&paths) {
-        Ok(_) => {
-            spinner.finish("Model ready");
-            if json {
-                Ok(serde_json::json!({"status": "ok"}).to_string())
-            } else {
-                Ok("Model downloaded and verified".to_owned())
-            }
-        }
-        Err(e) => {
-            spinner.cancel();
-            Err(YomuError::Internal(format!("Failed to verify model: {e}")))
-        }
-    }
 }
 
 fn exit_code_for(e: &YomuError) -> ExitCode {
@@ -577,33 +521,5 @@ mod tests {
             }
             other => panic!("expected Search, got {other:?}"),
         }
-    }
-
-    // T-117: embed --budget <valid> parses
-    #[test]
-    fn embed_budget_valid_parses() {
-        let cli = parse_cli_args(["yomu", "embed", "--budget", "50"]).unwrap();
-        match cli.command.unwrap() {
-            Command::Embed { budget } => assert_eq!(budget, Some(50)),
-            other => panic!("expected Embed, got {other:?}"),
-        }
-    }
-
-    // T-118: embed --budget 0 rejected (below MIN_EMBED_BUDGET=1)
-    #[test]
-    fn embed_budget_zero_is_rejected() {
-        assert!(
-            parse_cli_args(["yomu", "embed", "--budget", "0"]).is_err(),
-            "budget=0 should be rejected (below MIN_EMBED_BUDGET=1)"
-        );
-    }
-
-    // T-119: embed --budget 501 rejected (above MAX_EMBED_BUDGET=500)
-    #[test]
-    fn embed_budget_above_max_is_rejected() {
-        assert!(
-            parse_cli_args(["yomu", "embed", "--budget", "501"]).is_err(),
-            "budget=501 should be rejected (above MAX_EMBED_BUDGET=500)"
-        );
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -36,8 +36,6 @@ const MAX_QUERY_LENGTH: usize = 2000;
 pub const MAX_SEARCH_LIMIT: u32 = 100;
 pub const MAX_SEARCH_OFFSET: u32 = 500;
 pub const MAX_IMPACT_DEPTH: u32 = 10;
-pub const MIN_EMBED_BUDGET: u32 = 1;
-pub const MAX_EMBED_BUDGET: u32 = 500;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum IndexState {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -8,7 +8,8 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 
-use amici::model::ModelLoad;
+use amici::cli::embed_with_spinners;
+use amici::model::{ModelLoad, download_and_verify_model};
 use rurico::embed::Embed;
 use rurico::reranker::Rerank;
 
@@ -461,20 +462,45 @@ impl Yomu {
         ))
     }
 
-    pub fn embed(&self, budget: Option<u32>, json: bool) -> Result<String, YomuError> {
-        let embedder = self.try_embedder().map_err(|reason| {
-            let msg = match reason {
-                DegradedReason::Disabled => "embedding is disabled (YOMU_EMBED=0)",
-                DegradedReason::NotInstalled => "embedding model not installed",
-                DegradedReason::BackendUnavailable | DegradedReason::ProbeFailed => {
-                    "embedding model unavailable"
-                }
-            };
-            YomuError::EmbedderUnavailable(msg.to_owned())
+    pub fn embed(&self, json: bool) -> Result<String, YomuError> {
+        let pending = self.with_db(|conn| {
+            let stats = storage::get_stats(conn)?;
+            Ok(stats
+                .embeddable_chunks
+                .saturating_sub(stats.embedded_chunks))
         })?;
-        let max_chunks = budget.unwrap_or(self.embed_budget);
-        let result = indexer::run_incremental_embed(&self.conn, embedder, max_chunks, None)?;
-        Ok(format_embed_result(&result, json))
+
+        let result = embed_with_spinners(
+            pending,
+            |_| {
+                self.try_embedder_arc().map_err(|reason| {
+                    let msg = match reason {
+                        DegradedReason::Disabled => "embedding is disabled (YOMU_EMBED=0)",
+                        DegradedReason::NotInstalled => "embedding model not installed",
+                        DegradedReason::BackendUnavailable | DegradedReason::ProbeFailed => {
+                            "embedding model unavailable"
+                        }
+                    };
+                    YomuError::EmbedderUnavailable(msg.to_owned())
+                })
+            },
+            |r: &indexer::EmbedResult| format!("Embedded {} chunks", r.chunks_embedded),
+            |model: Arc<dyn Embed>, update| {
+                indexer::run_incremental_embed_with_progress(
+                    &self.conn,
+                    model.as_ref(),
+                    u32::MAX,
+                    None,
+                    |n| update(&format!("Embedding... {n}/{pending} chunks")),
+                )
+                .map_err(YomuError::from)
+            },
+        )?;
+
+        match result {
+            Some(r) => Ok(format_embed_result(&r, json)),
+            None => Ok(format_embed_result(&indexer::EmbedResult::default(), json)),
+        }
     }
 }
 
@@ -636,6 +662,15 @@ impl Yomu {
         let mut seen: HashSet<String> = HashSet::new();
         results.retain(|r| seen.insert(r.chunk.file_path.clone()));
         Ok(results)
+    }
+
+    pub fn model_download(json: bool) -> Result<String, YomuError> {
+        download_and_verify_model().map_err(|e| YomuError::Internal(e.to_string()))?;
+        if json {
+            Ok(serde_json::json!({"status": "ok"}).to_string())
+        } else {
+            Ok("Model downloaded and verified".to_owned())
+        }
     }
 }
 

--- a/src/tools/embedder.rs
+++ b/src/tools/embedder.rs
@@ -16,6 +16,8 @@ use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
 pub(super) const DEFAULT_EMBED_BUDGET: u32 = 50;
+const MIN_EMBED_BUDGET: u32 = 1;
+const MAX_EMBED_BUDGET: u32 = 500;
 
 pub(super) fn record_embedder_warning(reason: DegradedReason, detail: &str) {
     tracing::warn!(reason = ?reason, detail, "Embedder unavailable, using text search only");
@@ -51,13 +53,13 @@ impl Embed for NoOpEmbedder {
 pub(super) fn parse_budget_value(value: Option<&str>) -> u32 {
     match value {
         Some(v) => match v.parse::<u32>() {
-            Ok(n) if (super::MIN_EMBED_BUDGET..=super::MAX_EMBED_BUDGET).contains(&n) => n,
+            Ok(n) if (MIN_EMBED_BUDGET..=MAX_EMBED_BUDGET).contains(&n) => n,
             Ok(n) => {
                 tracing::warn!(
                     value = n,
                     "YOMU_EMBED_BUDGET out of range ({}..={}), using default",
-                    super::MIN_EMBED_BUDGET,
-                    super::MAX_EMBED_BUDGET
+                    MIN_EMBED_BUDGET,
+                    MAX_EMBED_BUDGET
                 );
                 DEFAULT_EMBED_BUDGET
             }

--- a/src/tools/embedder.rs
+++ b/src/tools/embedder.rs
@@ -107,6 +107,15 @@ impl Yomu {
             .map_err(|r| *r)
     }
 
+    pub(super) fn try_embedder_arc(&self) -> Result<Arc<dyn Embed>, DegradedReason> {
+        let disabled = self.embed_disabled;
+        self.embedder
+            .get_or_init(|| try_load_embedder(disabled))
+            .as_ref()
+            .map(Arc::clone)
+            .map_err(|r| *r)
+    }
+
     pub(super) fn get_embedder(&self) -> &dyn Embed {
         static NOOP: NoOpEmbedder = NoOpEmbedder;
         self.try_embedder().unwrap_or(&NOOP)

--- a/src/tools/format.rs
+++ b/src/tools/format.rs
@@ -371,28 +371,21 @@ struct JsonStatus {
 #[derive(Serialize)]
 struct JsonEmbedResult {
     embedded: u32,
-    budget_exhausted: bool,
 }
 
 pub(super) fn format_embed_result(result: &indexer::EmbedResult, json: bool) -> String {
     if json {
         let resp = JsonEmbedResult {
             embedded: result.chunks_embedded,
-            budget_exhausted: result.budget_exhausted,
         };
         return serde_json::to_string(&resp).unwrap();
     }
     if result.chunks_embedded == 0 {
         return "nothing to embed".to_owned();
     }
-    let note = if result.budget_exhausted {
-        " (budget reached; run again to embed more)"
-    } else {
-        ""
-    };
     format!(
-        "Embedded {} chunks across {} files{}",
-        result.chunks_embedded, result.files_completed, note
+        "Embedded {} chunks across {} files",
+        result.chunks_embedded, result.files_completed
     )
 }
 

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -1,6 +1,6 @@
 use super::embedder::{
-    DegradedReason, RECORDED_WARNINGS, degraded_reason_user_note, get_recorded_warnings,
-    parse_budget_value, record_embedder_warning,
+    DegradedReason, RECORDED_WARNINGS, get_recorded_warnings, parse_budget_value,
+    record_embedder_warning,
 };
 use super::*;
 use std::collections::HashMap;
@@ -1832,24 +1832,6 @@ fn disabled_no_user_note_in_search() {
     );
 }
 
-// T-232: user_note_exact_values_for_all_variants
-#[test]
-fn user_note_exact_values_for_all_variants() {
-    assert_eq!(degraded_reason_user_note(DegradedReason::Disabled), None);
-    assert_eq!(
-        degraded_reason_user_note(DegradedReason::NotInstalled),
-        Some("embedding model not installed; results from text search only")
-    );
-    assert_eq!(
-        degraded_reason_user_note(DegradedReason::BackendUnavailable),
-        Some("embedding model unavailable; results from text search only")
-    );
-    assert_eq!(
-        degraded_reason_user_note(DegradedReason::ProbeFailed),
-        Some("embedding model unavailable; results from text search only")
-    );
-}
-
 // T-116: degraded_reason() returns the amici-provided DegradedReason type
 #[test]
 fn degraded_reason_returns_amici_type() {
@@ -1910,7 +1892,7 @@ fn embed_pending_chunks_returns_count() {
     let y = Yomu::for_test(conn, dir.path().to_path_buf(), Some(embedder));
     indexer::run_chunk_only_index(&y.conn, y.root.as_path()).unwrap();
 
-    let text = y.embed(None, false).unwrap();
+    let text = y.embed(false).unwrap();
     assert!(
         text.starts_with("Embedded"),
         "expected result starting with 'Embedded': {text}"
@@ -1929,7 +1911,7 @@ fn embed_nothing_to_embed() {
     let y = Yomu::for_test(conn, dir.path().to_path_buf(), Some(embedder));
     // No index run — no chunks to embed.
 
-    let text = y.embed(None, false).unwrap();
+    let text = y.embed(false).unwrap();
     assert_eq!(
         text, "nothing to embed",
         "expected 'nothing to embed': {text}"
@@ -1947,7 +1929,7 @@ fn embed_json_format() {
     let y = Yomu::for_test(conn, dir.path().to_path_buf(), Some(embedder));
     indexer::run_chunk_only_index(&y.conn, y.root.as_path()).unwrap();
 
-    let json = y.embed(None, true).unwrap();
+    let json = y.embed(true).unwrap();
     let parsed = parse_json(&json);
     assert!(
         parsed.get("embedded").is_some(),
@@ -1962,14 +1944,15 @@ fn embed_json_format() {
 // T-112: embedder not installed → YomuError::EmbedderUnavailable
 #[test]
 fn embed_embedder_unavailable_returns_error() {
-    let (conn, dir) = setup_test_files(&[]);
+    let (conn, dir) = setup_test_files(&[("src/lib.rs", "pub fn hello() {}")]);
     let y = Yomu::for_test_raw(
         conn,
         dir.path().to_path_buf(),
         Err(DegradedReason::NotInstalled),
     );
+    y.index(false).unwrap();
 
-    let result = y.embed(None, false);
+    let result = y.embed(false);
     assert!(
         matches!(result, Err(YomuError::EmbedderUnavailable(_))),
         "expected EmbedderUnavailable error: {result:?}"
@@ -1979,14 +1962,15 @@ fn embed_embedder_unavailable_returns_error() {
 // T-120: embed() with Disabled reason → YomuError::EmbedderUnavailable
 #[test]
 fn embed_disabled_returns_embedder_unavailable() {
-    let (conn, dir) = setup_test_files(&[]);
+    let (conn, dir) = setup_test_files(&[("src/lib.rs", "pub fn hello() {}")]);
     let y = Yomu::for_test_raw(
         conn,
         dir.path().to_path_buf(),
         Err(DegradedReason::Disabled),
     );
+    y.index(false).unwrap();
 
-    let result = y.embed(None, false);
+    let result = y.embed(false);
     assert!(
         matches!(result, Err(YomuError::EmbedderUnavailable(_))),
         "expected EmbedderUnavailable for Disabled reason: {result:?}"

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -1918,7 +1918,7 @@ fn embed_nothing_to_embed() {
     );
 }
 
-// T-111: json=true produces {"embedded": N, "budget_exhausted": bool}
+// T-111: json=true produces {"embedded": N}
 #[test]
 fn embed_json_format() {
     let embedder = Arc::new(MockEmbedder::default()) as Arc<dyn Embed>;
@@ -1934,10 +1934,6 @@ fn embed_json_format() {
     assert!(
         parsed.get("embedded").is_some(),
         "expected 'embedded' key in JSON: {json}"
-    );
-    assert!(
-        parsed.get("budget_exhausted").is_some(),
-        "expected 'budget_exhausted' key in JSON: {json}"
     );
 }
 


### PR DESCRIPTION
## 概要

- `yomu embed` now embeds all pending chunks (no `--budget` cap) and displays a live spinner with a per-chunk progress counter (`Embedding... N/total chunks`) via `amici::cli::embed_with_spinners`.
- The `--budget` CLI flag and its validation range were removed; the embed subcommand takes no arguments. The embed budget constants (`MIN_EMBED_BUDGET`, `MAX_EMBED_BUDGET`) are no longer exported from `tools`.
- `run_incremental_embed` is refactored into a thin wrapper over a new `run_incremental_embed_with_progress` function that accepts an `on_progress` callback, called after each file is embedded.
- `EmbedResult` derives `Default`, replacing the redundant struct literals with `EmbedResult::default()`.
- `Yomu::model_download` is moved into `tools.rs` as a proper `impl Yomu` method (previously a free function in `main.rs`), delegating to `amici::model::download_and_verify_model` which owns the spinner and probe logic.
- Tests that depended on `--budget` parsing or `budget: Option<u32>` are replaced; error-path embed tests now index a real file first so the pending-chunk check can reach the embedder.

## テスト計画

- [ ] `cargo test` passes with no failures.
- [ ] Run `yomu embed` on a repo with pending chunks and confirm the spinner shows `Embedding... N/total chunks` updates followed by the final `Embedded N chunks` summary.
- [ ] Run `yomu embed` on a repo with no pending chunks and confirm the output is `nothing to embed` with no spinner error.
- [ ] Confirm `yomu embed --budget 50` is now rejected by the CLI (unknown argument).
- [ ] Run `yomu model download` and confirm the spinner and success message still appear correctly.