### PR TITLE
rurico/amici を bump し Phase 5 FTS 正規化に追従

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,10 +34,15 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=fe47f65#fe47f65a0cb61d911fde95dc57c58d349c33afcf"
+source = "git+https://github.com/thkt/amici?rev=138de41#138de41151e062efa0f7cec87ad8966dbf481256"
 dependencies = [
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
  "rurico",
  "rusqlite",
+ "serde",
+ "serde_json",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
 ]
@@ -208,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -230,6 +235,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "clang-sys"
@@ -442,6 +458,12 @@ checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
 ]
+
+[[package]]
+name = "daachorse"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f55d7153ba3b507595872a3874803f07a8a81d1e888abed8e5db7da0597d6e2"
 
 [[package]]
 name = "darling"
@@ -869,6 +891,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -981,7 +1004,7 @@ dependencies = [
  "log",
  "native-tls",
  "num_cpus",
- "rand",
+ "rand 0.9.4",
  "reqwest",
  "serde",
  "serde_json",
@@ -1032,9 +1055,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -1223,9 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1320,9 +1343,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1672,9 +1695,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onig"
-version = "6.5.1"
+version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
  "bitflags",
  "libc",
@@ -1684,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.9.1"
+version = "69.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1883,8 +1906,19 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1894,7 +1928,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1905,6 +1949,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -2056,24 +2106,27 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=7b739d1#7b739d100596d962a871a5bf2956c7bc698d0ba1"
+source = "git+https://github.com/thkt/rurico?rev=ef26de2#ef26de21cf0ef3d50f8c6dfbc8b06cf65bab0e16"
 dependencies = [
  "bytemuck",
  "hf-hub",
  "log",
  "mlx-rs",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
  "rurico-ffi",
  "rusqlite",
  "serde",
  "serde_json",
  "thiserror",
  "tokenizers",
+ "unicode-normalization",
 ]
 
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=7b739d1#7b739d100596d962a871a5bf2956c7bc698d0ba1"
+source = "git+https://github.com/thkt/rurico?rev=ef26de2#ef26de21cf0ef3d50f8c6dfbc8b06cf65bab0e16"
 dependencies = [
  "mlx-sys",
  "rusqlite",
@@ -2116,9 +2169,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
@@ -2131,9 +2184,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
@@ -2555,14 +2608,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokenizers"
-version = "0.22.2"
+name = "tinyvec"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44e5bea67576e04b6ff8564c5d9e09c2ef0cf476502245f2f120e497769d3112"
 dependencies = [
  "ahash",
- "aho-corasick",
  "compact_str",
+ "daachorse",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
@@ -2573,7 +2641,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand",
+ "rand 0.9.4",
  "rayon",
  "rayon-cond",
  "regex",
@@ -2861,6 +2929,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-normalization-alignments"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3034,9 +3111,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3047,9 +3124,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3057,9 +3134,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3067,9 +3144,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3080,9 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -3136,9 +3213,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ repository = "https://github.com/thkt/yomu"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "fe47f65" }
+amici = { git = "https://github.com/thkt/amici", rev = "138de41" }
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
-rurico = { git = "https://github.com/thkt/rurico", rev = "7b739d1" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "ef26de2" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -30,7 +30,7 @@ tree-sitter-rust = "0.24"
 tree-sitter-typescript = "0.23"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "7b739d1", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "ef26de2", features = ["test-support"] }
 tempfile = "3"
 
 [lints.rust]

--- a/src/indexer/embed.rs
+++ b/src/indexer/embed.rs
@@ -377,7 +377,7 @@ mod tests {
     // T-360: validate_rejects_empty_chunks
     #[test]
     fn validate_rejects_empty_chunks() {
-        let embs = vec![ChunkedEmbedding { chunks: vec![] }];
+        let embs = vec![ChunkedEmbedding::new(vec![])];
         assert!(validate_chunked_embeddings(embs).is_err());
     }
 
@@ -385,12 +385,8 @@ mod tests {
     #[test]
     fn validate_passes_non_empty_chunks() {
         let embs = vec![
-            ChunkedEmbedding {
-                chunks: vec![vec![1.0_f32; 3]],
-            },
-            ChunkedEmbedding {
-                chunks: vec![vec![2.0_f32; 3], vec![3.0_f32; 3]],
-            },
+            ChunkedEmbedding::new(vec![vec![1.0_f32; 3]]),
+            ChunkedEmbedding::new(vec![vec![2.0_f32; 3], vec![3.0_f32; 3]]),
         ];
         assert!(validate_chunked_embeddings(embs).is_ok());
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -23,6 +23,14 @@ pub type Db = Connection;
 
 pub use rurico::embed::EMBEDDING_DIMS;
 pub use rurico::storage::f32_as_bytes;
+pub(crate) use rurico::storage::{QueryNormalizationConfig, normalize_for_fts};
+
+/// FTS normalization shared by index INSERT and query MATCH paths.
+/// Both sides must use the same config — otherwise queries normalize while
+/// indexed text doesn't, and matches silently miss (rurico T-069-001).
+pub(crate) fn fts_normalization() -> QueryNormalizationConfig {
+    QueryNormalizationConfig::default()
+}
 
 pub(crate) use amici::storage::{anon_placeholders, as_sql_params, in_placeholders};
 
@@ -97,7 +105,7 @@ use rurico::embed::ChunkedEmbedding;
 
 #[cfg(test)]
 pub(crate) fn ce(v: Vec<f32>) -> ChunkedEmbedding {
-    ChunkedEmbedding { chunks: vec![v] }
+    ChunkedEmbedding::new(vec![v])
 }
 
 #[cfg(test)]

--- a/src/storage/mutation.rs
+++ b/src/storage/mutation.rs
@@ -5,7 +5,9 @@ use rurico::storage::f32_as_bytes;
 
 use crate::text::split_identifier;
 
-use super::{ChunkType, FileData, NewChunk, Reference, StorageError};
+use super::{
+    ChunkType, FileData, NewChunk, Reference, StorageError, fts_normalization, normalize_for_fts,
+};
 
 pub(crate) fn insert_chunk_row(
     conn: &Connection,
@@ -36,14 +38,15 @@ pub(crate) fn insert_chunk_row(
         .name
         .map(|n| split_identifier(n).join(" "))
         .unwrap_or_default();
+    let normalization = fts_normalization();
     conn.prepare_cached(
         "INSERT INTO fts_chunks(rowid, name, content, file_path) VALUES (?1, ?2, ?3, ?4)",
     )?
     .execute(rusqlite::params![
         chunk_id,
-        fts_name,
-        chunk.content,
-        file_path
+        normalize_for_fts(&fts_name, &normalization),
+        normalize_for_fts(chunk.content, &normalization),
+        normalize_for_fts(file_path, &normalization),
     ])?;
 
     Ok(chunk_id)

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -10,7 +10,7 @@ use rusqlite::ffi::{Error as FfiError, ErrorCode};
 
 use crate::text::split_identifier;
 
-use super::{EMBEDDING_DIMS, StorageError};
+use super::{EMBEDDING_DIMS, StorageError, fts_normalization, normalize_for_fts};
 
 pub fn open_db(path: &Path) -> Result<Connection, StorageError> {
     ensure_sqlite_vec().map_err(|e| StorageError::Io(io::Error::other(e)))?;
@@ -271,6 +271,7 @@ fn rebuild_fts_v7(conn: &Connection) -> Result<(), StorageError> {
         let mut insert = conn.prepare(
             "INSERT INTO fts_chunks(rowid, name, content, file_path) VALUES (?1, ?2, ?3, ?4)",
         )?;
+        let normalization = fts_normalization();
         while let Some(row) = rows.next()? {
             let id: i64 = row.get(0)?;
             let path: String = row.get(1)?;
@@ -280,7 +281,12 @@ fn rebuild_fts_v7(conn: &Connection) -> Result<(), StorageError> {
                 .as_deref()
                 .map(|n| split_identifier(n).join(" "))
                 .unwrap_or_default();
-            insert.execute(rusqlite::params![id, fts_name, content, path])?;
+            insert.execute(rusqlite::params![
+                id,
+                normalize_for_fts(&fts_name, &normalization),
+                normalize_for_fts(&content, &normalization),
+                normalize_for_fts(&path, &normalization),
+            ])?;
         }
     }
 

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -8,7 +8,7 @@ use rusqlite::{Connection, Error as RusqliteError, Row, params, params_from_iter
 
 use super::{
     Chunk, ChunkType, MatchSource, SearchResult, StorageError, anon_placeholders, f32_as_bytes,
-    in_placeholders,
+    fts_normalization, in_placeholders,
 };
 
 const VEC_MAXSIM_OVERSAMPLE: u32 = 10;
@@ -149,16 +149,19 @@ pub fn search_by_fts(
         return Ok(Vec::new());
     }
 
+    let normalization = fts_normalization();
     let parts: Vec<String> = keywords
         .iter()
-        .filter_map(|k| match prepare_match_query(conn, k, "fts_chunks_vocab") {
-            Ok(m) if !m.as_str().is_empty() => Some(m.into_string()),
-            Err(e) if !k.trim().is_empty() => {
-                tracing::debug!(keyword = %k, error = %e, "prepare_match_query failed, falling back to fts_quote");
-                Some(fts_quote(k))
-            }
-            _ => None,
-        })
+        .filter_map(
+            |k| match prepare_match_query(conn, k, "fts_chunks_vocab", &normalization) {
+                Ok(m) if !m.as_str().is_empty() => Some(m.into_string()),
+                Err(e) if !k.trim().is_empty() => {
+                    tracing::debug!(keyword = %k, error = %e, "prepare_match_query failed, falling back to fts_quote");
+                    Some(fts_quote(k))
+                }
+                _ => None,
+            },
+        )
         .collect();
     if parts.is_empty() {
         return Ok(Vec::new());

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -2497,8 +2497,8 @@ fn fts_stores_split_identifier_name() {
         .unwrap();
 
     assert_eq!(
-        fts_name, "use Auth Provider",
-        "FTS name column should contain split-identifier output"
+        fts_name, "use auth provider",
+        "FTS name column should contain split-identifier output (NFKC + ASCII lowercase via rurico Phase 5 normalization)"
     );
 }
 
@@ -2651,8 +2651,8 @@ fn migration_populates_fts_name_with_split_identifier() {
         )
         .unwrap();
     assert_eq!(
-        fts_name, "get User Name",
-        "migration should populate FTS name with split_identifier output"
+        fts_name, "get user name",
+        "migration should populate FTS name with split_identifier output (NFKC + ASCII lowercase via rurico Phase 5 normalization)"
     );
 }
 


### PR DESCRIPTION
## 概要

rurico/amici を Phase 5 後の commit に bump し、query/index 双方の FTS 正規化を一致させる。query 側だけ正規化されると index と match せず無音で空振るため（rurico T-069-001 で挙動 pin 済み）、両側で同じ `QueryNormalizationConfig` を共有する。

## 変更内容

- **Cargo.toml**: rurico `7b739d1` → `ef26de2`、amici `fe47f65` → `138de41`
- **src/storage.rs**: `fts_normalization()` 共有ヘルパー追加（NFKC + ASCII lowercase + whitespace collapse）
- **src/storage/search.rs**: `prepare_match_query` の新 4 引数 signature に追従
- **src/storage/mutation.rs**: `insert_chunk_row` で FTS INSERT 時に `name`/`content`/`file_path` を normalize
- **src/storage/schema.rs**: `rebuild_fts_v7` migration 内でも同様に normalize（v6→v7 移行時に整合性維持）
- **src/indexer/embed.rs / src/storage.rs**: `ChunkedEmbedding { chunks: ... }` → `ChunkedEmbedding::new(...)`（chunk_ids 自動採番）
- **src/storage/tests.rs**: 既存テスト 2 件の期待値を normalized 値に更新（"use Auth Provider" → "use auth provider"）

## 設計判断

- **`fts_chunks.file_path` も normalize**: search 側は `fts_chunks MATCH ?` で全カラム対象のため、index も全カラム揃えた。raw な file_path は `chunks.file_path` に残るので、検索結果表示には影響なし。
- **v2→v3 migration には normalize 適用せず**: 後段の v6→v7 (`rebuild_fts_v7`) で必ず再構築されるため、現行 schema_version (v8) のユーザーには影響なし。

## 動作確認

1. `cargo build --all-targets` → エラーなし
2. `cargo test --all-targets` → 433 テスト全通過
3. `cargo clippy --all-targets --all-features -- -D warnings` → warning なし
4. 既存 DB は `yomu reindex` または schema migration で v8 まで進めると FTS が normalized 値で再構築される

## 関連

- Closes #120
- Refs: rurico #79（Phase 5 PR）, rurico #69（Phase 5 issue）
