### PR TITLE
feat(resolver): Phase 1b - クレート自己参照の解決

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -167,9 +167,13 @@ fn check_file(
     }))
 }
 
-fn prepare_chunks(checked: CheckedFile, file_path: &Path) -> Option<PendingFile> {
+fn prepare_chunks(
+    checked: CheckedFile,
+    file_path: &Path,
+    crate_name: Option<&str>,
+) -> Option<PendingFile> {
     let ext = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
-    let file_chunks = chunker::chunk_file(&checked.source, ext);
+    let file_chunks = chunker::chunk_file_with_crate_name(&checked.source, ext, crate_name);
     if file_chunks.chunks.is_empty() {
         tracing::debug!(file = %checked.rel_path, "Skipped (no chunks)");
         return None;
@@ -212,7 +216,7 @@ fn process_file(
         CheckResult::Skip => return Ok(FileOutcome::Skipped),
         CheckResult::Error => return Ok(FileOutcome::Errored),
     };
-    let Some(pf) = prepare_chunks(checked, file_path) else {
+    let Some(pf) = prepare_chunks(checked, file_path, rust_resolver.crate_name()) else {
         return Ok(FileOutcome::Skipped);
     };
     let n = pf.raw_chunks.len() as u32;
@@ -246,6 +250,7 @@ fn collect_pending_files(
     root: &Path,
     files: &[PathBuf],
     force: bool,
+    crate_name: Option<&str>,
 ) -> Result<CollectResult, IndexError> {
     let mut pending: Vec<PendingFile> = Vec::new();
     let mut files_skipped = 0u32;
@@ -269,7 +274,7 @@ fn collect_pending_files(
                 }
             }
         };
-        match prepare_chunks(checked, file_path) {
+        match prepare_chunks(checked, file_path, crate_name) {
             Some(pf) => pending.push(pf),
             None => {
                 files_skipped += 1;
@@ -518,14 +523,14 @@ pub fn run_index(
     }
     tracing::info!(file_count = files.len(), force, "Starting indexing");
 
-    let collected = collect_pending_files(conn, root, &files, force)?;
+    let resolver = Resolver::new(root);
+    let rust_resolver = RustResolver::new(root);
+
+    let collected = collect_pending_files(conn, root, &files, force, rust_resolver.crate_name())?;
     let files_skipped = collected.files_skipped;
     let mut files_errored = collected.files_errored;
 
     remove_orphans(conn, &collected.rel_paths)?;
-
-    let resolver = Resolver::new(root);
-    let rust_resolver = RustResolver::new(root);
     let embed_result =
         embed_and_store(conn, embedder, collected.pending, &resolver, &rust_resolver)?;
     let files_processed = embed_result.files_processed;

--- a/src/indexer/chunker.rs
+++ b/src/indexer/chunker.rs
@@ -71,10 +71,18 @@ impl FileChunks {
 }
 
 pub fn chunk_file(source: &str, extension: &str) -> FileChunks {
+    chunk_file_with_crate_name(source, extension, None)
+}
+
+pub fn chunk_file_with_crate_name(
+    source: &str,
+    extension: &str,
+    crate_name: Option<&str>,
+) -> FileChunks {
     match extension {
         "tsx" | "jsx" => ts::chunk_tsx(source),
         "ts" | "js" | "mjs" => ts::chunk_ts(source),
-        "rs" => rust::chunk_rust(source),
+        "rs" => rust::chunk_rust(source, crate_name),
         "css" => FileChunks::chunks_only(css_html::chunk_css(source)),
         "html" => FileChunks::chunks_only(css_html::chunk_html(source)),
         "md" => FileChunks::chunks_only(markdown::chunk_markdown(source)),

--- a/src/indexer/chunker/rust.rs
+++ b/src/indexer/chunker/rust.rs
@@ -7,9 +7,9 @@ use super::{
     chunk_fallback, extract_name, make_chunk, make_parser, other_or_skip,
 };
 
-fn is_internal_path(path: &str) -> bool {
+fn is_internal_path(path: &str, crate_name: Option<&str>) -> bool {
     let prefix = path.split("::").next().unwrap_or("");
-    matches!(prefix, "crate" | "super" | "self")
+    matches!(prefix, "crate" | "super" | "self") || Some(prefix) == crate_name
 }
 
 fn classify_rust_node(node: &Node, source: &str) -> Option<RawChunk> {
@@ -106,11 +106,15 @@ fn collect_use_list_imports(base_path: &str, list: &Node, source: &str) -> Vec<P
     extra_imports
 }
 
-fn parse_scoped_identifier(node: &Node, source: &str) -> Option<ParsedImport> {
+fn parse_scoped_identifier(
+    node: &Node,
+    source: &str,
+    crate_name: Option<&str>,
+) -> Option<ParsedImport> {
     let path_node = node.child_by_field_name("path")?;
     let name_node = node.child_by_field_name("name")?;
     let path = &source[path_node.byte_range()];
-    if !is_internal_path(path) {
+    if !is_internal_path(path, crate_name) {
         return None;
     }
     Some(ParsedImport {
@@ -123,7 +127,7 @@ fn parse_scoped_identifier(node: &Node, source: &str) -> Option<ParsedImport> {
     })
 }
 
-fn parse_scoped_use_list(node: &Node, source: &str) -> Vec<ParsedImport> {
+fn parse_scoped_use_list(node: &Node, source: &str, crate_name: Option<&str>) -> Vec<ParsedImport> {
     let (Some(path_node), Some(list_node)) = (
         node.child_by_field_name("path"),
         node.child_by_field_name("list"),
@@ -131,19 +135,19 @@ fn parse_scoped_use_list(node: &Node, source: &str) -> Vec<ParsedImport> {
         return vec![];
     };
     let base_path = &source[path_node.byte_range()];
-    if !is_internal_path(base_path) {
+    if !is_internal_path(base_path, crate_name) {
         return vec![];
     }
     collect_use_list_imports(base_path, &list_node, source)
 }
 
-fn parse_use_wildcard(node: &Node, source: &str) -> Option<ParsedImport> {
+fn parse_use_wildcard(node: &Node, source: &str, crate_name: Option<&str>) -> Option<ParsedImport> {
     let mut cursor = node.walk();
     let path_node = node
         .children(&mut cursor)
         .find(tree_sitter::Node::is_named)?;
     let path = &source[path_node.byte_range()];
-    if !is_internal_path(path) {
+    if !is_internal_path(path, crate_name) {
         return None;
     }
     Some(ParsedImport {
@@ -156,14 +160,18 @@ fn parse_use_wildcard(node: &Node, source: &str) -> Option<ParsedImport> {
     })
 }
 
-fn parse_use_as_clause(node: &Node, source: &str) -> Option<ParsedImport> {
+fn parse_use_as_clause(
+    node: &Node,
+    source: &str,
+    crate_name: Option<&str>,
+) -> Option<ParsedImport> {
     let path_node = node.child_by_field_name("path")?;
     let alias_node = node.child_by_field_name("alias")?;
     if path_node.kind() == "scoped_identifier" {
         let inner_path = path_node.child_by_field_name("path")?;
         let inner_name = path_node.child_by_field_name("name")?;
         let path = &source[inner_path.byte_range()];
-        if !is_internal_path(path) {
+        if !is_internal_path(path, crate_name) {
             return None;
         }
         Some(ParsedImport {
@@ -198,17 +206,21 @@ fn parse_mod_decl(node: &Node, source: &str) -> Option<ParsedImport> {
     })
 }
 
-fn parse_rust_use(node: &Node, source: &str) -> Vec<ParsedImport> {
+fn parse_rust_use(node: &Node, source: &str, crate_name: Option<&str>) -> Vec<ParsedImport> {
     let Some(argument) = node.child_by_field_name("argument") else {
         return vec![];
     };
     match argument.kind() {
-        "scoped_identifier" => parse_scoped_identifier(&argument, source)
+        "scoped_identifier" => parse_scoped_identifier(&argument, source, crate_name)
             .into_iter()
             .collect(),
-        "scoped_use_list" => parse_scoped_use_list(&argument, source),
-        "use_wildcard" => parse_use_wildcard(&argument, source).into_iter().collect(),
-        "use_as_clause" => parse_use_as_clause(&argument, source).into_iter().collect(),
+        "scoped_use_list" => parse_scoped_use_list(&argument, source, crate_name),
+        "use_wildcard" => parse_use_wildcard(&argument, source, crate_name)
+            .into_iter()
+            .collect(),
+        "use_as_clause" => parse_use_as_clause(&argument, source, crate_name)
+            .into_iter()
+            .collect(),
         _ => vec![],
     }
 }
@@ -229,7 +241,7 @@ fn extract_rust_impl_name(node: &Node, source: &str) -> Option<String> {
     }
 }
 
-pub(super) fn chunk_rust(source: &str) -> FileChunks {
+pub(super) fn chunk_rust(source: &str, crate_name: Option<&str>) -> FileChunks {
     let Some(mut parser) = make_parser(&tree_sitter_rust::LANGUAGE.into()) else {
         return FileChunks::chunks_only(chunk_fallback(source));
     };
@@ -247,7 +259,7 @@ pub(super) fn chunk_rust(source: &str) -> FileChunks {
         match node.kind() {
             "use_declaration" => {
                 imports.push(source[node.byte_range()].to_owned());
-                parsed_imports.extend(parse_rust_use(&node, source));
+                parsed_imports.extend(parse_rust_use(&node, source, crate_name));
                 pending_comments.clear();
             }
             "mod_item" => {

--- a/src/indexer/chunker/tests.rs
+++ b/src/indexer/chunker/tests.rs
@@ -1398,3 +1398,29 @@ fn chunk_rust_emits_private_mod_declarations() {
             .collect::<Vec<_>>()
     );
 }
+
+// T-575 [Spec T-004]: chunk_rust_treats_crate_name_prefix_as_internal
+//
+// FR-004: when `crate_name = Some("myapp")` is supplied, `use myapp::foo::Bar;`
+// must be emitted as a ParsedImport (treated as internal). Without crate_name,
+// the same path is dropped as external (regression-guarded by T-469).
+#[test]
+fn chunk_rust_treats_crate_name_prefix_as_internal() {
+    let source = "use myapp::foo::Bar;\nfn run() {}";
+    let with_name = chunk_file_with_crate_name(source, "rs", Some("myapp"));
+    assert_eq!(
+        with_name.parsed_imports.len(),
+        1,
+        "expected 1 internal ParsedImport when crate_name matches, got: {:?}",
+        with_name.parsed_imports
+    );
+    assert_eq!(with_name.parsed_imports[0].source, "myapp::foo");
+    assert_eq!(with_name.parsed_imports[0].specifiers[0].name, "Bar");
+
+    let without_name = chunk_file(source, "rs");
+    assert!(
+        without_name.parsed_imports.is_empty(),
+        "expected no parsed_imports when crate_name is None, got: {:?}",
+        without_name.parsed_imports
+    );
+}

--- a/src/indexer/chunker/tests.rs
+++ b/src/indexer/chunker/tests.rs
@@ -1399,11 +1399,7 @@ fn chunk_rust_emits_private_mod_declarations() {
     );
 }
 
-// T-575 [Spec T-004]: chunk_rust_treats_crate_name_prefix_as_internal
-//
-// FR-004: when `crate_name = Some("myapp")` is supplied, `use myapp::foo::Bar;`
-// must be emitted as a ParsedImport (treated as internal). Without crate_name,
-// the same path is dropped as external (regression-guarded by T-469).
+// T-575: chunk_rust_treats_crate_name_prefix_as_internal
 #[test]
 fn chunk_rust_treats_crate_name_prefix_as_internal() {
     let source = "use myapp::foo::Bar;\nfn run() {}";

--- a/src/rust_resolver.rs
+++ b/src/rust_resolver.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::resolver::{Resolve, strip_canonical_prefix};
@@ -5,6 +6,7 @@ use crate::resolver::{Resolve, strip_canonical_prefix};
 pub struct RustResolver {
     root: PathBuf,
     canonical_root: Option<PathBuf>,
+    crate_name: Option<String>,
 }
 
 fn module_path_from_file(from_file: &str) -> Vec<String> {
@@ -126,10 +128,16 @@ impl RustResolver {
 
     pub fn new(root: &Path) -> Self {
         let canonical_root = root.canonicalize().ok();
+        let crate_name = read_crate_name(root);
         Self {
             root: root.to_path_buf(),
             canonical_root,
+            crate_name,
         }
+    }
+
+    pub(crate) fn crate_name(&self) -> Option<&str> {
+        self.crate_name.as_deref()
     }
 
     pub fn resolve(&self, source: &str, from_file: &str) -> Option<String> {
@@ -138,6 +146,7 @@ impl RustResolver {
             "crate" => self.resolve_crate(rest),
             "super" => self.resolve_super(source, from_file),
             "self" => self.resolve_self(rest, from_file),
+            name if Some(name) == self.crate_name.as_deref() => self.resolve_crate(rest),
             _ => None,
         }
     }
@@ -145,6 +154,28 @@ impl RustResolver {
     pub fn resolve_mod_decl(&self, name: &str, from_file: &str) -> Option<String> {
         self.resolve(&format!("self::{name}"), from_file)
     }
+}
+
+fn read_crate_name(root: &Path) -> Option<String> {
+    let content = fs::read_to_string(root.join("Cargo.toml")).ok()?;
+    let mut in_package = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if let Some(section) = trimmed.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+            in_package = section.trim() == "package";
+            continue;
+        }
+        if !in_package {
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("name") {
+            let after_eq = rest.trim_start().strip_prefix('=')?.trim();
+            let stripped = after_eq.strip_prefix('"')?;
+            let end = stripped.find('"')?;
+            return Some(stripped[..end].replace('-', "_"));
+        }
+    }
+    None
 }
 
 impl Resolve for RustResolver {

--- a/src/rust_resolver/tests.rs
+++ b/src/rust_resolver/tests.rs
@@ -319,11 +319,7 @@ fn resolve_mod_decl_in_submodule() {
     assert_eq!(result, Some("src/storage/graph.rs".to_owned()));
 }
 
-// T-337 [Spec T-004 / BR-005]: read_crate_name_normalizes_hyphen_to_underscore
-//
-// BR-005: Cargo.toml `name = "foo-bar"` is normalized to `foo_bar` so that
-// `use foo_bar::xxx` (the actual import path Rust generates) matches the
-// crate identifier stored on RustResolver.
+// T-337: read_crate_name_normalizes_hyphen_to_underscore
 #[test]
 fn read_crate_name_normalizes_hyphen_to_underscore() {
     let tmp = tempdir().unwrap();
@@ -338,11 +334,7 @@ fn read_crate_name_normalizes_hyphen_to_underscore() {
     assert_eq!(resolver.crate_name(), Some("foo_bar"));
 }
 
-// T-338 [Spec T-004]: resolve_crate_self_reference_via_package_name
-//
-// FR-004: when Cargo.toml declares `name = "myapp"`, `use myapp::foo::Bar`
-// resolves to src/foo.rs the same way `use crate::foo::Bar` would. Without
-// the package name (no Cargo.toml), the same path returns None (external).
+// T-338: resolve_crate_self_reference_via_package_name
 #[test]
 fn resolve_crate_self_reference_via_package_name() {
     let tmp = tempdir().unwrap();
@@ -360,11 +352,7 @@ fn resolve_crate_self_reference_via_package_name() {
     assert_eq!(result, Some("src/foo.rs".to_owned()));
 }
 
-// T-339 [Spec T-004]: resolve_without_cargo_toml_falls_through
-//
-// FR-004 / AS-002 fallback: when no Cargo.toml is present (workspace-only or
-// missing), crate_name is None and `use myapp::xxx` returns None instead of
-// panicking. Other resolve paths (`crate::`, `self::`) keep working.
+// T-339: resolve_without_cargo_toml_falls_through
 #[test]
 fn resolve_without_cargo_toml_falls_through() {
     let tmp = tempdir().unwrap();

--- a/src/rust_resolver/tests.rs
+++ b/src/rust_resolver/tests.rs
@@ -318,3 +318,66 @@ fn resolve_mod_decl_in_submodule() {
     let result = resolver.resolve_mod_decl("graph", "src/storage.rs");
     assert_eq!(result, Some("src/storage/graph.rs".to_owned()));
 }
+
+// T-337 [Spec T-004 / BR-005]: read_crate_name_normalizes_hyphen_to_underscore
+//
+// BR-005: Cargo.toml `name = "foo-bar"` is normalized to `foo_bar` so that
+// `use foo_bar::xxx` (the actual import path Rust generates) matches the
+// crate identifier stored on RustResolver.
+#[test]
+fn read_crate_name_normalizes_hyphen_to_underscore() {
+    let tmp = tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("src")).unwrap();
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nname = \"foo-bar\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+
+    let resolver = RustResolver::new(tmp.path());
+    assert_eq!(resolver.crate_name(), Some("foo_bar"));
+}
+
+// T-338 [Spec T-004]: resolve_crate_self_reference_via_package_name
+//
+// FR-004: when Cargo.toml declares `name = "myapp"`, `use myapp::foo::Bar`
+// resolves to src/foo.rs the same way `use crate::foo::Bar` would. Without
+// the package name (no Cargo.toml), the same path returns None (external).
+#[test]
+fn resolve_crate_self_reference_via_package_name() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("foo.rs"), "").unwrap();
+    fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[package]\nname = \"myapp\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+
+    let resolver = RustResolver::new(tmp.path());
+    let result = resolver.resolve("myapp::foo::Bar", "src/main.rs");
+    assert_eq!(result, Some("src/foo.rs".to_owned()));
+}
+
+// T-339 [Spec T-004]: resolve_without_cargo_toml_falls_through
+//
+// FR-004 / AS-002 fallback: when no Cargo.toml is present (workspace-only or
+// missing), crate_name is None and `use myapp::xxx` returns None instead of
+// panicking. Other resolve paths (`crate::`, `self::`) keep working.
+#[test]
+fn resolve_without_cargo_toml_falls_through() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("foo.rs"), "").unwrap();
+
+    let resolver = RustResolver::new(tmp.path());
+    assert_eq!(resolver.crate_name(), None);
+    assert_eq!(resolver.resolve("myapp::foo", "src/main.rs"), None);
+    assert_eq!(
+        resolver.resolve("crate::foo", "src/main.rs"),
+        Some("src/foo.rs".to_owned()),
+        "crate:: must keep working when crate_name is None"
+    );
+}


### PR DESCRIPTION
## 概要

`yomu brief` 構想の Phase 1b。`use <crate_name>::xxx`（`<crate_name>` が `Cargo.toml [package].name` と一致する場合）を `use crate::xxx` と等価な内部パスとして扱えるようにする。

`feat/brief-phase-1a`（mod 宣言 edge 化）の上に積んだ stacked PR。

## 仕様・SOW

- SOW: `.claude/workspace/planning/2026-04-30-brief/sow.md`
- Spec: `.claude/workspace/planning/2026-04-30-brief/spec.md`
- カバー範囲: FR-004 / BR-005 / AS-002 fallback
- 受け入れ基準: AC-2

## 変更内容

| Commit | スコープ | ファイル |
|---|---|---|
| `a00d447` | PoC fast-forward (`poc/resolver-crate-self-ref` d405b69 を cherry-pick) | chunker/rust.rs, chunker.rs, rust_resolver.rs, indexer.rs |
| `32580c5` | テスト追加 | indexer/chunker/tests.rs, rust_resolver/tests.rs |

### Resolver 層 (`rust_resolver.rs`)

- `crate_name: Option<String>` フィールドを追加し `Cargo.toml [package].name` から読み込む
- BR-005: ハイフンをアンダースコアに正規化（`name = "foo-bar"` → `foo_bar`）。Rust が実際に生成する import path に合わせる
- `resolve` の match に `<crate_name>::xxx` 経路を追加し `resolve_crate` に委譲
- AS-002: `Cargo.toml` 不在時は `crate_name = None` で graceful degrade、他の resolve 経路は影響なし

### Chunker 層 (`chunker/rust.rs`, `chunker.rs`)

- `parse_rust_use` および補助関数（`parse_scoped_identifier`, `parse_scoped_use_list`, `parse_use_wildcard`, `parse_use_as_clause`）に `crate_name: Option<&str>` を threading
- 新エントリ `chunk_file_with_crate_name(source, ext, crate_name)` を公開。既存 `chunk_file` は `None` で呼び出して後方互換維持

### Indexer 配線 (`indexer.rs`)

- `prepare_chunks` と `collect_pending_files` が `crate_name` を受け取り chunker に転送
- Resolver の `crate_name()` をファイル単位で chunker 層に渡す

## テスト追加

| ID | 対象 | Spec 対応 |
|---|---|---|
| T-575 | `chunk_rust_treats_crate_name_prefix_as_internal` | T-004 (FR-004 chunker 層) |
| T-337 | `read_crate_name_normalizes_hyphen_to_underscore` | BR-005 |
| T-338 | `resolve_crate_self_reference_via_package_name` | FR-004 resolver 層 |
| T-339 | `resolve_without_cargo_toml_falls_through` | AS-002 fallback |

## AC-2 検証

| 基準 | 期待値 | 実測値 |
|---|---|---|
| AC-2-1: `use <crate_name>::xxx` を internal 化 | `src/main.rs` の outgoing edge >= 1 (PoC 計測値: 6) | 6 |
| AC-2-2: 既存 `use crate::` の挙動を破壊しない | `cargo test --lib` >= 433 pass | 442 pass |

## テスト計画

- [ ] `cargo test --lib` (442 tests pass)
- [ ] `cargo test --test cli_integration` (38 tests pass)
- [ ] `cargo clippy -- -D warnings` (0 warnings)
- [ ] Phase 1a が main にマージされた後、本ブランチを rebase または merge して履歴を整理
- [ ] フレッシュ index 実行後 `sqlite3 .yomu/index.db "SELECT COUNT(*) FROM file_references WHERE source_file='src/main.rs'"` が >= 1 を返すこと

## 備考

- 本 PR は `feat/brief-phase-1a`（mod 宣言 edge 化）に依存。マージ順序: 1a → main → 1b の base を main に切り替え → 1b マージ
- 既存の `crate::`, `self::`, `super::` 解決の意味論には変更なし
- workspace-only / Cargo.toml 不在のリポジトリでも AS-002 fallback で動作継続。T-339 がこれを保証