### PR TITLE
storage: append_* フィルタ実装を amici::storage::filter に移譲

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=2a8c734#2a8c734f011d02987de98a1f290f44114e6a413d"
+source = "git+https://github.com/thkt/amici?rev=fe47f65#fe47f65a0cb61d911fde95dc57c58d349c33afcf"
 dependencies = [
  "rurico",
  "rusqlite",
@@ -2056,7 +2056,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=e83581c#e83581cd3976363522bca282e489194567f034cf"
+source = "git+https://github.com/thkt/rurico?rev=7b739d1#7b739d100596d962a871a5bf2956c7bc698d0ba1"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -2073,7 +2073,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=e83581c#e83581cd3976363522bca282e489194567f034cf"
+source = "git+https://github.com/thkt/rurico?rev=7b739d1#7b739d100596d962a871a5bf2956c7bc698d0ba1"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ repository = "https://github.com/thkt/yomu"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "2a8c734" }
+amici = { git = "https://github.com/thkt/amici", rev = "fe47f65" }
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
-rurico = { git = "https://github.com/thkt/rurico", rev = "e83581c" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "7b739d1" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -30,7 +30,7 @@ tree-sitter-rust = "0.24"
 tree-sitter-typescript = "0.23"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "e83581c", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "7b739d1", features = ["test-support"] }
 tempfile = "3"
 
 [lints.rust]

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -28,6 +28,10 @@ fn chunk_from_row(row: &Row<'_>, offset: usize) -> rusqlite::Result<Chunk> {
 /// Appends a chunk-type `IN (...)` filter, treating both `None` and
 /// `Some(&[])` as "no filter". Contrast with [`append_in_filter`], which
 /// renders `Some(&[])` as `AND 1 = 0`.
+///
+/// Precondition: `sql` ends inside an open WHERE clause — callers anchor with
+/// `MATCH ?` (FTS path) or a trailing `IN (...)` (vec path) so the leading
+/// ` AND ` from amici helpers attaches cleanly.
 fn append_chunk_type_filter(
     sql: &mut String,
     params: &mut Vec<Box<dyn ToSql>>,

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -1,5 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
+use amici::storage::filter::{
+    append_exclude_ids, append_in_filter, append_include_ids, append_like_prefix_filter,
+};
 use rurico::storage::{fts_quote, prepare_match_query};
 use rusqlite::{Connection, Error as RusqliteError, Row, params, params_from_iter, types::ToSql};
 
@@ -22,86 +25,20 @@ fn chunk_from_row(row: &Row<'_>, offset: usize) -> rusqlite::Result<Chunk> {
     })
 }
 
