### PR TITLE
rurico の vocab_table 引数追加に追従

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1694,9 +1694,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1726,9 +1726,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -2140,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2358,9 +2358,9 @@ dependencies = [
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
+checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
 dependencies = [
  "cc",
  "js-sys",
@@ -2850,9 +2850,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=ae6ed39#ae6ed39f7a845ebd1aef40e9f126cc2c5dc5e308"
+source = "git+https://github.com/thkt/amici?rev=2a8c734#2a8c734f011d02987de98a1f290f44114e6a413d"
 dependencies = [
  "rurico",
  "rusqlite",
@@ -2056,7 +2056,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=bc2ad90#bc2ad90c2cd36b421aaacdc23cffed98d4f51a19"
+source = "git+https://github.com/thkt/rurico?rev=e83581c#e83581cd3976363522bca282e489194567f034cf"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -2073,7 +2073,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=bc2ad90#bc2ad90c2cd36b421aaacdc23cffed98d4f51a19"
+source = "git+https://github.com/thkt/rurico?rev=e83581c#e83581cd3976363522bca282e489194567f034cf"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ repository = "https://github.com/thkt/yomu"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "ae6ed39" }
+amici = { git = "https://github.com/thkt/amici", rev = "2a8c734" }
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
-rurico = { git = "https://github.com/thkt/rurico", rev = "bc2ad90" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "e83581c" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -30,7 +30,7 @@ tree-sitter-rust = "0.24"
 tree-sitter-typescript = "0.23"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "bc2ad90", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "e83581c", features = ["test-support"] }
 tempfile = "3"
 
 [lints.rust]

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -208,7 +208,7 @@ pub fn search_by_fts(
 
     let parts: Vec<String> = keywords
         .iter()
-        .filter_map(|k| match prepare_match_query(conn, k) {
+        .filter_map(|k| match prepare_match_query(conn, k, "fts_chunks_vocab") {
             Ok(m) if !m.as_str().is_empty() => Some(m.into_string()),
             Err(e) if !k.trim().is_empty() => {
                 tracing::debug!(keyword = %k, error = %e, "prepare_match_query failed, falling back to fts_quote");


### PR DESCRIPTION
## 概要

rurico `e83581c` で `prepare_match_query` が第三引数 `vocab_table: &str` を要求するようになった（破壊的変更、rurico#38 merged）。yomu は従来の挙動を維持するため `"fts_chunks_vocab"` を渡すように更新する。

## 変更内容

- `Cargo.toml`: rurico rev `bc2ad90` → `e83581c`、amici rev `ae6ed39` → `2a8c734`（dep graph 内の rurico を単一バージョンに統一）
- `src/storage/search.rs:211`: `prepare_match_query(conn, k)` → `prepare_match_query(conn, k, "fts_chunks_vocab")`

## 挙動の変化

なし — 従来と同じ `fts_chunks_vocab` テーブルを参照するため、検索結果に差分はない。

## テスト方法

- `cargo test` — 474 passed / 2 ignored / 0 failed
- `cargo clippy --all-targets --all-features -- -D warnings` — 通過