### PR TITLE
main.rs の eprintln! を amici::cli ヘルパー経由に移行

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=2dd9a52#2dd9a5221b91de6215dade71dd9404ab8abbba22"
+source = "git+https://github.com/thkt/amici?rev=ae6ed39#ae6ed39f7a845ebd1aef40e9f126cc2c5dc5e308"
 dependencies = [
  "rurico",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/thkt/yomu"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "2dd9a52" }
+amici = { git = "https://github.com/thkt/amici", rev = "ae6ed39" }
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
 rurico = { git = "https://github.com/thkt/rurico", rev = "bc2ad90" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::io::{self, IsTerminal, Read};
 use std::iter;
 use std::process::ExitCode;
 
-use amici::cli::try_expand_shorthand;
+use amici::cli::{deprecation_warn, exit_error, hint_arrow, try_expand_shorthand};
 use clap::error::ErrorKind;
 use clap::{CommandFactory, Parser, Subcommand};
 use rurico::model_probe::handle_probe_if_needed;
@@ -143,7 +143,7 @@ fn main() -> ExitCode {
                 ExitCode::SUCCESS
             }
             Err(e) => {
-                eprintln!("error: {e}");
+                exit_error(&format!("{e}"));
                 exit_code_for(&e)
             }
         };
@@ -152,7 +152,7 @@ fn main() -> ExitCode {
     let yomu = match Yomu::new() {
         Ok(y) => y,
         Err(e) => {
-            eprintln!("error: {e}");
+            exit_error(&format!("{e}"));
             return exit_code_for(&e);
         }
     };
@@ -167,7 +167,7 @@ fn main() -> ExitCode {
             format,
         } => {
             if format.is_some() {
-                eprintln!("warning: --format is deprecated, use --json instead");
+                deprecation_warn("--format", "--json");
             }
             let json = json || format.as_deref() == Some("json");
             if from.is_some() {
@@ -180,7 +180,7 @@ fn main() -> ExitCode {
                         Ok(q) => Some(q),
                         Err(QueryError::NoQuery(_)) => None,
                         Err(e @ QueryError::Io(_)) => {
-                            eprintln!("error: {e}");
+                            exit_error(&format!("{e}"));
                             return ExitCode::FAILURE;
                         }
                     }
@@ -197,7 +197,7 @@ fn main() -> ExitCode {
                 let query = match resolve_query(query) {
                     Ok(q) => q,
                     Err(e) => {
-                        eprintln!("error: {e}");
+                        exit_error(&format!("{e}"));
                         return ExitCode::from(2);
                     }
                 };
@@ -235,7 +235,7 @@ fn main() -> ExitCode {
             ExitCode::SUCCESS
         }
         Err(e) => {
-            eprintln!("error: {e}");
+            exit_error(&format!("{e}"));
             exit_code_for(&e)
         }
     }
@@ -259,7 +259,7 @@ where
         let display: Vec<_> = iter::once("yomu")
             .chain(expanded[1..].iter().filter_map(|a| a.to_str()))
             .collect();
-        eprintln!("→ {}", display.join(" "));
+        hint_arrow(&display);
         return Ok(cli);
     }
     Cli::try_parse_from(args)
@@ -380,16 +380,6 @@ mod tests {
         let cli = parse_cli_args(["yomu", "search", "認証"]).unwrap();
         match cli.command.unwrap() {
             Command::Search { query, .. } => assert_eq!(query.as_deref(), Some("認証")),
-            other => panic!("expected Search, got {other:?}"),
-        }
-    }
-
-    // T-033: `yomu search` (missing arg) parses to stdin fallback path
-    #[test]
-    fn search_missing_arg_parses_for_stdin_fallback() {
-        let cli = parse_cli_args(["yomu", "search"]).unwrap();
-        match cli.command.unwrap() {
-            Command::Search { query, .. } => assert_eq!(query, None),
             other => panic!("expected Search, got {other:?}"),
         }
     }


### PR DESCRIPTION
## 背景

`main.rs` の `eprintln!` 7 箇所を `amici::cli::exit_error` / `deprecation_warn` / `hint_arrow` に統一する。sae・yomu・recall 3 ツール横断で CLI UI の出力パターンを amici に集約する取り組みの一環であり、yomu は最後まで独自実装が残っていた箇所を解消する。

## 変更点

- `src/main.rs`: `eprintln!` 7 箇所を `amici::cli` の 3 ヘルパー (`exit_error` / `deprecation_warn` / `hint_arrow`) に置換し、`use` 文を拡張
- `src/main.rs` (tests): T-033 を削除 — T-016 が上位互換のため冗長
- `Cargo.toml` / `Cargo.lock`: amici rev を `2dd9a52` → `ae6ed39` に bump (amici#10 で追加された CLI UI ヘルパーを取り込むため)

## スコープ

- **対象外**: `main.rs` 以外の `tracing::warn!` / `info!` 呼び出しは構造化ログとして既に機能しているため変更なし
- **対象外**: `amici::cli::info` / `user_warn!` は yomu で採用箇所が特定できていないため対象外

## 設計判断

- ヘルパーを 3 種 (`exit_error` / `deprecation_warn` / `hint_arrow`) に絞ったのは、yomu の main.rs に存在するパターンがこの 3 種のみだったため (YAGNI)
- amici rev を bump して実装を取り込む方式は sae#66 / recall#33 と同様のパターンに従う

## テスト方法

1. `cargo build` — ビルドエラーなし
2. `cargo test` — 17 unit + 32 cli_integration + 2 schema_validation + doc-test、全 green
3. `cargo clippy --all-targets -- -D warnings` — warning ゼロ
4. `cargo fmt --check` — 差分なし

## 関連

- Closes #100
- Depends on: thkt/amici#9 (closed), thkt/amici#10 (merged)
- Related: thkt/sae#66, thkt/recall#33