### PR TITLE
ci(dependabot): cargo と github-actions の自動更新を有効化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: chore
+      include: scope
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - rust
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      patch-and-minor:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## 概要
- `.github/dependabot.yml` を追加し、`github-actions` と `cargo` の依存を weekly で自動更新
- Cargo の minor/patch は 1 PR にグルーピング(major は個別)、ラベル `dependencies` / `ci` / `rust` を付与
- 内容は thkt/rurico#49 の設定とミラー(クロスリポジトリ整合)

## 動作確認
- [ ] PR マージ後、GitHub の Insights > Dependency graph > Dependabot で設定が認識されること
- [ ] 初回スキャン後、weekly で更新 PR が立つこと(github-actions / cargo それぞれ)
- [ ] 付与ラベル(`dependencies`/`ci`/`rust`)が PR に反映されていること

Closes #112