-fn append_type_filter(
+/// Appends a chunk-type `IN (...)` filter, treating both `None` and
+/// `Some(&[])` as "no filter". Contrast with [`append_in_filter`], which
+/// renders `Some(&[])` as `AND 1 = 0`.
+fn append_chunk_type_filter(
     sql: &mut String,
     params: &mut Vec<Box<dyn ToSql>>,
-    column: &str,
+    column: &'static str,
     types: Option<&[ChunkType]>,
 ) {
-    if let Some(types) = types
-        && !types.is_empty()
-    {
-        sql.push_str(&format!(
-            " AND {column} IN ({})",
-            anon_placeholders(types.len())
-        ));
-        for t in types {
-            params.push(Box::new(t.as_str().to_owned()));
-        }
-    }
-}
-
-fn append_exclude_ids(
-    sql: &mut String,
-    params: &mut Vec<Box<dyn ToSql>>,
-    column: &str,
-    exclude_ids: &HashSet<i64>,
-) {
-    if !exclude_ids.is_empty() {
-        sql.push_str(&format!(
-            " AND {column} NOT IN ({})",
-            anon_placeholders(exclude_ids.len())
-        ));
-        for id in exclude_ids {
-            params.push(Box::new(*id));
-        }
-    }
-}
-
-fn append_include_ids(
-    sql: &mut String,
-    params: &mut Vec<Box<dyn ToSql>>,
-    column: &str,
-    include_ids: Option<&HashSet<i64>>,
-) {
-    if let Some(ids) = include_ids {
-        if ids.is_empty() {
-            sql.push_str(" AND 1 = 0");
-        } else {
-            sql.push_str(&format!(
-                " AND {column} IN ({})",
-                anon_placeholders(ids.len())
-            ));
-            for id in ids {
-                params.push(Box::new(*id));
-            }
-        }
-    }
-}
-
-fn escape_like(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('%', "\\%")
-        .replace('_', "\\_")
-}
-
-fn append_path_filter(
-    sql: &mut String,
-    params: &mut Vec<Box<dyn ToSql>>,
-    column: &str,
-    paths: &[String],
-) {
-    if paths.is_empty() {
+    let Some(types) = types.filter(|t| !t.is_empty()) else {
         return;
-    }
-    let conditions: Vec<String> = paths
-        .iter()
-        .map(|_| format!("{column} LIKE ? ESCAPE '\\'"))
-        .collect();
-    sql.push_str(&format!(" AND ({})", conditions.join(" OR ")));
-    for path in paths {
-        params.push(Box::new(format!("{}%", escape_like(path))));
-    }
+    };
+    let strings: Vec<String> = types.iter().map(|c| c.as_str().to_owned()).collect();
+    append_in_filter(sql, params, column, Some(&strings));
 }
 
 pub fn vec_search(
@@ -155,8 +92,8 @@ pub fn vec_search(
         .iter()
         .map(|id| Box::new(*id) as Box<dyn ToSql>)
         .collect();
-    append_path_filter(&mut sql, &mut params, "file_path", path_filter);
-    append_type_filter(&mut sql, &mut params, "chunk_type", type_filter);
+    append_like_prefix_filter(&mut sql, &mut params, "file_path", path_filter);
+    append_chunk_type_filter(&mut sql, &mut params, "chunk_type", type_filter);
 
     let mut stmt2 = conn.prepare(&sql)?;
     let meta: HashMap<i64, Chunk> = stmt2
@@ -238,10 +175,10 @@ pub fn search_by_fts(
     let mut params: Vec<Box<dyn ToSql>> = Vec::new();
     params.push(Box::new(fts_query));
 
-    append_type_filter(&mut sql, &mut params, "c.chunk_type", type_filter);
+    append_chunk_type_filter(&mut sql, &mut params, "c.chunk_type", type_filter);
     append_exclude_ids(&mut sql, &mut params, "c.id", exclude_ids);
     append_include_ids(&mut sql, &mut params, "c.id", include_ids);
-    append_path_filter(&mut sql, &mut params, "c.file_path", path_filter);
+    append_like_prefix_filter(&mut sql, &mut params, "c.file_path", path_filter);
     sql.push_str(&format!(" ORDER BY {BM25_EXPR} LIMIT ?"));
     params.push(Box::new(limit));
 


### PR DESCRIPTION
## 概要

`src/storage/search.rs` に inline 実装していた SQL フィルタ構築ヘルパー 4 本を `amici::storage::filter` の共有実装で置き換えるリファクタリング。public API のシグネチャ・挙動は変更なし。

## Motivation

yomu / recall / sae の 3 リポが同一の SQL filter 構築ロジックをそれぞれ保持していた。amici #15 → PR #19 で `append_*` ヘルパーファミリーを amici に集約したため、yomu 側の自前実装をその下流として置き換える。See also: #105

## 変更内容

### ヘルパー置換マッピング

| yomu 自前実装 | amici 置換先 |
|---|---|
| `append_type_filter` | `append_in_filter` + `append_chunk_type_filter` wrapper |
| `append_exclude_ids` | `append_exclude_ids` (同名) |
| `append_include_ids` | `append_include_ids` (同名) |
| `append_path_filter` | `append_like_prefix_filter` |

### 意味論の吸収

yomu の `append_type_filter` は `Some(&[])` を no-op として扱うが、amici の `append_in_filter` は `Some(&[])` を `AND 1 = 0` に変換する。呼び出し側の形状に合わせた wrapper `append_chunk_type_filter` を `search.rs` に追加し、empty slice → skip に正規化することで既存の挙動を維持。

### 依存バンプ

| crate | 変更前 | 変更後 | 理由 |
|---|---|---|---|
| amici | `2a8c734` | `fe47f65` | PR #19 本体 + filter 内部整理 |
| rurico | `e83581c` | `7b739d1` | amici の推移依存、API 変更なし |

### diffstat

3 ファイル変更、22 insertions / 85 deletions (net −63 行)

## Verification

- [x] Unit tests: 425 passed / 0 failed
- [x] Integration tests: 34 passed / 0 failed
- [x] `cargo clippy -- -D warnings`: クリーン
- [x] Codex review: blocking regression 0
- [x] T-544 / T-561 / T-562 / T-563 (type-filter / exclude テスト): 全 pass

## Follow-up (別 issue 化予定)

以下は本 PR のスコープ外。別途対応予定。

- `src/storage/embed.rs:108–112`: `ChunkType → String` の inline 変換が残存
- `src/storage/embed.rs`, `src/storage/graph.rs`: inline `IN ({placeholders})` 構築が残存

Closes #109
See also: #105
