### PR TITLE
Rust MSRV を 1.95 に固定し amici/rurico を対応 rev に揃える

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=d0460c6#d0460c681b2158f504104f852d90a6cddd9c4beb"
+source = "git+https://github.com/thkt/amici?rev=a2428bf#a2428bf65fc94b0a2b06992d88e333bf3f9691b8"
 dependencies = [
  "rurico",
  "rusqlite",
@@ -2055,7 +2055,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=3cc9cb0#3cc9cb06ca23a2805fa39de2f6c281d85347580b"
+source = "git+https://github.com/thkt/rurico?rev=e5f4fb5#e5f4fb50c1ad13807513033047bd215413ec6ccb"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -2072,7 +2072,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=3cc9cb0#3cc9cb06ca23a2805fa39de2f6c281d85347580b"
+source = "git+https://github.com/thkt/rurico?rev=e5f4fb5#e5f4fb50c1ad13807513033047bd215413ec6ccb"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=a2428bf#a2428bf65fc94b0a2b06992d88e333bf3f9691b8"
+source = "git+https://github.com/thkt/amici?rev=e5a73f1#e5a73f1bb0c2c0b0e5e26f596af8a9535926aeda"
 dependencies = [
  "rurico",
  "rusqlite",
@@ -2055,7 +2055,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=e5f4fb5#e5f4fb50c1ad13807513033047bd215413ec6ccb"
+source = "git+https://github.com/thkt/rurico?rev=0de6526#0de65266126ee94fbfa292964d68e6475ddae2d9"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -2072,7 +2072,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=e5f4fb5#e5f4fb50c1ad13807513033047bd215413ec6ccb"
+source = "git+https://github.com/thkt/rurico?rev=0de6526#0de65266126ee94fbfa292964d68e6475ddae2d9"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=e5a73f1#e5a73f1bb0c2c0b0e5e26f596af8a9535926aeda"
+source = "git+https://github.com/thkt/amici?rev=466b4cb#466b4cb87cf68ae8768ec8a20571b3cd1aa376a8"
 dependencies = [
  "rurico",
  "rusqlite",
@@ -2055,7 +2055,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=0de6526#0de65266126ee94fbfa292964d68e6475ddae2d9"
+source = "git+https://github.com/thkt/rurico?rev=bc2ad90#bc2ad90c2cd36b421aaacdc23cffed98d4f51a19"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -2072,7 +2072,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=0de6526#0de65266126ee94fbfa292964d68e6475ddae2d9"
+source = "git+https://github.com/thkt/rurico?rev=bc2ad90#bc2ad90c2cd36b421aaacdc23cffed98d4f51a19"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ repository = "https://github.com/thkt/yomu"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "a2428bf" }
+amici = { git = "https://github.com/thkt/amici", rev = "e5a73f1" }
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
-rurico = { git = "https://github.com/thkt/rurico", rev = "e5f4fb5" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "0de6526" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -30,7 +30,7 @@ tree-sitter-rust = "0.24"
 tree-sitter-typescript = "0.23"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "e5f4fb5", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "0de6526", features = ["test-support"] }
 tempfile = "3"
 
 [lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "yomu"
 version = "0.14.0"
 edition = "2024"
+rust-version = "1.95"
 description = "Frontend code search for AI agents"
 license = "MIT"
 repository = "https://github.com/thkt/yomu"
@@ -10,10 +11,10 @@ repository = "https://github.com/thkt/yomu"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "d0460c6" }
+amici = { git = "https://github.com/thkt/amici", rev = "a2428bf" }
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
-rurico = { git = "https://github.com/thkt/rurico", rev = "3cc9cb0" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "e5f4fb5" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -29,28 +30,28 @@ tree-sitter-rust = "0.24"
 tree-sitter-typescript = "0.23"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "3cc9cb0", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "e5f4fb5", features = ["test-support"] }
 tempfile = "3"
 
 [lints.rust]
 unsafe_code = "forbid"
 
 [lints.clippy]
-# フルパス使用検出
+# absolute paths
 absolute_paths = "deny"
-# Rustイディオム (RUST.md idioms table)
+# idiomatic iterators
 cast_possible_truncation = "deny"
 redundant_closure_for_method_calls = "deny"
 filter_map_next = "deny"
 flat_map_option = "deny"
 manual_filter_map = "deny"
 manual_find_map = "deny"
-# インポート
+# imports
 wildcard_imports = "deny"
 enum_glob_use = "deny"
-# 文字列
+# strings
 str_to_string = "deny"
-# 引数
+# arguments
 needless_pass_by_value = "deny"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ repository = "https://github.com/thkt/yomu"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "e5a73f1" }
+amici = { git = "https://github.com/thkt/amici", rev = "466b4cb" }
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
-rurico = { git = "https://github.com/thkt/rurico", rev = "0de6526" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "bc2ad90" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -30,7 +30,7 @@ tree-sitter-rust = "0.24"
 tree-sitter-typescript = "0.23"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "0de6526", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "bc2ad90", features = ["test-support"] }
 tempfile = "3"
 
 [lints.rust]


### PR DESCRIPTION
## 概要

- `Cargo.toml` の `[package]` に `rust-version = "1.95"` を追加し、yomu の MSRV を 1.95 に固定
- `Cargo.toml` の clippy セクションのコメントを日本語から英語に翻訳
- `amici` / `rurico` を MSRV 1.95 対応済みの rev に 2 段階バンプ（rurico `bc2ad90` は PR #37 "chore(msrv): bump FFI MSRV to 1.95" をマージ済み）

## 背景

downstream の `rurico-ffi` が `mlx-sys` の要件により Rust 1.95 を必要とするため、CI の一貫性を保つために yomu 側でも MSRV を明示的に固定する。

## テスト計画

- [ ] `cargo build` が Rust 1.95 環境で完了すること
- [ ] `cargo test --features test-support` — 32 passed + 2 passed (schema_validation), 0 failed
- [ ] `cargo clippy --all-targets --features test-support` — no warnings
