### PR TITLE
feat(brief): Phase 1c - yomu brief サブコマンド実装

### DIFF
--- a/src/brief.rs
+++ b/src/brief.rs
@@ -1,9 +1,7 @@
-//! Brief expansion plan: TaskBrief -> forward closure -> chunks -> BriefOutput.
-//!
-//! Phase 1c-3 scaffold. cap (BR-001) and topo sort (BR-002) are deferred to
-//! follow-up commits in this phase.
+//! Brief expansion plan: TaskBrief -> forward closure -> chunks -> cap -> topo -> BriefOutput.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::fmt;
 
 use rusqlite::Connection;
 use serde::Serialize;
@@ -40,6 +38,17 @@ pub enum ChunkInclusionReason {
     Forward(u32),
     Sibling,
     ModDecl,
+}
+
+impl fmt::Display for ChunkInclusionReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Seed => f.write_str("seed"),
+            Self::Forward(n) => write!(f, "forward-{n}"),
+            Self::Sibling => f.write_str("sibling"),
+            Self::ModDecl => f.write_str("mod-decl"),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -121,29 +130,30 @@ fn under_cap(chunks: &[BriefChunk], max_chunks: u32, max_bytes: u32) -> bool {
     count <= max_chunks && bytes as u32 <= max_bytes
 }
 
-/// Applies BR-001 cap deletion order: drop chunks first by
-/// `(seed_distance DESC, incoming_edge_count ASC)`. Stops once both
-/// `max_chunks` and `max_bytes` constraints are satisfied. Pure: takes
-/// pre-computed `depth_by_path` and `incoming_counts` so callers can test
-/// deterministically without DB access.
+fn deletion_priority(
+    chunk: &BriefChunk,
+    depth_by_path: &HashMap<String, u32>,
+    incoming_counts: &HashMap<String, u32>,
+) -> (u32, u32) {
+    let depth = depth_by_path.get(&chunk.file_path).copied().unwrap_or(0);
+    let incoming = incoming_counts.get(&chunk.file_path).copied().unwrap_or(0);
+    (depth, incoming)
+}
+
 #[allow(clippy::cast_possible_truncation)]
-pub fn apply_cap(
-    chunks: Vec<BriefChunk>,
+fn select_drops(
+    chunks: &[BriefChunk],
     depth_by_path: &HashMap<String, u32>,
     incoming_counts: &HashMap<String, u32>,
     max_chunks: u32,
     max_bytes: u32,
-) -> Vec<BriefChunk> {
-    if under_cap(&chunks, max_chunks, max_bytes) {
-        return chunks;
-    }
+) -> HashSet<usize> {
     let mut order: Vec<(usize, u32, u32)> = chunks
         .iter()
         .enumerate()
         .map(|(i, c)| {
-            let depth = depth_by_path.get(&c.file_path).copied().unwrap_or(0);
-            let incoming = incoming_counts.get(&c.file_path).copied().unwrap_or(0);
-            (i, depth, incoming)
+            let (d, e) = deletion_priority(c, depth_by_path, incoming_counts);
+            (i, d, e)
         })
         .collect();
     order.sort_by(|a, b| b.1.cmp(&a.1).then(a.2.cmp(&b.2)));
@@ -159,6 +169,30 @@ pub fn apply_cap(
         count -= 1;
         bytes -= chunks[idx].content.len();
     }
+    drop_idx
+}
+
+/// Applies BR-001 cap deletion order: drop chunks first by
+/// `(seed_distance DESC, incoming_edge_count ASC)`. Pure: takes pre-computed
+/// `depth_by_path` and `incoming_counts` so callers can test deterministically
+/// without DB access.
+pub fn apply_cap(
+    chunks: Vec<BriefChunk>,
+    depth_by_path: &HashMap<String, u32>,
+    incoming_counts: &HashMap<String, u32>,
+    max_chunks: u32,
+    max_bytes: u32,
+) -> Vec<BriefChunk> {
+    if under_cap(&chunks, max_chunks, max_bytes) {
+        return chunks;
+    }
+    let drop_idx = select_drops(
+        &chunks,
+        depth_by_path,
+        incoming_counts,
+        max_chunks,
+        max_bytes,
+    );
     chunks
         .into_iter()
         .enumerate()
@@ -181,6 +215,22 @@ fn build_dep_graph(chunks: &[BriefChunk], edges: &[(String, String)]) -> DepGrap
         }
     }
     (out_degree, dependents)
+}
+
+fn append_cycle_tail(
+    positions: &mut HashMap<String, usize>,
+    next_idx: &mut usize,
+    all_files: &HashMap<String, u32>,
+) {
+    let mut leftover: Vec<&String> = all_files
+        .keys()
+        .filter(|p| !positions.contains_key(*p))
+        .collect();
+    leftover.sort();
+    for p in leftover {
+        positions.insert(p.clone(), *next_idx);
+        *next_idx += 1;
+    }
 }
 
 fn kahn_positions(graph: DepGraph) -> HashMap<String, usize> {
@@ -207,15 +257,7 @@ fn kahn_positions(graph: DepGraph) -> HashMap<String, usize> {
             }
         }
     }
-    let mut leftover: Vec<&String> = out_degree
-        .keys()
-        .filter(|p| !positions.contains_key(*p))
-        .collect();
-    leftover.sort();
-    for p in leftover {
-        positions.insert(p.clone(), idx);
-        idx += 1;
-    }
+    append_cycle_tail(&mut positions, &mut idx, &out_degree);
     positions
 }
 
@@ -233,15 +275,6 @@ pub fn topo_sort(chunks: Vec<BriefChunk>, edges: &[(String, String)]) -> Vec<Bri
         )
     });
     sorted
-}
-
-fn inclusion_reason_str(reason: &ChunkInclusionReason) -> String {
-    match reason {
-        ChunkInclusionReason::Seed => "seed".to_owned(),
-        ChunkInclusionReason::Forward(n) => format!("forward-{n}"),
-        ChunkInclusionReason::Sibling => "sibling".to_owned(),
-        ChunkInclusionReason::ModDecl => "mod-decl".to_owned(),
-    }
 }
 
 #[derive(Serialize)]
@@ -276,7 +309,7 @@ pub fn render_json(output: &BriefOutput) -> String {
                 end_line: c.end_line,
                 chunk_type: c.chunk_type.as_str(),
                 content: &c.content,
-                included_reason: inclusion_reason_str(&c.included_reason),
+                included_reason: c.included_reason.to_string(),
             })
             .collect(),
     };
@@ -318,7 +351,12 @@ pub fn expand_plan(conn: &Connection, task: &TaskBrief) -> Result<BriefOutput, S
     let chunks = get_chunks_for_files(conn, &paths)?;
     let brief_chunks = build_brief_chunks(chunks, &depth_by_path);
 
-    let incoming_counts = get_import_counts(conn, &paths)?;
+    // BR-001 priority data is only needed when chunks exceed the budget.
+    let incoming_counts = if under_cap(&brief_chunks, task.max_chunks, task.max_bytes) {
+        HashMap::new()
+    } else {
+        get_import_counts(conn, &paths)?
+    };
     let capped = apply_cap(
         brief_chunks,
         &depth_by_path,
@@ -327,7 +365,11 @@ pub fn expand_plan(conn: &Connection, task: &TaskBrief) -> Result<BriefOutput, S
         task.max_bytes,
     );
 
-    let edges = get_edges_among_files(conn, &paths)?;
+    // Edges only matter for files that survived cap; querying the pre-cap
+    // closure would fetch rows that topo_sort silently discards.
+    let capped_paths: HashSet<&str> = capped.iter().map(|c| c.file_path.as_str()).collect();
+    let capped_paths: Vec<&str> = capped_paths.into_iter().collect();
+    let edges = get_edges_among_files(conn, &capped_paths)?;
     let ordered = topo_sort(capped, &edges);
 
     let total_chunks = ordered.len() as u32;

--- a/src/brief.rs
+++ b/src/brief.rs
@@ -3,12 +3,12 @@
 //! Phase 1c-3 scaffold. cap (BR-001) and topo sort (BR-002) are deferred to
 //! follow-up commits in this phase.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use rusqlite::Connection;
 
 use crate::storage::{
-    Chunk, ChunkType, StorageError, get_chunks_for_files, get_import_counts,
+    Chunk, ChunkType, StorageError, get_chunks_for_files, get_edges_among_files, get_import_counts,
     get_transitive_dependencies,
 };
 
@@ -166,6 +166,74 @@ pub fn apply_cap(
         .collect()
 }
 
