### PR TITLE
amici::migration::notify_schema_change 経由化

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,11 +34,12 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=466b4cb#466b4cb87cf68ae8768ec8a20571b3cd1aa376a8"
+source = "git+https://github.com/thkt/amici?rev=2dd9a52#2dd9a5221b91de6215dade71dd9404ab8abbba22"
 dependencies = [
  "rurico",
  "rusqlite",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3015,11 +3016,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -3028,7 +3029,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -3336,6 +3337,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/thkt/yomu"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "466b4cb" }
+amici = { git = "https://github.com/thkt/amici", rev = "2dd9a52" }
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
 rurico = { git = "https://github.com/thkt/rurico", rev = "bc2ad90" }

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
+use amici::migration::notify_schema_change;
 use rurico::storage::ensure_sqlite_vec;
 use rusqlite::Connection;
 use rusqlite::ffi::{Error as FfiError, ErrorCode};
@@ -251,10 +252,8 @@ fn migrate(conn: &Connection, from: u32, path: &Path) -> Result<(), StorageError
         // Without this, should_reindex() would skip every file whose content hasn't changed,
         // leaving embedded_chunk_ids permanently empty after the migration.
         conn.execute_batch("UPDATE chunks SET file_hash = ''")?;
-        tracing::warn!(
-            path = %path.display(),
-            "schema upgraded to v8: embeddings cleared, please re-run `yomu index`"
-        );
+        let _span = tracing::info_span!("migration_v8", path = %path.display()).entered();
+        notify_schema_change("yomu", "embeddings", 0, "yomu index");
     }
 
     Ok(())


### PR DESCRIPTION
## 背景と目的

v7→v8 マイグレーション時の通知メッセージを `tracing::warn!` のインライン呼び出しから `amici::migration::notify_schema_change` ヘルパー経由に切り替える。recall / sae がすでに同ヘルパーを使っており、yomu を移行することで3ツール間の通知フォーマットが一致する。

## 変更内容

- `Cargo.toml`: amici rev を `466b4cb` → `2dd9a52` に更新し `amici::migration` モジュールを有効化 (thkt/amici#8)
- `src/storage/schema.rs`: v7→v8 の `tracing::warn!("schema upgraded to v8: ...")` を `info_span!("migration_v8", path=%path.display())` + `notify_schema_change("yomu", "embeddings", 0, "yomu index")` に置き換え

## スコープ

- **対象外**: `from > 0` ガードは追加しない。スコープはフォーマット統一のみであり、ガードの要否は別 Issue で判断する。

## 設計判断

- メッセージ文言はヘルパーの標準形 ("schema changed — clearing embeddings; run \`yomu index\` to rebuild") に変わるが、動作上の効果は同等。意図した変更。
- `tracing::warn!` から `info_span!` + ヘルパーに変えることで、path フィールドが span に記録される。

## テスト計画

- [x] `cargo build` 成功
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過
- [x] `cargo test` 全テスト通過 (unit 32 + schema_validation 2)
- [ ] v7 相当のDBで実際に migration をトリガーし、ヘルパーの標準メッセージが出力されること確認

## 関連

- Closes #98
- 上流依存: thkt/amici#7 (設計) / thkt/amici#8 (モジュール追加のマージ)
- 3ツール横断の設計議論: thkt/recall#32