### PR TITLE
fix(resolver): bare super/self/crate を解決し symbol fallback を修正

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,9 +1344,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"

--- a/src/rust_resolver.rs
+++ b/src/rust_resolver.rs
@@ -46,6 +46,25 @@ impl RustResolver {
         None
     }
 
+    fn probe_crate_root(&self) -> Option<String> {
+        let canonical_root = self.canonical_root.as_deref();
+        for name in ["lib.rs", "main.rs"] {
+            let candidate = self.root.join("src").join(name);
+            if let Ok(abs) = candidate.canonicalize() {
+                return strip_canonical_prefix(&abs, canonical_root);
+            }
+        }
+        None
+    }
+
+    fn probe_module_or_crate_root(&self, module_path: &[String]) -> Option<String> {
+        if module_path.is_empty() {
+            return self.probe_crate_root();
+        }
+        let segments: Vec<&str> = module_path.iter().map(String::as_str).collect();
+        self.probe_module(&segments)
+    }
+
     fn probe_with_symbol_fallback(&self, segments: &[&str], min_len: usize) -> Option<String> {
         self.probe_module(segments).or_else(|| {
             (segments.len() > min_len)
@@ -55,6 +74,9 @@ impl RustResolver {
     }
 
     fn resolve_crate(&self, rest: &str) -> Option<String> {
+        if rest.is_empty() {
+            return self.probe_crate_root();
+        }
         let segments: Vec<&str> = rest.split("::").collect();
         self.probe_with_symbol_fallback(&segments, 1)
     }
@@ -62,14 +84,24 @@ impl RustResolver {
     fn resolve_super(&self, source: &str, from_file: &str) -> Option<String> {
         let mut module_path = module_path_from_file(from_file);
         let mut rest = source;
-        while let Some(after) = rest.strip_prefix("super::") {
+        loop {
+            let next = if let Some(after) = rest.strip_prefix("super::") {
+                after
+            } else if rest == "super" {
+                ""
+            } else {
+                break;
+            };
             if module_path.is_empty() {
                 return None;
             }
             module_path.pop();
-            rest = after;
+            rest = next;
         }
-        let min_len = module_path.len() + 1;
+        if rest.is_empty() {
+            return self.probe_module_or_crate_root(&module_path);
+        }
+        let min_len = module_path.len();
         let segments: Vec<&str> = module_path
             .iter()
             .map(String::as_str)
@@ -80,7 +112,10 @@ impl RustResolver {
 
     fn resolve_self(&self, rest: &str, from_file: &str) -> Option<String> {
         let module_path = module_path_from_file(from_file);
-        let min_len = module_path.len() + 1;
+        if rest.is_empty() {
+            return self.probe_module_or_crate_root(&module_path);
+        }
+        let min_len = module_path.len();
         let segments: Vec<&str> = module_path
             .iter()
             .map(String::as_str)
@@ -98,14 +133,12 @@ impl RustResolver {
     }
 
     pub fn resolve(&self, source: &str, from_file: &str) -> Option<String> {
-        if let Some(rest) = source.strip_prefix("crate::") {
-            self.resolve_crate(rest)
-        } else if source.starts_with("super::") {
-            self.resolve_super(source, from_file)
-        } else if let Some(rest) = source.strip_prefix("self::") {
-            self.resolve_self(rest, from_file)
-        } else {
-            None
+        let (head, rest) = source.split_once("::").unwrap_or((source, ""));
+        match head {
+            "crate" => self.resolve_crate(rest),
+            "super" => self.resolve_super(source, from_file),
+            "self" => self.resolve_self(rest, from_file),
+            _ => None,
         }
     }
 }
@@ -287,5 +320,105 @@ mod tests {
         // a::b::c → super → a::b → super → a → util → a::util
         let result = resolver.resolve("super::super::util", "src/a/b/c.rs");
         assert_eq!(result, Some("src/a/util.rs".to_owned()));
+    }
+
+    // T-327: resolve_super_symbol_fallback
+    #[test]
+    fn resolve_super_symbol_fallback() {
+        let tmp = tempdir().unwrap();
+        let src = tmp.path().join("src");
+        let tools = src.join("tools");
+        fs::create_dir_all(&tools).unwrap();
+        fs::write(src.join("tools.rs"), "").unwrap();
+        fs::write(tools.join("reranker.rs"), "").unwrap();
+
+        let resolver = RustResolver::new(tmp.path());
+        // `use super::Yomu` from src/tools/reranker.rs → parent module src/tools.rs
+        let result = resolver.resolve("super::Yomu", "src/tools/reranker.rs");
+        assert_eq!(result, Some("src/tools.rs".to_owned()));
+    }
+
+    // T-328: resolve_self_symbol_fallback
+    #[test]
+    fn resolve_self_symbol_fallback() {
+        let tmp = tempdir().unwrap();
+        let src = tmp.path().join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("foo.rs"), "").unwrap();
+
+        let resolver = RustResolver::new(tmp.path());
+        // `use self::Symbol` from src/foo.rs → current module src/foo.rs
+        let result = resolver.resolve("self::Symbol", "src/foo.rs");
+        assert_eq!(result, Some("src/foo.rs".to_owned()));
+    }
+
+    // T-329: resolve_bare_super
+    #[test]
+    fn resolve_bare_super() {
+        let tmp = tempdir().unwrap();
+        let src = tmp.path().join("src");
+        let tools = src.join("tools");
+        fs::create_dir_all(&tools).unwrap();
+        fs::write(src.join("tools.rs"), "").unwrap();
+        fs::write(tools.join("reranker.rs"), "").unwrap();
+
+        let resolver = RustResolver::new(tmp.path());
+        // parser emits source="super" for `use super::Yomu;`
+        let result = resolver.resolve("super", "src/tools/reranker.rs");
+        assert_eq!(result, Some("src/tools.rs".to_owned()));
+    }
+
+    // T-330: resolve_bare_self
+    #[test]
+    fn resolve_bare_self() {
+        let tmp = tempdir().unwrap();
+        let src = tmp.path().join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("foo.rs"), "").unwrap();
+
+        let resolver = RustResolver::new(tmp.path());
+        // parser emits source="self" for `use self::Symbol;`
+        let result = resolver.resolve("self", "src/foo.rs");
+        assert_eq!(result, Some("src/foo.rs".to_owned()));
+    }
+
+    // T-331: resolve_bare_crate_to_lib_rs
+    #[test]
+    fn resolve_bare_crate_to_lib_rs() {
+        let tmp = tempdir().unwrap();
+        let src = tmp.path().join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("lib.rs"), "").unwrap();
+
+        let resolver = RustResolver::new(tmp.path());
+        // parser emits source="crate" for `use crate::Yomu;`
+        let result = resolver.resolve("crate", "src/lib.rs");
+        assert_eq!(result, Some("src/lib.rs".to_owned()));
+    }
+
+    // T-332: resolve_bare_crate_to_main_rs
+    #[test]
+    fn resolve_bare_crate_to_main_rs() {
+        let tmp = tempdir().unwrap();
+        let src = tmp.path().join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("main.rs"), "").unwrap();
+
+        let resolver = RustResolver::new(tmp.path());
+        let result = resolver.resolve("crate", "src/main.rs");
+        assert_eq!(result, Some("src/main.rs".to_owned()));
+    }
+
+    // T-333: resolve_bare_super_at_root_returns_none
+    #[test]
+    fn resolve_bare_super_at_root_returns_none() {
+        let tmp = tempdir().unwrap();
+        let src = tmp.path().join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("lib.rs"), "").unwrap();
+
+        let resolver = RustResolver::new(tmp.path());
+        let result = resolver.resolve("super", "src/lib.rs");
+        assert_eq!(result, None);
     }
 }


### PR DESCRIPTION
Closes #106

## 原因 (2 層)

1. **Parser contract**: `src/indexer/chunker/rust.rs` の `parse_scoped_identifier` は `use super::Sym;` を `ParsedImport.source = \"super\"` / `specifier.name = \"Sym\"` として emit する。`use crate::mod::Sym;` のように複数 segment ある場合のみ source に `\"crate::mod\"` が入る非対称な仕様。

2. **Resolver dispatch**: `resolve()` が `\"super::\"` / `\"self::\"` / `\"crate::\"` 接頭辞しか dispatch せず、bare `\"super\"` / `\"self\"` / `\"crate\"` は全て `None`。結果、同一 crate 内 use の大半が `file_references` に記録されず、`yomu impact` の caller 解析が機能していなかった。

さらに `resolve_super` / `resolve_self` の `min_len = module_path.len() + 1` は、multi-level 形式 (`use super::super::util;` で source=`\"super::super\"`) 到達時に symbol fallback を発火させない計算ミスがあった。

## 変更

- `resolve()` を `split_once(\"::\")` で head/rest に分割し、head (`crate`/`super`/`self`) で dispatch (bare 形式も受ける)
- `resolve_crate(rest)` / `resolve_self(rest, ...)` が `rest.is_empty()` を許容 → crate root (`src/lib.rs` or `src/main.rs`) / current module を返す
- `resolve_super` のループに `rest == \"super\"` を追加し、連鎖 pop 後に rest 空なら親モジュールを返す
- `min_len = module_path.len() + 1` → `module_path.len()` (symbol fallback 発火条件の修正)
- `probe_crate_root` / `probe_module_or_crate_root` ヘルパーを追加

## テスト (T-NNN)

| Case | ID | 内容 |
| --- | --- | --- |
| bare super | T-329 | `super` from `src/tools/reranker.rs` → `src/tools.rs` |
| bare self | T-330 | `self` from `src/foo.rs` → `src/foo.rs` |
| bare crate (lib) | T-331 | `crate` from `src/lib.rs` → `src/lib.rs` |
| bare crate (main) | T-332 | `crate` from `src/main.rs` → `src/main.rs` |
| bare super at root | T-333 | `super` from `src/lib.rs` → `None` |
| super::Sym fallback | T-327 | multi-level `super::Yomu` → parent module |
| self::Sym fallback | T-328 | `self::Symbol` → current module |

## 受入基準検証 (yomu repo 自身)

- [x] `resolve_super` で `super::Symbol` が親モジュールに解決される (T-327 + bare T-329)
- [x] `resolve_self` で `self::Symbol` が現モジュールに解決される (T-328 + bare T-330)
- [x] `tests` モジュールに `super::Symbol` / `self::Symbol` の解決テスト追加 (T-327〜T-333)
- [x] `yomu rebuild` 後、`yomu impact src/tools.rs --symbol Yomu --depth 1 --json`:

修正前:
\`\`\`json
{\"symbol_refs\":[],\"dependents\":[],\"total\":0}
\`\`\`

修正後:
\`\`\`json
{\"symbol_refs\":[\"src/tools/reranker.rs\",\"src/tools/embedder.rs\"],\"dependents\":[{\"file_path\":\"src/tools/embedder.rs\",\"depth\":1},{\"file_path\":\"src/tools/reranker.rs\",\"depth\":1},{\"file_path\":\"src/tools/tests.rs\",\"depth\":1}],\"total\":3}
\`\`\`

`file_references` 件数: **35 → 112** (+77)

## 動作確認

- [x] `cargo test --lib rust_resolver` (19 passed)
- [x] `cargo test` (全 suite green)
- [x] `cargo build --release && ./target/release/yomu rebuild`
- [x] `./target/release/yomu impact src/tools.rs --symbol Yomu --depth 1 --json` で `symbol_refs` が非空 + `src/tools/reranker.rs` を含む

## 補足

- Cargo.lock に `libc 0.2.185 → 0.2.186` の incidental update が含まれる (cargo が自動更新)
- scope について #106 に [追記コメント](https://github.com/thkt/yomu/issues/106#issuecomment-4310130865) を残した (issue 本文の Fix 案だけでは integration が通らなかった経緯)