+type DepGraph = (HashMap<String, u32>, HashMap<String, Vec<String>>);
+
+fn build_dep_graph(chunks: &[BriefChunk], edges: &[(String, String)]) -> DepGraph {
+    let in_scope: HashSet<&str> = chunks.iter().map(|c| c.file_path.as_str()).collect();
+    let mut out_degree: HashMap<String, u32> =
+        in_scope.iter().map(|p| ((*p).to_owned(), 0)).collect();
+    let mut dependents: HashMap<String, Vec<String>> = HashMap::new();
+    for (src, tgt) in edges {
+        if src != tgt && in_scope.contains(src.as_str()) && in_scope.contains(tgt.as_str()) {
+            *out_degree.entry(src.clone()).or_insert(0) += 1;
+            dependents.entry(tgt.clone()).or_default().push(src.clone());
+        }
+    }
+    (out_degree, dependents)
+}
+
+fn kahn_positions(graph: DepGraph) -> HashMap<String, usize> {
+    let (mut out_degree, dependents) = graph;
+    let mut available: BTreeSet<String> = out_degree
+        .iter()
+        .filter(|(_, d)| **d == 0)
+        .map(|(p, _)| p.clone())
+        .collect();
+    let mut positions: HashMap<String, usize> = HashMap::new();
+    let mut idx = 0;
+    while let Some(p) = available.iter().next().cloned() {
+        available.remove(&p);
+        positions.insert(p.clone(), idx);
+        idx += 1;
+        if let Some(deps) = dependents.get(&p) {
+            for dep in deps {
+                if let Some(d) = out_degree.get_mut(dep) {
+                    *d -= 1;
+                    if *d == 0 {
+                        available.insert(dep.clone());
+                    }
+                }
+            }
+        }
+    }
+    let mut leftover: Vec<&String> = out_degree
+        .keys()
+        .filter(|p| !positions.contains_key(*p))
+        .collect();
+    leftover.sort();
+    for p in leftover {
+        positions.insert(p.clone(), idx);
+        idx += 1;
+    }
+    positions
+}
+
+/// Applies BR-002 topological order: dependencies first (depended-upon files
+/// come before their dependents), tie-breaking by file_path lex order.
+/// Within the same file, chunks keep their `start_line` ordering. Cycles
+/// degrade to lex order at the tail of the result.
+pub fn topo_sort(chunks: Vec<BriefChunk>, edges: &[(String, String)]) -> Vec<BriefChunk> {
+    let positions = kahn_positions(build_dep_graph(&chunks, edges));
+    let mut sorted = chunks;
+    sorted.sort_by_key(|c| {
+        (
+            positions.get(&c.file_path).copied().unwrap_or(usize::MAX),
+            c.start_line,
+        )
+    });
+    sorted
+}
+
 #[allow(clippy::cast_possible_truncation)]
 pub fn expand_plan(conn: &Connection, task: &TaskBrief) -> Result<BriefOutput, StorageError> {
     let seeds = collect_seed_paths(task);
@@ -184,11 +252,14 @@ pub fn expand_plan(conn: &Connection, task: &TaskBrief) -> Result<BriefOutput, S
         task.max_bytes,
     );
 
