### PR TITLE
fix(search): ハイブリッド検索の vec パスに type_filter を伝播

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2116,9 +2116,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "log",
  "once_cell",
@@ -3322,9 +3322,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]

--- a/src/query.rs
+++ b/src/query.rs
@@ -350,7 +350,7 @@ pub fn search_from_file(
     } else {
         limit.saturating_add(source_buf)
     };
-    let mut results = storage::vec_search_multi(conn, &emb_refs, fetch_limit, path_filter)?;
+    let mut results = storage::vec_search_multi(conn, &emb_refs, fetch_limit, None, path_filter)?;
 
     // FR-005 / BR-001
     results.retain(|r| !r.chunk_id.is_some_and(|id| source_chunk_ids.contains(&id)));
@@ -409,9 +409,17 @@ fn search_pipeline(
     } else {
         limit.saturating_add(offset)
     };
+    let type_filter = if type_hints.is_empty() {
+        None
+    } else {
+        Some(type_hints.as_slice())
+    };
+
     let use_semantic = query_embedding.is_some() && stats.embedded_chunks > 0;
     let mut results = match query_embedding {
-        Some(emb) if use_semantic => storage::vec_search(conn, emb, fetch_limit, path_filter)?,
+        Some(emb) if use_semantic => {
+            storage::vec_search(conn, emb, fetch_limit, type_filter, path_filter)?
+        }
         _ => Vec::new(),
     };
 