-    let total_chunks = capped.len() as u32;
-    let total_bytes: u32 = capped.iter().map(|c| c.content.len() as u32).sum();
+    let edges = get_edges_among_files(conn, &paths)?;
+    let ordered = topo_sort(capped, &edges);
+
+    let total_chunks = ordered.len() as u32;
+    let total_bytes: u32 = ordered.iter().map(|c| c.content.len() as u32).sum();
 
     Ok(BriefOutput {
-        chunks: capped,
+        chunks: ordered,
         degraded: false,
         total_chunks,
         total_bytes,

--- a/src/brief.rs
+++ b/src/brief.rs
@@ -234,6 +234,23 @@ pub fn topo_sort(chunks: Vec<BriefChunk>, edges: &[(String, String)]) -> Vec<Bri
     sorted
 }
 
+/// Plain CLI rendering (FR-011): each chunk becomes
+/// `<file_path>:<start_line>-<end_line>\n<content>`, separated by `\n---\n`.
+/// Empty BriefOutput renders to an empty string.
+pub fn render_plain(output: &BriefOutput) -> String {
+    output
+        .chunks
+        .iter()
+        .map(|c| {
+            format!(
+                "{}:{}-{}\n{}",
+                c.file_path, c.start_line, c.end_line, c.content
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n---\n")
+}
+
 #[allow(clippy::cast_possible_truncation)]
 pub fn expand_plan(conn: &Connection, task: &TaskBrief) -> Result<BriefOutput, StorageError> {
     let seeds = collect_seed_paths(task);

--- a/src/brief.rs
+++ b/src/brief.rs
@@ -3,12 +3,13 @@
 //! Phase 1c-3 scaffold. cap (BR-001) and topo sort (BR-002) are deferred to
 //! follow-up commits in this phase.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use rusqlite::Connection;
 
 use crate::storage::{
-    Chunk, ChunkType, StorageError, get_chunks_for_files, get_transitive_dependencies,
+    Chunk, ChunkType, StorageError, get_chunks_for_files, get_import_counts,
+    get_transitive_dependencies,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -113,6 +114,59 @@ fn build_brief_chunks(chunks: Vec<Chunk>, depth_by_path: &HashMap<String, u32>) 
 }
 
 #[allow(clippy::cast_possible_truncation)]
+fn under_cap(chunks: &[BriefChunk], max_chunks: u32, max_bytes: u32) -> bool {
+    let count = chunks.len() as u32;
+    let bytes: usize = chunks.iter().map(|c| c.content.len()).sum();
+    count <= max_chunks && bytes as u32 <= max_bytes
+}
+
+/// Applies BR-001 cap deletion order: drop chunks first by
+/// `(seed_distance DESC, incoming_edge_count ASC)`. Stops once both
+/// `max_chunks` and `max_bytes` constraints are satisfied. Pure: takes
+/// pre-computed `depth_by_path` and `incoming_counts` so callers can test
+/// deterministically without DB access.
+#[allow(clippy::cast_possible_truncation)]
+pub fn apply_cap(
+    chunks: Vec<BriefChunk>,
+    depth_by_path: &HashMap<String, u32>,
+    incoming_counts: &HashMap<String, u32>,
+    max_chunks: u32,
+    max_bytes: u32,
+) -> Vec<BriefChunk> {
+    if under_cap(&chunks, max_chunks, max_bytes) {
+        return chunks;
+    }
+    let mut order: Vec<(usize, u32, u32)> = chunks
+        .iter()
+        .enumerate()
+        .map(|(i, c)| {
+            let depth = depth_by_path.get(&c.file_path).copied().unwrap_or(0);
+            let incoming = incoming_counts.get(&c.file_path).copied().unwrap_or(0);
+            (i, depth, incoming)
+        })
+        .collect();
+    order.sort_by(|a, b| b.1.cmp(&a.1).then(a.2.cmp(&b.2)));
+
+    let mut drop_idx: HashSet<usize> = HashSet::new();
+    let mut count = chunks.len() as u32;
+    let mut bytes: usize = chunks.iter().map(|c| c.content.len()).sum();
+    for (idx, _, _) in order {
+        if count <= max_chunks && bytes as u32 <= max_bytes {
+            break;
+        }
+        drop_idx.insert(idx);
+        count -= 1;
+        bytes -= chunks[idx].content.len();
+    }
+    chunks
+        .into_iter()
+        .enumerate()
+        .filter(|(i, _)| !drop_idx.contains(i))
+        .map(|(_, c)| c)
+        .collect()
+}
+
+#[allow(clippy::cast_possible_truncation)]
 pub fn expand_plan(conn: &Connection, task: &TaskBrief) -> Result<BriefOutput, StorageError> {
     let seeds = collect_seed_paths(task);
     let depth_by_path = collect_closure(conn, &seeds, task.depth)?;
@@ -121,11 +175,20 @@ pub fn expand_plan(conn: &Connection, task: &TaskBrief) -> Result<BriefOutput, S
     let chunks = get_chunks_for_files(conn, &paths)?;
     let brief_chunks = build_brief_chunks(chunks, &depth_by_path);
 
-    let total_chunks = brief_chunks.len() as u32;
-    let total_bytes: u32 = brief_chunks.iter().map(|c| c.content.len() as u32).sum();
+    let incoming_counts = get_import_counts(conn, &paths)?;
+    let capped = apply_cap(
+        brief_chunks,
+        &depth_by_path,
+        &incoming_counts,
+        task.max_chunks,
+        task.max_bytes,
+    );
+
+    let total_chunks = capped.len() as u32;
+    let total_bytes: u32 = capped.iter().map(|c| c.content.len() as u32).sum();
 
     Ok(BriefOutput {
-        chunks: brief_chunks,
+        chunks: capped,
         degraded: false,
         total_chunks,
         total_bytes,

--- a/src/brief.rs
+++ b/src/brief.rs
@@ -6,6 +6,7 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use rusqlite::Connection;
+use serde::Serialize;
 
 use crate::storage::{
     Chunk, ChunkType, StorageError, get_chunks_for_files, get_edges_among_files, get_import_counts,
@@ -232,6 +233,54 @@ pub fn topo_sort(chunks: Vec<BriefChunk>, edges: &[(String, String)]) -> Vec<Bri
         )
     });
     sorted
+}
+
+fn inclusion_reason_str(reason: &ChunkInclusionReason) -> String {
+    match reason {
+        ChunkInclusionReason::Seed => "seed".to_owned(),
+        ChunkInclusionReason::Forward(n) => format!("forward-{n}"),
+        ChunkInclusionReason::Sibling => "sibling".to_owned(),
+        ChunkInclusionReason::ModDecl => "mod-decl".to_owned(),
+    }
+}
+
+#[derive(Serialize)]
+struct JsonOutput<'a> {
+    degraded: bool,
+    chunks: Vec<JsonChunk<'a>>,
+}
+
+#[derive(Serialize)]
+struct JsonChunk<'a> {
+    file_path: &'a str,
+    start_line: u32,
+    end_line: u32,
+    chunk_type: &'static str,
+    content: &'a str,
+    included_reason: String,
+}
+
+/// JSON CLI rendering (FR-012): emits
+/// `{"degraded": bool, "chunks": [{"file_path", "start_line", "end_line",
+/// "chunk_type", "content", "included_reason"}]}`. Compact (no pretty),
+/// suitable for `jq` piping.
+pub fn render_json(output: &BriefOutput) -> String {
+    let json = JsonOutput {
+        degraded: output.degraded,
+        chunks: output
+            .chunks
+            .iter()
+            .map(|c| JsonChunk {
+                file_path: &c.file_path,
+                start_line: c.start_line,
+                end_line: c.end_line,
+                chunk_type: c.chunk_type.as_str(),
+                content: &c.content,
+                included_reason: inclusion_reason_str(&c.included_reason),
+            })
+            .collect(),
+    };
+    serde_json::to_string(&json).expect("BriefOutput JSON serialization is infallible")
 }
 
 /// Plain CLI rendering (FR-011): each chunk becomes

--- a/src/brief.rs
+++ b/src/brief.rs
@@ -1,0 +1,136 @@
+//! Brief expansion plan: TaskBrief -> forward closure -> chunks -> BriefOutput.
+//!
+//! Phase 1c-3 scaffold. cap (BR-001) and topo sort (BR-002) are deferred to
+//! follow-up commits in this phase.
+
+use std::collections::HashMap;
+
+use rusqlite::Connection;
+
+use crate::storage::{
+    Chunk, ChunkType, StorageError, get_chunks_for_files, get_transitive_dependencies,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SeedKind {
+    File,
+    Symbol,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Seed {
+    pub kind: SeedKind,
+    pub value: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct TaskBrief {
+    pub task: String,
+    pub seeds: Vec<Seed>,
+    pub depth: u32,
+    pub max_chunks: u32,
+    pub max_bytes: u32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ChunkInclusionReason {
+    Seed,
+    Forward(u32),
+    Sibling,
+    ModDecl,
+}
+
+#[derive(Debug, Clone)]
+pub struct BriefChunk {
+    pub file_path: String,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub chunk_type: ChunkType,
+    pub content: String,
+    pub included_reason: ChunkInclusionReason,
+}
+
+#[derive(Debug, Clone)]
+pub struct BriefOutput {
+    pub chunks: Vec<BriefChunk>,
+    pub degraded: bool,
+    pub total_chunks: u32,
+    pub total_bytes: u32,
+}
+
+fn collect_seed_paths(task: &TaskBrief) -> Vec<String> {
+    task.seeds
+        .iter()
+        .filter(|s| s.kind == SeedKind::File)
+        .map(|s| s.value.clone())
+        .collect()
+}
+
+fn collect_closure(
+    conn: &Connection,
+    seeds: &[String],
+    depth: u32,
+) -> Result<HashMap<String, u32>, StorageError> {
+    let mut depth_by_path: HashMap<String, u32> = HashMap::new();
+    for seed in seeds {
+        for dep in get_transitive_dependencies(conn, seed, depth)? {
+            depth_by_path
+                .entry(dep.file_path)
+                .and_modify(|d| {
+                    if dep.depth < *d {
+                        *d = dep.depth;
+                    }
+                })
+                .or_insert(dep.depth);
+        }
+    }
+    Ok(depth_by_path)
+}
+
+fn determine_reason(depth: u32) -> ChunkInclusionReason {
+    if depth == 0 {
+        ChunkInclusionReason::Seed
+    } else {
+        ChunkInclusionReason::Forward(depth)
+    }
+}
+
+fn build_brief_chunks(chunks: Vec<Chunk>, depth_by_path: &HashMap<String, u32>) -> Vec<BriefChunk> {
+    chunks
+        .into_iter()
+        .map(|c| {
+            let depth = depth_by_path.get(&c.file_path).copied().unwrap_or(0);
+            BriefChunk {
+                file_path: c.file_path,
+                start_line: c.start_line,
+                end_line: c.end_line,
+                chunk_type: c.chunk_type,
+                content: c.content,
+                included_reason: determine_reason(depth),
+            }
+        })
+        .collect()
+}
+
+#[allow(clippy::cast_possible_truncation)]
+pub fn expand_plan(conn: &Connection, task: &TaskBrief) -> Result<BriefOutput, StorageError> {
+    let seeds = collect_seed_paths(task);
+    let depth_by_path = collect_closure(conn, &seeds, task.depth)?;
+
+    let paths: Vec<&str> = depth_by_path.keys().map(String::as_str).collect();
+    let chunks = get_chunks_for_files(conn, &paths)?;
+    let brief_chunks = build_brief_chunks(chunks, &depth_by_path);
+
+    let total_chunks = brief_chunks.len() as u32;
+    let total_bytes: u32 = brief_chunks.iter().map(|c| c.content.len() as u32).sum();
+
+    Ok(BriefOutput {
+        chunks: brief_chunks,
+        degraded: false,
+        total_chunks,
+        total_bytes,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/brief.rs
+++ b/src/brief.rs
@@ -110,7 +110,14 @@ fn build_brief_chunks(chunks: Vec<Chunk>, depth_by_path: &HashMap<String, u32>) 
     chunks
         .into_iter()
         .map(|c| {
-            let depth = depth_by_path.get(&c.file_path).copied().unwrap_or(0);
+            let depth = depth_by_path.get(&c.file_path).copied().unwrap_or_else(|| {
+                debug_assert!(
+                    false,
+                    "chunk file_path not in depth_by_path: {}",
+                    c.file_path
+                );
+                0
+            });
             BriefChunk {
                 file_path: c.file_path,
                 start_line: c.start_line,
@@ -127,7 +134,8 @@ fn build_brief_chunks(chunks: Vec<Chunk>, depth_by_path: &HashMap<String, u32>) 
 fn under_cap(chunks: &[BriefChunk], max_chunks: u32, max_bytes: u32) -> bool {
     let count = chunks.len() as u32;
     let bytes: usize = chunks.iter().map(|c| c.content.len()).sum();
-    count <= max_chunks && bytes as u32 <= max_bytes
+    let bytes_capped = u32::try_from(bytes).unwrap_or(u32::MAX);
+    count <= max_chunks && bytes_capped <= max_bytes
 }
 
 fn deletion_priority(

--- a/src/brief.rs
+++ b/src/brief.rs
@@ -283,11 +283,15 @@ pub fn render_json(output: &BriefOutput) -> String {
     serde_json::to_string(&json).expect("BriefOutput JSON serialization is infallible")
 }
 
-/// Plain CLI rendering (FR-011): each chunk becomes
+const DEGRADED_NOTE: &str = "Note: degraded mode — FTS-only seed selection";
+
+/// Plain CLI rendering (FR-011 + FR-014): each chunk becomes
 /// `<file_path>:<start_line>-<end_line>\n<content>`, separated by `\n---\n`.
-/// Empty BriefOutput renders to an empty string.
+/// When `output.degraded` is true, prepends an advisory line so the caller
+/// knows seed selection fell back to FTS-only. Empty + non-degraded renders
+/// to an empty string.
 pub fn render_plain(output: &BriefOutput) -> String {
-    output
+    let body = output
         .chunks
         .iter()
         .map(|c| {
@@ -297,7 +301,12 @@ pub fn render_plain(output: &BriefOutput) -> String {
             )
         })
         .collect::<Vec<_>>()
-        .join("\n---\n")
+        .join("\n---\n");
+    match (output.degraded, body.is_empty()) {
+        (true, true) => DEGRADED_NOTE.to_owned(),
+        (true, false) => format!("{DEGRADED_NOTE}\n{body}"),
+        (false, _) => body,
+    }
 }
 
 #[allow(clippy::cast_possible_truncation)]

--- a/src/brief/tests.rs
+++ b/src/brief/tests.rs
@@ -49,6 +49,57 @@ fn insert_test_chunk(conn: &Connection, file_path: &str, name: &'static str, sta
     .unwrap();
 }
 
+fn make_brief_chunk(file_path: &str, content: &str) -> BriefChunk {
+    BriefChunk {
+        file_path: file_path.to_owned(),
+        start_line: 1,
+        end_line: 3,
+        chunk_type: ChunkType::RustFn,
+        content: content.to_owned(),
+        included_reason: ChunkInclusionReason::Forward(1),
+    }
+}
+
+// T-601: apply_cap_drops_high_depth_low_incoming_first
+#[test]
+fn apply_cap_drops_high_depth_low_incoming_first() {
+    let chunks = vec![
+        make_brief_chunk("src/a.rs", "a"),
+        make_brief_chunk("src/b.rs", "b"),
+        make_brief_chunk("src/c.rs", "c"),
+        make_brief_chunk("src/d.rs", "d"),
+    ];
+    let depth_by_path: std::collections::HashMap<String, u32> = [
+        ("src/a.rs".to_owned(), 0),
+        ("src/b.rs".to_owned(), 1),
+        ("src/c.rs".to_owned(), 1),
+        ("src/d.rs".to_owned(), 2),
+    ]
+    .into_iter()
+    .collect();
+    let incoming_counts: std::collections::HashMap<String, u32> = [
+        ("src/a.rs".to_owned(), 10),
+        ("src/b.rs".to_owned(), 5),
+        ("src/c.rs".to_owned(), 2),
+        ("src/d.rs".to_owned(), 1),
+    ]
+    .into_iter()
+    .collect();
+
+    let kept = apply_cap(chunks, &depth_by_path, &incoming_counts, 2, u32::MAX);
+
+    assert_eq!(kept.len(), 2);
+    let kept_paths: Vec<&str> = kept.iter().map(|c| c.file_path.as_str()).collect();
+    assert!(
+        kept_paths.contains(&"src/a.rs"),
+        "seed (depth=0) must survive cap, got: {kept_paths:?}"
+    );
+    assert!(
+        kept_paths.contains(&"src/b.rs"),
+        "depth=1 incoming=5 must survive over depth=1 incoming=2, got: {kept_paths:?}"
+    );
+}
+
 // T-600: expand_plan_returns_seed_and_forward_chunks
 #[test]
 fn expand_plan_returns_seed_and_forward_chunks() {

--- a/src/brief/tests.rs
+++ b/src/brief/tests.rs
@@ -195,6 +195,48 @@ fn render_plain_returns_empty_string_for_empty_output() {
     assert_eq!(render_plain(&output), "");
 }
 
+// T-606: render_plain_prepends_degraded_note [Spec FR-014]
+#[test]
+fn render_plain_prepends_degraded_note() {
+    let output = BriefOutput {
+        chunks: vec![BriefChunk {
+            file_path: "src/foo.rs".to_owned(),
+            start_line: 1,
+            end_line: 3,
+            chunk_type: ChunkType::RustFn,
+            content: "fn foo() {}".to_owned(),
+            included_reason: ChunkInclusionReason::Seed,
+        }],
+        degraded: true,
+        total_chunks: 1,
+        total_bytes: 11,
+    };
+    let rendered = render_plain(&output);
+    assert!(
+        rendered.starts_with("Note: degraded mode — FTS-only seed selection\n"),
+        "expected degraded note prefix, got: {rendered}"
+    );
+    assert!(
+        rendered.contains("src/foo.rs:1-3\nfn foo() {}"),
+        "chunk body must follow the note, got: {rendered}"
+    );
+}
+
+// T-607: render_plain_empty_degraded_returns_only_note
+#[test]
+fn render_plain_empty_degraded_returns_only_note() {
+    let output = BriefOutput {
+        chunks: vec![],
+        degraded: true,
+        total_chunks: 0,
+        total_bytes: 0,
+    };
+    assert_eq!(
+        render_plain(&output),
+        "Note: degraded mode — FTS-only seed selection"
+    );
+}
+
 // T-602: topo_sort_orders_dependencies_first
 #[test]
 fn topo_sort_orders_dependencies_first() {

--- a/src/brief/tests.rs
+++ b/src/brief/tests.rs
@@ -100,6 +100,29 @@ fn apply_cap_drops_high_depth_low_incoming_first() {
     );
 }
 
+// T-602: topo_sort_orders_dependencies_first
+#[test]
+fn topo_sort_orders_dependencies_first() {
+    let chunks = vec![
+        make_brief_chunk("src/a.rs", "a"),
+        make_brief_chunk("src/b.rs", "b"),
+        make_brief_chunk("src/c.rs", "c"),
+    ];
+    let edges = vec![
+        ("src/a.rs".to_owned(), "src/b.rs".to_owned()),
+        ("src/b.rs".to_owned(), "src/c.rs".to_owned()),
+    ];
+
+    let sorted = topo_sort(chunks, &edges);
+
+    let order: Vec<&str> = sorted.iter().map(|c| c.file_path.as_str()).collect();
+    assert_eq!(
+        order,
+        vec!["src/c.rs", "src/b.rs", "src/a.rs"],
+        "BR-002: dependencies (depended-upon) come first"
+    );
+}
+
 // T-600: expand_plan_returns_seed_and_forward_chunks
 #[test]
 fn expand_plan_returns_seed_and_forward_chunks() {
@@ -137,4 +160,43 @@ fn expand_plan_returns_seed_and_forward_chunks() {
         by_path["src/b.rs"].included_reason,
         ChunkInclusionReason::Forward(1)
     );
+}
+
+// T-603: expand_plan_is_deterministic [Spec T-008]
+#[test]
+fn expand_plan_is_deterministic() {
+    let (conn, _dir) = test_db();
+    insert_test_chunk(&conn, "src/a.rs", "a", 1);
+    insert_test_chunk(&conn, "src/b.rs", "b", 1);
+    insert_test_chunk(&conn, "src/c.rs", "c", 1);
+    let edge = |source: &str, target: &str| Reference {
+        source_file: source.into(),
+        target_file: target.into(),
+        symbol_name: None,
+        ref_kind: RefKind::Named,
+    };
+    replace_file_references(&conn, "src/a.rs", &[edge("src/a.rs", "src/b.rs")]).unwrap();
+    replace_file_references(&conn, "src/b.rs", &[edge("src/b.rs", "src/c.rs")]).unwrap();
+
+    let task = task_with_seeds(vec![seed_file("src/a.rs")], 2);
+    let signature = |o: &BriefOutput| -> Vec<(String, u32, u32, String)> {
+        o.chunks
+            .iter()
+            .map(|c| {
+                (
+                    c.file_path.clone(),
+                    c.start_line,
+                    c.end_line,
+                    c.content.clone(),
+                )
+            })
+            .collect()
+    };
+
+    let first = expand_plan(&conn, &task).unwrap();
+    let second = expand_plan(&conn, &task).unwrap();
+
+    assert_eq!(signature(&first), signature(&second));
+    assert_eq!(first.total_chunks, second.total_chunks);
+    assert_eq!(first.total_bytes, second.total_bytes);
 }

--- a/src/brief/tests.rs
+++ b/src/brief/tests.rs
@@ -1,0 +1,89 @@
+use rusqlite::Connection;
+use tempfile::{TempDir, tempdir};
+
+use super::*;
+use crate::storage::{
+    EMBEDDING_DIMS, NewChunk, RefKind, Reference, ce, insert_chunk, open_db,
+    replace_file_references,
+};
+
+fn test_db() -> (Connection, TempDir) {
+    let dir = tempdir().unwrap();
+    let conn = open_db(&dir.path().join("test.db")).unwrap();
+    (conn, dir)
+}
+
+fn seed_file(value: &str) -> Seed {
+    Seed {
+        kind: SeedKind::File,
+        value: value.to_owned(),
+    }
+}
+
+fn task_with_seeds(seeds: Vec<Seed>, depth: u32) -> TaskBrief {
+    TaskBrief {
+        task: "find search".to_owned(),
+        seeds,
+        depth,
+        max_chunks: 80,
+        max_bytes: 80_000,
+    }
+}
+
+fn insert_test_chunk(conn: &Connection, file_path: &str, name: &'static str, start: u32) {
+    insert_chunk(
+        conn,
+        file_path,
+        &NewChunk {
+            chunk_type: &ChunkType::RustFn,
+            name: Some(name),
+            content: "fn body() {}",
+            start_line: start,
+            end_line: start + 2,
+            parent_index: None,
+        },
+        "h",
+        &ce(vec![0.0_f32; EMBEDDING_DIMS]),
+        None,
+    )
+    .unwrap();
+}
+
+// T-600: expand_plan_returns_seed_and_forward_chunks
+#[test]
+fn expand_plan_returns_seed_and_forward_chunks() {
+    let (conn, _dir) = test_db();
+    insert_test_chunk(&conn, "src/a.rs", "a", 1);
+    insert_test_chunk(&conn, "src/b.rs", "b", 1);
+    replace_file_references(
+        &conn,
+        "src/a.rs",
+        &[Reference {
+            source_file: "src/a.rs".into(),
+            target_file: "src/b.rs".into(),
+            symbol_name: None,
+            ref_kind: RefKind::Named,
+        }],
+    )
+    .unwrap();
+
+    let task = task_with_seeds(vec![seed_file("src/a.rs")], 1);
+    let output = expand_plan(&conn, &task).unwrap();
+
+    assert_eq!(output.chunks.len(), 2);
+    assert!(!output.degraded);
+
+    let by_path: std::collections::HashMap<&str, &BriefChunk> = output
+        .chunks
+        .iter()
+        .map(|c| (c.file_path.as_str(), c))
+        .collect();
+    assert_eq!(
+        by_path["src/a.rs"].included_reason,
+        ChunkInclusionReason::Seed
+    );
+    assert_eq!(
+        by_path["src/b.rs"].included_reason,
+        ChunkInclusionReason::Forward(1)
+    );
+}

--- a/src/brief/tests.rs
+++ b/src/brief/tests.rs
@@ -100,6 +100,46 @@ fn apply_cap_drops_high_depth_low_incoming_first() {
     );
 }
 
+// T-604: render_plain_outputs_separator_and_header
+#[test]
+fn render_plain_outputs_separator_and_header() {
+    let chunk = |path: &str, content: &str, start: u32, end: u32| BriefChunk {
+        file_path: path.to_owned(),
+        start_line: start,
+        end_line: end,
+        chunk_type: ChunkType::RustFn,
+        content: content.to_owned(),
+        included_reason: ChunkInclusionReason::Seed,
+    };
+    let output = BriefOutput {
+        chunks: vec![
+            chunk("src/foo.rs", "fn foo() {}", 10, 12),
+            chunk("src/bar.rs", "fn bar() {}", 20, 22),
+        ],
+        degraded: false,
+        total_chunks: 2,
+        total_bytes: 0,
+    };
+
+    let rendered = render_plain(&output);
+
+    assert_eq!(
+        rendered,
+        "src/foo.rs:10-12\nfn foo() {}\n---\nsrc/bar.rs:20-22\nfn bar() {}"
+    );
+}
+
+#[test]
+fn render_plain_returns_empty_string_for_empty_output() {
+    let output = BriefOutput {
+        chunks: vec![],
+        degraded: false,
+        total_chunks: 0,
+        total_bytes: 0,
+    };
+    assert_eq!(render_plain(&output), "");
+}
+
 // T-602: topo_sort_orders_dependencies_first
 #[test]
 fn topo_sort_orders_dependencies_first() {

--- a/src/brief/tests.rs
+++ b/src/brief/tests.rs
@@ -100,6 +100,61 @@ fn apply_cap_drops_high_depth_low_incoming_first() {
     );
 }
 
+// T-605: render_json_emits_spec_shape
+#[test]
+fn render_json_emits_spec_shape() {
+    let output = BriefOutput {
+        chunks: vec![BriefChunk {
+            file_path: "src/foo.rs".to_owned(),
+            start_line: 10,
+            end_line: 12,
+            chunk_type: ChunkType::RustFn,
+            content: "fn foo() {}".to_owned(),
+            included_reason: ChunkInclusionReason::Forward(2),
+        }],
+        degraded: true,
+        total_chunks: 1,
+        total_bytes: 11,
+    };
+
+    let rendered = render_json(&output);
+    let parsed: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+
+    assert_eq!(parsed["degraded"], true);
+    assert_eq!(parsed["chunks"][0]["file_path"], "src/foo.rs");
+    assert_eq!(parsed["chunks"][0]["start_line"], 10);
+    assert_eq!(parsed["chunks"][0]["end_line"], 12);
+    assert_eq!(parsed["chunks"][0]["chunk_type"], "rust_fn");
+    assert_eq!(parsed["chunks"][0]["content"], "fn foo() {}");
+    assert_eq!(parsed["chunks"][0]["included_reason"], "forward-2");
+}
+
+#[test]
+fn render_json_includes_seed_and_modkinds() {
+    let chunk = |reason: ChunkInclusionReason| BriefChunk {
+        file_path: "x".to_owned(),
+        start_line: 1,
+        end_line: 1,
+        chunk_type: ChunkType::Other,
+        content: "".to_owned(),
+        included_reason: reason,
+    };
+    let output = BriefOutput {
+        chunks: vec![
+            chunk(ChunkInclusionReason::Seed),
+            chunk(ChunkInclusionReason::Sibling),
+            chunk(ChunkInclusionReason::ModDecl),
+        ],
+        degraded: false,
+        total_chunks: 3,
+        total_bytes: 0,
+    };
+    let parsed: serde_json::Value = serde_json::from_str(&render_json(&output)).unwrap();
+    assert_eq!(parsed["chunks"][0]["included_reason"], "seed");
+    assert_eq!(parsed["chunks"][1]["included_reason"], "sibling");
+    assert_eq!(parsed["chunks"][2]["included_reason"], "mod-decl");
+}
+
 // T-604: render_plain_outputs_separator_and_header
 #[test]
 fn render_plain_outputs_separator_and_header() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod brief;
 pub mod config;
 pub mod indexer;
 pub mod query;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use amici::cli::{deprecation_warn, exit_error, hint_arrow, try_expand_shorthand}
 use clap::error::ErrorKind;
 use clap::{CommandFactory, Parser, Subcommand};
 use rurico::model_probe::handle_probe_if_needed;
+use yomu::brief;
 use yomu::tools::{
     MAX_IMPACT_DEPTH, MAX_SEARCH_LIMIT, MAX_SEARCH_OFFSET, Yomu, YomuError, YomuOptions,
 };
@@ -79,6 +80,29 @@ enum Command {
     Status,
     /// Embed pending chunks for semantic search.
     Embed,
+    /// Bundle forward-closure code for an agent (recall-complete brief).
+    Brief {
+        /// Free-form task description (must not be empty)
+        task: String,
+        /// Seed file path (repeatable)
+        #[arg(long)]
+        seed_file: Vec<String>,
+        /// Seed symbol name (repeatable)
+        #[arg(long)]
+        seed_symbol: Vec<String>,
+        /// Forward closure depth (1..=10)
+        #[arg(long, default_value_t = 3, value_parser = clap::value_parser!(u32).range(1..=10))]
+        depth: u32,
+        /// Maximum chunks in output (1..=1000)
+        #[arg(long, default_value_t = 80, value_parser = clap::value_parser!(u32).range(1..=1000))]
+        max_chunks: u32,
+        /// Maximum bytes in output (1000..=10000000)
+        #[arg(long, default_value_t = 80_000, value_parser = clap::value_parser!(u32).range(1000..=10_000_000))]
+        max_bytes: u32,
+        /// Skip embedding lookups; use FTS5 only.
+        #[arg(long)]
+        no_embed: bool,
+    },
     /// Manage the embedding model.
     #[command(
         subcommand_required = true,
@@ -156,7 +180,7 @@ fn main() -> ExitCode {
     }
 
     let yomu_options = match &command {
-        Command::Search { no_embed, .. } => YomuOptions {
+        Command::Search { no_embed, .. } | Command::Brief { no_embed, .. } => YomuOptions {
             no_embed: *no_embed,
         },
         _ => YomuOptions::default(),
@@ -240,6 +264,38 @@ fn main() -> ExitCode {
         } => yomu.impact(&target, symbol.as_deref(), depth, json, semantic),
         Command::Status => yomu.status(json),
         Command::Embed => yomu.embed(json),
+        Command::Brief {
+            task,
+            seed_file,
+            seed_symbol,
+            depth,
+            max_chunks,
+            max_bytes,
+            no_embed: _,
+        } => {
+            let mut seeds: Vec<brief::Seed> =
+                Vec::with_capacity(seed_file.len() + seed_symbol.len());
+            for value in seed_file {
+                seeds.push(brief::Seed {
+                    kind: brief::SeedKind::File,
+                    value,
+                });
+            }
+            for value in seed_symbol {
+                seeds.push(brief::Seed {
+                    kind: brief::SeedKind::Symbol,
+                    value,
+                });
+            }
+            let task_brief = brief::TaskBrief {
+                task,
+                seeds,
+                depth,
+                max_chunks,
+                max_bytes,
+            };
+            yomu.brief(&task_brief, json)
+        }
         Command::Model { .. } => unreachable!("handled before Yomu::new()"),
     };
 
@@ -256,7 +312,7 @@ fn main() -> ExitCode {
 }
 
 const KNOWN_SUBCOMMANDS: &[&str] = &[
-    "search", "index", "rebuild", "impact", "status", "embed", "model",
+    "search", "index", "rebuild", "impact", "status", "embed", "brief", "model",
 ];
 const GLOBAL_FLAGS: &[&str] = &["--json"];
 
@@ -511,6 +567,85 @@ mod tests {
                 assert!(!semantic, "expected semantic=false by default");
             }
             other => panic!("expected Impact, got {other:?}"),
+        }
+    }
+
+    // T-565: brief_parses_with_required_task
+    #[test]
+    fn brief_parses_with_required_task() {
+        let cli = parse_cli_args(["yomu", "brief", "implement search"]).unwrap();
+        match cli.command.unwrap() {
+            Command::Brief {
+                task,
+                seed_file,
+                seed_symbol,
+                depth,
+                max_chunks,
+                max_bytes,
+                ..
+            } => {
+                assert_eq!(task, "implement search");
+                assert!(seed_file.is_empty());
+                assert!(seed_symbol.is_empty());
+                assert_eq!(depth, 3);
+                assert_eq!(max_chunks, 80);
+                assert_eq!(max_bytes, 80_000);
+            }
+            other => panic!("expected Brief, got {other:?}"),
+        }
+    }
+
+    // T-566: brief_rejects_depth_out_of_range [Spec FR-005b]
+    #[test]
+    fn brief_rejects_depth_out_of_range() {
+        let result = parse_cli_args(["yomu", "brief", "task", "--depth", "11"]);
+        assert!(result.is_err(), "depth=11 must fail (range 1..=10)");
+
+        let result = parse_cli_args(["yomu", "brief", "task", "--depth", "0"]);
+        assert!(result.is_err(), "depth=0 must fail (range 1..=10)");
+    }
+
+    // T-567: brief_rejects_max_chunks_or_bytes_out_of_range [Spec FR-009b]
+    #[test]
+    fn brief_rejects_max_chunks_or_bytes_out_of_range() {
+        let result = parse_cli_args(["yomu", "brief", "task", "--max-chunks", "1001"]);
+        assert!(
+            result.is_err(),
+            "max-chunks=1001 must fail (range 1..=1000)"
+        );
+
+        let result = parse_cli_args(["yomu", "brief", "task", "--max-bytes", "999"]);
+        assert!(
+            result.is_err(),
+            "max-bytes=999 must fail (range 1000..=10000000)"
+        );
+    }
+
+    // T-568: brief_accepts_multiple_seed_files [Spec FR-013]
+    #[test]
+    fn brief_accepts_multiple_seed_files() {
+        let cli = parse_cli_args([
+            "yomu",
+            "brief",
+            "task",
+            "--seed-file",
+            "src/a.rs",
+            "--seed-file",
+            "src/b.rs",
+            "--seed-symbol",
+            "Foo",
+        ])
+        .unwrap();
+        match cli.command.unwrap() {
+            Command::Brief {
+                seed_file,
+                seed_symbol,
+                ..
+            } => {
+                assert_eq!(seed_file, vec!["src/a.rs", "src/b.rs"]);
+                assert_eq!(seed_symbol, vec!["Foo"]);
+            }
+            other => panic!("expected Brief, got {other:?}"),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,23 +273,9 @@ fn main() -> ExitCode {
             max_bytes,
             no_embed: _,
         } => {
-            let mut seeds: Vec<brief::Seed> =
-                Vec::with_capacity(seed_file.len() + seed_symbol.len());
-            for value in seed_file {
-                seeds.push(brief::Seed {
-                    kind: brief::SeedKind::File,
-                    value,
-                });
-            }
-            for value in seed_symbol {
-                seeds.push(brief::Seed {
-                    kind: brief::SeedKind::Symbol,
-                    value,
-                });
-            }
             let task_brief = brief::TaskBrief {
                 task,
-                seeds,
+                seeds: build_seeds(seed_file, seed_symbol),
                 depth,
                 max_chunks,
                 max_bytes,
@@ -314,6 +300,19 @@ fn main() -> ExitCode {
 const KNOWN_SUBCOMMANDS: &[&str] = &[
     "search", "index", "rebuild", "impact", "status", "embed", "brief", "model",
 ];
+
+fn build_seeds(files: Vec<String>, symbols: Vec<String>) -> Vec<brief::Seed> {
+    let mut seeds = Vec::with_capacity(files.len() + symbols.len());
+    seeds.extend(files.into_iter().map(|value| brief::Seed {
+        kind: brief::SeedKind::File,
+        value,
+    }));
+    seeds.extend(symbols.into_iter().map(|value| brief::Seed {
+        kind: brief::SeedKind::Symbol,
+        value,
+    }));
+    seeds
+}
 const GLOBAL_FLAGS: &[&str] = &["--json"];
 
 fn parse_cli_args<I, T>(args: I) -> Result<Cli, clap::Error>

--- a/src/storage/graph.rs
+++ b/src/storage/graph.rs
@@ -12,12 +12,6 @@ pub struct Dependent {
     pub depth: u32,
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct Dependency {
-    pub file_path: String,
-    pub depth: u32,
-}
-
 /// One reference edge from `source_file` to a target file, retaining the
 /// `ref_kind` (named/default/...) and the symbol that triggered it.
 ///
@@ -112,12 +106,13 @@ pub fn get_edges_among_files(
 
 /// Forward closure: files that `seed` transitively depends on, ordered by
 /// distance ascending. `seed` itself is included at depth 0 so brief output
-/// can group seed chunks alongside their forward dependencies.
+/// can group seed chunks alongside their forward dependencies. Reuses
+/// `Dependent` for shape; direction is implicit from the function name.
 pub fn get_transitive_dependencies(
     conn: &Connection,
     seed: &str,
     max_depth: u32,
-) -> Result<Vec<Dependency>, StorageError> {
+) -> Result<Vec<Dependent>, StorageError> {
     let max_depth = max_depth.min(10);
     let mut stmt = conn.prepare_cached(
         "WITH RECURSIVE deps(file_path, depth, visited) AS (
@@ -134,7 +129,7 @@ pub fn get_transitive_dependencies(
         FROM deps GROUP BY file_path ORDER BY depth, file_path",
     )?;
     let rows = stmt.query_map(rusqlite::params![seed, max_depth], |row| {
-        Ok(Dependency {
+        Ok(Dependent {
             file_path: row.get(0)?,
             depth: row.get(1)?,
         })

--- a/src/storage/graph.rs
+++ b/src/storage/graph.rs
@@ -12,6 +12,12 @@ pub struct Dependent {
     pub depth: u32,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct Dependency {
+    pub file_path: String,
+    pub depth: u32,
+}
+
 /// One reference edge from `source_file` to a target file, retaining the
 /// `ref_kind` (named/default/...) and the symbol that triggered it.
 ///
@@ -73,6 +79,38 @@ pub fn get_transitive_dependents(
     )?;
     let rows = stmt.query_map(rusqlite::params![target_file, max_depth], |row| {
         Ok(Dependent {
+            file_path: row.get(0)?,
+            depth: row.get(1)?,
+        })
+    })?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}
+
+/// Forward closure: files that `seed` transitively depends on, ordered by
+/// distance ascending. `seed` itself is included at depth 0 so brief output
+/// can group seed chunks alongside their forward dependencies.
+pub fn get_transitive_dependencies(
+    conn: &Connection,
+    seed: &str,
+    max_depth: u32,
+) -> Result<Vec<Dependency>, StorageError> {
+    let max_depth = max_depth.min(10);
+    let mut stmt = conn.prepare_cached(
+        "WITH RECURSIVE deps(file_path, depth, visited) AS (
+            SELECT ?1, 0, ',' || ?1 || ','
+          UNION
+            SELECT r.target_file, d.depth + 1,
+                   d.visited || r.target_file || ','
+            FROM file_references r
+            INNER JOIN deps d ON r.source_file = d.file_path
+            WHERE d.depth < ?2
+              AND INSTR(d.visited, ',' || r.target_file || ',') = 0
+        )
+        SELECT file_path, MIN(depth) as depth
+        FROM deps GROUP BY file_path ORDER BY depth, file_path",
+    )?;
+    let rows = stmt.query_map(rusqlite::params![seed, max_depth], |row| {
+        Ok(Dependency {
             file_path: row.get(0)?,
             depth: row.get(1)?,
         })

--- a/src/storage/graph.rs
+++ b/src/storage/graph.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
-use rusqlite::Connection;
+use rusqlite::{Connection, params_from_iter};
 
 #[cfg(test)]
 use super::Reference;
-use super::{ChunkType, RefKind, StorageError, as_sql_params, in_placeholders};
+use super::{ChunkType, RefKind, StorageError, anon_placeholders, as_sql_params, in_placeholders};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Dependent {
@@ -82,6 +82,30 @@ pub fn get_transitive_dependents(
             file_path: row.get(0)?,
             depth: row.get(1)?,
         })
+    })?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}
+
+/// Returns every `(source_file, target_file)` edge where both endpoints are
+/// in `paths`. Used by brief topo sort to build a dependency graph
+/// restricted to the in-scope chunk set.
+pub fn get_edges_among_files(
+    conn: &Connection,
+    paths: &[&str],
+) -> Result<Vec<(String, String)>, StorageError> {
+    if paths.is_empty() {
+        return Ok(Vec::new());
+    }
+    let placeholders = anon_placeholders(paths.len());
+    let sql = format!(
+        "SELECT DISTINCT source_file, target_file FROM file_references
+         WHERE source_file IN ({placeholders}) AND target_file IN ({placeholders})"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let mut params: Vec<&str> = paths.to_vec();
+    params.extend_from_slice(paths);
+    let rows = stmt.query_map(params_from_iter(params.iter()), |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
     })?;
     rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
 }

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -240,6 +240,24 @@ pub fn get_chunks_by_ids(
         .map_err(Into::into)
 }
 
+/// Bulk-fetch every Chunk (with body content) belonging to the given files.
+/// Output is sorted by `(file_path, start_line)` so brief expansion can apply
+/// topological ordering on top without an extra sort pass.
+pub fn get_chunks_for_files(conn: &Connection, paths: &[&str]) -> Result<Vec<Chunk>, StorageError> {
+    if paths.is_empty() {
+        return Ok(Vec::new());
+    }
+    let placeholders = in_placeholders(paths.len());
+    let sql = format!(
+        "SELECT file_path, chunk_type, name, content, start_line, end_line, parent_chunk_id
+         FROM chunks WHERE file_path IN ({placeholders})
+         ORDER BY file_path, start_line"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_from_iter(paths.iter()), |row| chunk_from_row(row, 0))?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}
+
 pub fn get_keyword_doc_frequencies(
     conn: &Connection,
     keywords: &[&str],

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -3215,6 +3215,89 @@ fn get_chunks_for_from_target_symbol_not_found_returns_empty() {
     assert!(rows.is_empty());
 }
 
+// T-574: get_chunks_for_files_returns_all_chunks_sorted
+#[test]
+fn get_chunks_for_files_returns_all_chunks_sorted() {
+    let (conn, _dir) = test_db();
+    let emb = vec![0.0_f32; EMBEDDING_DIMS];
+
+    let new_chunk = |name: &'static str, start: u32| NewChunk {
+        chunk_type: &ChunkType::RustFn,
+        name: Some(name),
+        content: "fn body() {}",
+        start_line: start,
+        end_line: start + 2,
+        parent_index: None,
+    };
+
+    insert_chunk(
+        &conn,
+        "src/a.rs",
+        &new_chunk("a1", 10),
+        "h",
+        &ce(emb.clone()),
+        None,
+    )
+    .unwrap();
+    insert_chunk(
+        &conn,
+        "src/a.rs",
+        &new_chunk("a2", 1),
+        "h",
+        &ce(emb.clone()),
+        None,
+    )
+    .unwrap();
+    insert_chunk(
+        &conn,
+        "src/b.rs",
+        &new_chunk("b1", 5),
+        "h",
+        &ce(emb.clone()),
+        None,
+    )
+    .unwrap();
+    insert_chunk(
+        &conn,
+        "src/c.rs",
+        &new_chunk("c1", 1),
+        "h",
+        &ce(emb.clone()),
+        None,
+    )
+    .unwrap();
+    insert_chunk(
+        &conn,
+        "src/skip.rs",
+        &new_chunk("skip", 1),
+        "h",
+        &ce(emb.clone()),
+        None,
+    )
+    .unwrap();
+
+    let chunks = get_chunks_for_files(&conn, &["src/a.rs", "src/b.rs", "src/c.rs"]).unwrap();
+
+    assert_eq!(chunks.len(), 4, "src/skip.rs must not be included");
+    assert!(
+        chunks.iter().all(|c| !c.content.is_empty()),
+        "every chunk must include body content"
+    );
+    let order: Vec<(&str, u32)> = chunks
+        .iter()
+        .map(|c| (c.file_path.as_str(), c.start_line))
+        .collect();
+    assert_eq!(
+        order,
+        vec![
+            ("src/a.rs", 1),
+            ("src/a.rs", 10),
+            ("src/b.rs", 5),
+            ("src/c.rs", 1),
+        ]
+    );
+}
+
 // T-541: get_sub_embeddings_for_chunks returns correct byte length
 #[allow(clippy::cast_possible_truncation)]
 #[test]

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -906,15 +906,15 @@ fn get_transitive_dependencies_chain() {
     assert_eq!(
         deps,
         vec![
-            Dependency {
+            Dependent {
                 file_path: "src/A.tsx".into(),
                 depth: 0
             },
-            Dependency {
+            Dependent {
                 file_path: "src/B.tsx".into(),
                 depth: 1
             },
-            Dependency {
+            Dependent {
                 file_path: "src/C.tsx".into(),
                 depth: 2
             },
@@ -953,11 +953,11 @@ fn get_transitive_dependencies_circular() {
     assert_eq!(
         deps,
         vec![
-            Dependency {
+            Dependent {
                 file_path: "src/A.tsx".into(),
                 depth: 0
             },
-            Dependency {
+            Dependent {
                 file_path: "src/B.tsx".into(),
                 depth: 1
             },

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -864,6 +864,107 @@ fn get_transitive_dependents_circular() {
     );
 }
 
+// T-572: get_transitive_dependencies_chain
+#[test]
+fn get_transitive_dependencies_chain() {
+    let (conn, _dir) = test_db();
+    replace_file_references(
+        &conn,
+        "src/A.tsx",
+        &[Reference {
+            source_file: "src/A.tsx".into(),
+            target_file: "src/B.tsx".into(),
+            symbol_name: None,
+            ref_kind: RefKind::Named,
+        }],
+    )
+    .unwrap();
+    replace_file_references(
+        &conn,
+        "src/B.tsx",
+        &[Reference {
+            source_file: "src/B.tsx".into(),
+            target_file: "src/C.tsx".into(),
+            symbol_name: None,
+            ref_kind: RefKind::Named,
+        }],
+    )
+    .unwrap();
+    replace_file_references(
+        &conn,
+        "src/C.tsx",
+        &[Reference {
+            source_file: "src/C.tsx".into(),
+            target_file: "src/D.tsx".into(),
+            symbol_name: None,
+            ref_kind: RefKind::Named,
+        }],
+    )
+    .unwrap();
+
+    let deps = get_transitive_dependencies(&conn, "src/A.tsx", 2).unwrap();
+    assert_eq!(
+        deps,
+        vec![
+            Dependency {
+                file_path: "src/A.tsx".into(),
+                depth: 0
+            },
+            Dependency {
+                file_path: "src/B.tsx".into(),
+                depth: 1
+            },
+            Dependency {
+                file_path: "src/C.tsx".into(),
+                depth: 2
+            },
+        ]
+    );
+}
+
+// T-573: get_transitive_dependencies_circular
+#[test]
+fn get_transitive_dependencies_circular() {
+    let (conn, _dir) = test_db();
+    replace_file_references(
+        &conn,
+        "src/A.tsx",
+        &[Reference {
+            source_file: "src/A.tsx".into(),
+            target_file: "src/B.tsx".into(),
+            symbol_name: None,
+            ref_kind: RefKind::Named,
+        }],
+    )
+    .unwrap();
+    replace_file_references(
+        &conn,
+        "src/B.tsx",
+        &[Reference {
+            source_file: "src/B.tsx".into(),
+            target_file: "src/A.tsx".into(),
+            symbol_name: None,
+            ref_kind: RefKind::Named,
+        }],
+    )
+    .unwrap();
+
+    let deps = get_transitive_dependencies(&conn, "src/A.tsx", 10).unwrap();
+    assert_eq!(
+        deps,
+        vec![
+            Dependency {
+                file_path: "src/A.tsx".into(),
+                depth: 0
+            },
+            Dependency {
+                file_path: "src/B.tsx".into(),
+                depth: 1
+            },
+        ]
+    );
+}
+
 fn get_chunk_ids(conn: &Connection, file_path: &str) -> Vec<i64> {
     let mut stmt = conn
         .prepare("SELECT id FROM chunks WHERE file_path = ?1 ORDER BY id")

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -13,6 +13,7 @@ use amici::model::{ModelLoad, download_and_verify_model};
 use rurico::embed::Embed;
 use rurico::reranker::Rerank;
 
+use crate::brief;
 use crate::config;
 use crate::indexer;
 use crate::query::{self, QueryError};
@@ -518,6 +519,18 @@ impl Yomu {
             Some(r) => Ok(format_embed_result(&r, json)),
             None => Ok(format_embed_result(&indexer::EmbedResult::default(), json)),
         }
+    }
+
+    pub fn brief(&self, task: &brief::TaskBrief, json: bool) -> Result<String, YomuError> {
+        if task.task.trim().is_empty() {
+            return Err(YomuError::InvalidInput("task must not be empty".into()));
+        }
+        let output = self.with_db(|conn| brief::expand_plan(conn, task))?;
+        Ok(if json {
+            brief::render_json(&output)
+        } else {
+            brief::render_plain(&output)
+        })
     }
 }
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -37,6 +37,7 @@ const MAX_QUERY_LENGTH: usize = 2000;
 pub const MAX_SEARCH_LIMIT: u32 = 100;
 pub const MAX_SEARCH_OFFSET: u32 = 500;
 pub const MAX_IMPACT_DEPTH: u32 = 10;
+const BRIEF_MAX_INFERRED_SEEDS: u32 = 5;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum IndexState {
@@ -521,11 +522,58 @@ impl Yomu {
         }
     }
 
+    fn infer_seed_paths(&self, task: &str, max_seeds: u32) -> Result<Vec<String>, DegradedReason> {
+        let embedder = self.try_embedder_arc()?;
+        let task_emb = embedder
+            .embed_query(task)
+            .map_err(|_| DegradedReason::ProbeFailed)?;
+        let conn = self
+            .conn
+            .lock()
+            .expect("brief seed inference: lock poisoned");
+        let results = storage::vec_search(&conn, &task_emb, max_seeds, None, &[])
+            .map_err(|_| DegradedReason::ProbeFailed)?;
+        drop(conn);
+
+        let cap = max_seeds as usize;
+        let mut paths = Vec::with_capacity(cap);
+        let mut seen = HashSet::new();
+        for r in results {
+            if !seen.insert(r.chunk.file_path.clone()) {
+                continue;
+            }
+            paths.push(r.chunk.file_path);
+            if paths.len() >= cap {
+                break;
+            }
+        }
+        Ok(paths)
+    }
+
     pub fn brief(&self, task: &brief::TaskBrief, json: bool) -> Result<String, YomuError> {
         if task.task.trim().is_empty() {
             return Err(YomuError::InvalidInput("task must not be empty".into()));
         }
-        let output = self.with_db(|conn| brief::expand_plan(conn, task))?;
+
+        let mut effective = task.clone();
+        let mut degraded = false;
+        if effective.seeds.is_empty() {
+            match self.infer_seed_paths(&effective.task, BRIEF_MAX_INFERRED_SEEDS) {
+                Ok(paths) => {
+                    effective.seeds = paths
+                        .into_iter()
+                        .map(|value| brief::Seed {
+                            kind: brief::SeedKind::File,
+                            value,
+                        })
+                        .collect();
+                }
+                Err(_) => degraded = true,
+            }
+        }
+
+        let mut output = self.with_db(|conn| brief::expand_plan(conn, &effective))?;
+        output.degraded = degraded;
         Ok(if json {
             brief::render_json(&output)
         } else {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -554,6 +554,15 @@ impl Yomu {
         if task.task.trim().is_empty() {
             return Err(YomuError::InvalidInput("task must not be empty".into()));
         }
+        if task
+            .seeds
+            .iter()
+            .any(|s| matches!(s.kind, brief::SeedKind::Symbol))
+        {
+            return Err(YomuError::InvalidInput(
+                "--seed-symbol is not yet implemented; use --seed-file".into(),
+            ));
+        }
 
         let mut effective = task.clone();
         let mut degraded = false;
@@ -573,7 +582,7 @@ impl Yomu {
         }
 
         let mut output = self.with_db(|conn| brief::expand_plan(conn, &effective))?;
-        output.degraded = degraded;
+        output.degraded |= degraded;
         Ok(if json {
             brief::render_json(&output)
         } else {

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -2464,3 +2464,111 @@ fn search_from_json_output_has_results_key() {
         "expected 'results' to be an array, got: {json}"
     );
 }
+
+fn seed_brief_chunks(conn: &storage::Db) {
+    let emb = vec![0.0_f32; storage::EMBEDDING_DIMS];
+    let new_chunk = |name: &'static str, start: u32| storage::NewChunk {
+        chunk_type: &storage::ChunkType::RustFn,
+        name: Some(name),
+        content: "fn body() {}",
+        start_line: start,
+        end_line: start + 2,
+        parent_index: None,
+    };
+    storage::insert_chunk(
+        conn,
+        "src/a.rs",
+        &new_chunk("a", 1),
+        "h",
+        &storage::ce(emb.clone()),
+        None,
+    )
+    .unwrap();
+    storage::insert_chunk(
+        conn,
+        "src/b.rs",
+        &new_chunk("b", 1),
+        "h",
+        &storage::ce(emb),
+        None,
+    )
+    .unwrap();
+    storage::replace_file_references(
+        conn,
+        "src/a.rs",
+        &[storage::Reference {
+            source_file: "src/a.rs".into(),
+            target_file: "src/b.rs".into(),
+            symbol_name: None,
+            ref_kind: storage::RefKind::Named,
+        }],
+    )
+    .unwrap();
+}
+
+fn brief_task(seed_file: &str) -> brief::TaskBrief {
+    brief::TaskBrief {
+        task: "find body".to_owned(),
+        seeds: vec![brief::Seed {
+            kind: brief::SeedKind::File,
+            value: seed_file.to_owned(),
+        }],
+        depth: 1,
+        max_chunks: 80,
+        max_bytes: 80_000,
+    }
+}
+
+// T-568: yomu_brief_returns_plain_format
+#[test]
+fn yomu_brief_returns_plain_format() {
+    let (conn, dir) = test_db();
+    seed_brief_chunks(&conn);
+    let yomu = Yomu::for_test(conn, dir.path().to_path_buf(), None);
+
+    let output = yomu.brief(&brief_task("src/a.rs"), false).unwrap();
+
+    assert!(
+        output.contains("src/a.rs:1-3"),
+        "expected header for src/a.rs, got: {output}"
+    );
+    assert!(
+        output.contains("src/b.rs:1-3"),
+        "expected header for src/b.rs, got: {output}"
+    );
+    assert!(
+        output.contains("\n---\n"),
+        "expected chunk separator, got: {output}"
+    );
+}
+
+// T-569: yomu_brief_with_json_returns_valid_json
+#[test]
+fn yomu_brief_with_json_returns_valid_json() {
+    let (conn, dir) = test_db();
+    seed_brief_chunks(&conn);
+    let yomu = Yomu::for_test(conn, dir.path().to_path_buf(), None);
+
+    let output = yomu.brief(&brief_task("src/a.rs"), true).unwrap();
+    let parsed = parse_json(&output);
+
+    assert_eq!(parsed["degraded"], false);
+    assert!(parsed["chunks"].is_array());
+    assert!(
+        parsed["chunks"].as_array().unwrap().len() >= 2,
+        "expected at least seed + forward chunks, got: {output}"
+    );
+}
+
+// T-570: yomu_brief_rejects_empty_task [Spec FR-010b prep]
+#[test]
+fn yomu_brief_rejects_empty_task() {
+    let (yomu, _dir) = test_yomu();
+    let mut task = brief_task("src/a.rs");
+    task.task = "   ".to_owned();
+    let err = yomu.brief(&task, false).unwrap_err();
+    assert!(
+        matches!(err, YomuError::InvalidInput(_)),
+        "expected InvalidInput, got: {err:?}"
+    );
+}

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -2560,6 +2560,35 @@ fn yomu_brief_with_json_returns_valid_json() {
     );
 }
 
+// T-571: brief_falls_back_to_degraded_when_no_embedder
+#[test]
+fn brief_falls_back_to_degraded_when_no_embedder() {
+    let (conn, dir) = test_db();
+    seed_brief_chunks(&conn);
+    let yomu = Yomu::for_test(conn, dir.path().to_path_buf(), None);
+
+    let task = brief::TaskBrief {
+        task: "infer something".to_owned(),
+        seeds: vec![],
+        depth: 1,
+        max_chunks: 80,
+        max_bytes: 80_000,
+    };
+
+    let output = yomu.brief(&task, true).unwrap();
+    let parsed = parse_json(&output);
+
+    assert_eq!(
+        parsed["degraded"], true,
+        "no embedder + empty seeds must mark degraded, got: {output}"
+    );
+    assert_eq!(
+        parsed["chunks"].as_array().unwrap().len(),
+        0,
+        "without seeds the closure is empty, got: {output}"
+    );
+}
+
 // T-570: yomu_brief_rejects_empty_task [Spec FR-010b prep]
 #[test]
 fn yomu_brief_rejects_empty_task() {

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -7,6 +7,47 @@ fn yomu_cmd() -> Command {
     Command::new(env!("CARGO_BIN_EXE_yomu"))
 }
 
+fn setup_brief_chain_project() -> TempDir {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("lib.rs"), "pub mod a;\npub mod b;\npub mod c;\n").unwrap();
+    fs::write(
+        src.join("a.rs"),
+        "use crate::b;\npub fn run() { b::work(); }\n",
+    )
+    .unwrap();
+    fs::write(
+        src.join("b.rs"),
+        "use crate::c;\npub fn work() { c::utility(); }\n",
+    )
+    .unwrap();
+    fs::write(src.join("c.rs"), "pub fn utility() {}\n").unwrap();
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"gt_chain\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    Command::new("git")
+        .args(["init"])
+        .current_dir(dir.path())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .unwrap();
+    let out = yomu_cmd()
+        .arg("index")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "index failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    dir
+}
+
 // T-495: version_flag
 #[test]
 fn version_flag() {
@@ -945,5 +986,92 @@ fn search_no_embed_flag_marks_json_degraded() {
     assert!(
         parsed["results"].as_array().is_some_and(|r| !r.is_empty()),
         "should still return FTS5 results: {stdout}"
+    );
+}
+
+// T-610: brief_integration_includes_forward_closure [Spec FR-015 minimal GT]
+#[test]
+fn brief_integration_includes_forward_closure() {
+    let dir = setup_brief_chain_project();
+    let output = yomu_cmd()
+        .args([
+            "brief",
+            "find utility",
+            "--seed-file",
+            "src/a.rs",
+            "--depth",
+            "2",
+            "--no-embed",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "brief failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in ["src/a.rs", "src/b.rs", "src/c.rs"] {
+        assert!(
+            stdout.contains(expected),
+            "forward closure recall: expected {expected} in output, got: {stdout}"
+        );
+    }
+}
+
+// T-611: brief_integration_rejects_empty_task [Spec FR-010b]
+#[test]
+fn brief_integration_rejects_empty_task() {
+    let dir = setup_brief_chain_project();
+    let output = yomu_cmd()
+        .args(["brief", ""])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "empty task must fail, got success with: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "empty task must exit 2, got: {:?} (stderr: {})",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// T-612: brief_integration_json_output_includes_chunks [Spec FR-012]
+#[test]
+fn brief_integration_json_output_includes_chunks() {
+    let dir = setup_brief_chain_project();
+    let output = yomu_cmd()
+        .args([
+            "--json",
+            "brief",
+            "anything",
+            "--seed-file",
+            "src/a.rs",
+            "--no-embed",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "brief --json failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("expected JSON output, parse error {e}: {stdout}"));
+    assert!(parsed["chunks"].is_array(), "expected .chunks array");
+    assert!(
+        parsed["chunks"].as_array().unwrap().len() >= 1,
+        "expected at least seed chunk, got: {stdout}"
     );
 }


### PR DESCRIPTION
## 概要

`yomu brief` 構想の Phase 1c。自由文タスクから forward closure 上の chunks を recall 完全性で束ねる新サブコマンドを実装。`feat/brief-phase-1a`（mod 宣言 edge 化）の上に積んだ stacked PR。PR #124（Phase 1a/1b → main）がマージされたら base が main に切り替わる。

## 仕様・SOW

- SOW: `.claude/workspace/planning/2026-04-30-brief/sow.md`
- Spec: `.claude/workspace/planning/2026-04-30-brief/spec.md`
- カバー範囲: FR-005 / FR-006 / FR-007 / FR-008 / FR-009 / FR-009b / FR-010 / FR-010b / FR-011 / FR-012 / FR-013 / FR-014 / FR-015 / BR-001 / BR-002
- 受け入れ基準: AC-3 / AC-4 / AC-5 / AC-6 / AC-7
- Outcome: `yomu brief "task"` が forward closure recall で chunks を束ねた 1 ツール出力を返す

## Phase 内訳と主要コミット

### 1c-1 / 1c-2: storage primitives

| Commit | 内容 | FR |
|---|---|---|
| `1ea3972` | `get_transitive_dependencies` (forward closure) | FR-005 / FR-006 |
| `8f1c9dc` | `get_chunks_for_files` (bulk chunk fetch) | FR-007 |

### 1c-3: brief expansion plan (3 baby steps)

| Commit | 内容 | FR |
|---|---|---|
| `19fa88c` | `expand_plan` scaffold (types + skeleton) | FR-008 partial |
| `f5896b4` | `apply_cap` (cap deletion BR-001) | FR-009 / BR-001 |
| `f7612bd` | `topo_sort` + `get_edges_among_files` (BR-002) | FR-008 / BR-002 |

### 1c-4: CLI 配線 (5 baby steps)

| Commit | 内容 | FR |
|---|---|---|
| `46e6776` | `render_plain` | FR-011 |
| `5b81c73` | `render_json` | FR-012 |
| `90aba14` | `Yomu::brief` orchestrator | FR-010 partial |
| `0db4086` | `Command::Brief` + clap range validators | FR-005b / 009b / 010 / 010b / 013 |
| `0452087` | seed inference + degraded flag | FR-014 partial |
| `85cbfba` | render_plain で degraded note prepend | FR-014 complete |

### 1c-5: integration tests

| Commit | 内容 | FR |
|---|---|---|
| `ee7743a` | tempdir minimal Rust project で end-to-end recall | FR-015 |

### Polish (3 commits)

| Commit | 内容 |
|---|---|
| `a123d20` | reviewer-reuse / readability / efficiency の指摘 7 件反映 |
| `108b666` | codex P2 + coderabbit minor の 4 件反映 |
| `12cf089` | `Dependency` を `Dependent` に統合 (REUSE-001) |

## 主な追加 API

| API | 配置 | 用途 |
|---|---|---|
| `storage::get_transitive_dependencies` | `src/storage/graph.rs` | forward closure (Vec<Dependent>) |
| `storage::get_chunks_for_files` | `src/storage/search.rs` | bulk chunk fetch |
| `storage::get_edges_among_files` | `src/storage/graph.rs` | topo sort 用 edge bulk fetch |
| `brief::expand_plan` | `src/brief.rs` | task → BriefOutput pipeline |
| `brief::apply_cap` | `src/brief.rs` | BR-001 cap deletion (pure) |
| `brief::topo_sort` | `src/brief.rs` | BR-002 dependencies-first (Kahn's) |
| `brief::render_plain` / `render_json` | `src/brief.rs` | CLI 出力 |
| `Yomu::brief` | `src/tools.rs` | seed inference + expand + render |

## CLI 仕様

```text
yomu brief "<task>" [--seed-file PATH]... [--seed-symbol NAME]...
                    [--depth 1..=10] [--max-chunks 1..=1000]
                    [--max-bytes 1000..=10000000] [--no-embed] [--json]
```

| フラグ | デフォルト | 用途 |
|---|---|---|
| `task` (positional) | 必須 | 自由文タスク。空 / whitespace のみは exit 2 |
| `--seed-file` | (空) | seed file 明示指定（repeatable） |
| `--seed-symbol` | (空) | 現状未実装、指定すると InvalidInput で reject |
| `--depth` | 3 | forward closure 深さ |
| `--max-chunks` | 80 | chunk 数 cap (BR-001) |
| `--max-bytes` | 80000 | content 累計 bytes cap |
| `--no-embed` | false | embedder スキップ（degraded mode） |
| `--json` | false | JSON 出力 |

## 検証

| 項目 | 結果 |
|---|---|
| `cargo test --lib` | 459 passed, 0 failed, 2 ignored |
| `cargo test --bin yomu` | 21 passed |
| `cargo test --test cli_integration` | 39 passed |
| `cargo clippy` | 0 warnings |

### AC 達成

| AC | Spec | 検証 |
|---|---|---|
| AC-3 | forward closure primitive | T-572 (chain) / T-573 (circular) |
| AC-4 | bulk chunk fetch | T-574 |
| AC-5 | expand plan + cap | T-601 (cap order) / T-603 (deterministic) |
| AC-6 | brief CLI plain / json / multi-seed | T-565〜T-568 (parse) / T-568〜T-571 (Yomu) / T-604〜T-607 (render) |
| AC-7 | recall completeness | T-610 (forward closure recall) / T-611 (FR-010b) / T-612 (FR-012) |

## 後続フォローアップ

| ID | 内容 | 状態 |
|---|---|---|
| CODEX-1 | `--no-embed` で FTS fallback による seed 選択 | issue #125 |
| CODEX-3 | `--max-bytes` を rendered output で計算 | spec 解釈差、現実装が原仕様通り（skip） |
| REUSE-002 | forward / reverse SQL を direction enum で統一 | 仕様差あり進化耐性低下のため skip |
| CR-2 | visited を `char(0)` セパレータに | 実害なし、YAGNI で skip |

## テスト計画

- [ ] `cargo test --lib`（459 passed）
- [ ] `cargo test --test cli_integration`（39 passed）
- [ ] `cargo clippy -- -D warnings`（0 warnings）
- [ ] `yomu index` 後 `yomu brief "search 実装" --seed-file src/query.rs --depth 2 --no-embed` が forward closure を出力すること
- [ ] PR #124 マージ後、本 PR の base が `main` に切り替わること

## 備考

- 本 PR は PR #124 (Phase 1a/1b) に依存。マージ順序: 1a/1b → main → 1c の base を main に切替 → 1c マージ
- `--seed-symbol` は現状 InvalidInput で reject（CODEX-2 fix）。symbol → file 解決は将来 phase
- 既存 `yomu impact` の reverse closure と本 PR の forward closure は対称な API
- workspace-only / Cargo.toml 不在のリポジトリでも degraded mode で動作継続