@@ -420,12 +428,6 @@ fn search_pipeline(
     let fallback_limit = limit.saturating_add(offset).saturating_mul(3);
 
     if !keywords.is_empty() {
-        let type_filter = if type_hints.is_empty() {
-            None
-        } else {
-            Some(type_hints.as_slice())
-        };
-
         let exclude_ids: HashSet<i64> = results.iter().filter_map(|r| r.chunk_id).collect();
         let fts_results = storage::search_by_fts(
             conn,

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -108,6 +108,7 @@ pub fn vec_search(
     conn: &Connection,
     query_embedding: &[f32],
     limit: u32,
+    type_filter: Option<&[ChunkType]>,
     path_filter: &[String],
 ) -> Result<Vec<SearchResult>, StorageError> {
     let query_bytes = f32_as_bytes(query_embedding);
@@ -155,6 +156,7 @@ pub fn vec_search(
         .map(|id| Box::new(*id) as Box<dyn ToSql>)
         .collect();
     append_path_filter(&mut sql, &mut params, "file_path", path_filter);
+    append_type_filter(&mut sql, &mut params, "chunk_type", type_filter);
 
     let mut stmt2 = conn.prepare(&sql)?;
     let meta: HashMap<i64, Chunk> = stmt2
@@ -322,6 +324,7 @@ pub fn vec_search_multi(
     conn: &Connection,
     query_embeddings: &[&[f32]],
     limit: u32,
+    type_filter: Option<&[ChunkType]>,
     path_filter: &[String],
 ) -> Result<Vec<SearchResult>, StorageError> {
     if query_embeddings.is_empty() {
@@ -330,7 +333,7 @@ pub fn vec_search_multi(
 
     let mut best: HashMap<i64, SearchResult> = HashMap::new();
     for emb in query_embeddings {
-        for result in vec_search(conn, emb, limit, path_filter)? {
+        for result in vec_search(conn, emb, limit, type_filter, path_filter)? {
             if let Some(chunk_id) = result.chunk_id {
                 best.entry(chunk_id)
                     .and_modify(|existing| {

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -395,7 +395,7 @@ fn vec_search_returns_ordered_results() {
     )
     .unwrap();
 
-    let results = vec_search(&conn, &emb_a, 10, &[]).unwrap();
+    let results = vec_search(&conn, &emb_a, 10, None, &[]).unwrap();
     assert_eq!(results.len(), 2);
     assert_eq!(results[0].chunk.name.as_deref(), Some("A"));
     assert!(results[0].distance <= results[1].distance);
@@ -1358,7 +1358,7 @@ fn vec_search_sets_semantic_match_source() {
     )
     .unwrap();
 
-    let results = vec_search(&conn, &emb, 10, &[]).unwrap();
+    let results = vec_search(&conn, &emb, 10, None, &[]).unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].match_source, MatchSource::Semantic);
 }
@@ -1387,7 +1387,7 @@ fn vec_search_sets_initial_score() {
     )
     .unwrap();
 
-    let results = vec_search(&conn, &emb, 10, &[]).unwrap();
+    let results = vec_search(&conn, &emb, 10, None, &[]).unwrap();
     assert_eq!(results.len(), 1);
 
     // score should be initialized to 1.0 / (1.0 + distance)
@@ -2721,6 +2721,105 @@ fn search_by_fts_respects_type_filter() {
     assert_eq!(results[0].chunk.name.as_deref(), Some("useAuth"));
 }
 
+// T-562: vec_search_respects_type_filter
+#[test]
+fn vec_search_respects_type_filter() {
+    let (conn, _dir) = test_db();
+    let mut emb = vec![0.0_f32; EMBEDDING_DIMS];
+    emb[0] = 1.0;
+
+    // Hook chunk → passes Some(&[Hook]) filter
+    insert_chunk(
+        &conn,
+        "src/hook.tsx",
+        &NewChunk {
+            chunk_type: &ChunkType::Hook,
+            name: Some("useAuth"),
+            content: "hook body",
+            start_line: 1,
+            end_line: 3,
+            parent_index: None,
+        },
+        "h1",
+        &ce(emb.clone()),
+        None,
+    )
+    .unwrap();
+
+    // Component chunk with identical embedding → violates Some(&[Hook]) filter
+    insert_chunk(
+        &conn,
+        "src/comp.tsx",
+        &NewChunk {
+            chunk_type: &ChunkType::Component,
+            name: Some("AuthBtn"),
+            content: "component body",
+            start_line: 1,
+            end_line: 3,
+            parent_index: None,
+        },
+        "h2",
+        &ce(emb.clone()),
+        None,
+    )
+    .unwrap();
+
+    let results = vec_search(&conn, &emb, 10, Some(&[ChunkType::Hook]), &[]).unwrap();
+    assert_eq!(
+        results.len(),
+        1,
+        "type_filter should limit to hooks, got {:?}",
+        results.iter().map(|r| &r.chunk.name).collect::<Vec<_>>()
+    );
+    assert_eq!(results[0].chunk.name.as_deref(), Some("useAuth"));
+}
+
+// T-563: vec_search_multi_respects_type_filter
+#[test]
+fn vec_search_multi_respects_type_filter() {
+    let (conn, _dir) = test_db();
+    let mut emb = vec![0.0_f32; EMBEDDING_DIMS];
+    emb[0] = 1.0;
+
+    insert_chunk(
+        &conn,
+        "src/hook.tsx",
+        &NewChunk {
+            chunk_type: &ChunkType::Hook,
+            name: Some("useAuth"),
+            content: "hook body",
+            start_line: 1,
+            end_line: 3,
+            parent_index: None,
+        },
+        "h1",
+        &ce(emb.clone()),
+        None,
+    )
+    .unwrap();
+    insert_chunk(
+        &conn,
+        "src/comp.tsx",
+        &NewChunk {
+            chunk_type: &ChunkType::Component,
+            name: Some("AuthBtn"),
+            content: "component body",
+            start_line: 1,
+            end_line: 3,
+            parent_index: None,
+        },
+        "h2",
+        &ce(emb.clone()),
+        None,
+    )
+    .unwrap();
+
+    let embs: Vec<&[f32]> = vec![emb.as_slice()];
+    let results = vec_search_multi(&conn, &embs, 10, Some(&[ChunkType::Hook]), &[]).unwrap();
+    assert_eq!(results.len(), 1, "type_filter should limit to hooks");
+    assert_eq!(results[0].chunk.name.as_deref(), Some("useAuth"));
+}
+
 // T-561: search_by_fts_excludes_ids
 #[test]
 fn search_by_fts_excludes_ids() {
@@ -3037,7 +3136,7 @@ fn vec_search_multi_keeps_min_distance_for_duplicate_chunk() {
     // query_a = exact match to target (distance ≈ 0)
     // query_b = far from target (distance ≈ √2)
     // min-distance merge should keep distance ≈ 0 for target
-    let results = vec_search_multi(&conn, &[&emb_target, &emb_other], 10, &[]).unwrap();
+    let results = vec_search_multi(&conn, &[&emb_target, &emb_other], 10, None, &[]).unwrap();
     let target = results
         .iter()
         .find(|r| r.chunk.name.as_deref() == Some("target"))
@@ -3150,7 +3249,7 @@ fn vec_search_multi_returns_union() {
     )
     .unwrap();
 
-    let results = vec_search_multi(&conn, &[&emb_a, &emb_b], 10, &[]).unwrap();
+    let results = vec_search_multi(&conn, &[&emb_a, &emb_b], 10, None, &[]).unwrap();
     assert_eq!(results.len(), 2);
     let names: Vec<_> = results
         .iter()


### PR DESCRIPTION
## 概要

- `vec_search` / `vec_search_multi` が `type_filter` を受け取らず、ハイブリッド検索で vec-only マッチに `chunk_type` 違反の chunk が混入していた
- 両関数のシグネチャに `type_filter: Option<&[ChunkType]>` を追加し、既存の `append_type_filter` を `path_filter` と同列に適用
- recall #35 と同種の FTS↔vec 非対称性を解消するが、yomu は既存の `append_*` helper が揃っているため SQL push-down 方式で対応（recall は post-filter 方式）

Closes #103

## 変更内容

- `src/storage/search.rs:107-111, 321-326` — `vec_search` / `vec_search_multi` のシグネチャに `type_filter` 追加
- `src/storage/search.rs:158` — `append_type_filter(&mut sql, &mut params, "chunk_type", type_filter)` を `append_path_filter` の直後に追加
- `src/query.rs:412-416` — `type_filter` の構築を `search_pipeline` 全体のスコープに移し、vec / FTS 両パスに渡す
- `src/query.rs:353` — `search_from_file` は type_filter 不使用仕様のため `None` を渡す
- `src/storage/tests.rs` — 新規テスト追加（T-562: `vec_search_respects_type_filter`, T-563: `vec_search_multi_respects_type_filter`）+ 既存テストの呼び出しを新シグネチャに追随
- `Cargo.lock` — transitive deps bump (rustls, winnow) は別コミット

## 関連

- recall #35 (https://github.com/thkt/recall/pull/44) — 同種の非対称性を recall で修正済
- amici #13 (https://github.com/thkt/amici/issues/13) — `escape_like` / `like_prefix_match` の共通化
- amici #14 (https://github.com/thkt/amici/issues/14) — FTS↔vec 対称性テストヘルパー

## テスト確認

- [x] `cargo test --lib` (425 passed, 0 failed)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [ ] 実環境 (vec モデル有効) で `--type` フィルタと hybrid search の組み合わせ動作確認