### PR TITLE
feat(search): #133 検索ホットパスの bulk-fetch 化

### DIFF
--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -13,6 +13,16 @@ use super::{
 
 const VEC_MAXSIM_OVERSAMPLE: u32 = 10;
 
+/// Hard cap on candidates passed to a single `WHERE id IN (?, ...)` query.
+/// SQLite's default `SQLITE_MAX_VARIABLE_NUMBER` is 32766; we leave headroom
+/// for filter params.
+const MAX_VEC_CANDIDATES: usize = 30_000;
+
+/// Hard cap on keywords for the bulk UNION ALL doc-frequency query. Above
+/// this we skip the bulk path entirely so we do not build SQL that SQLite
+/// will refuse to compile (`SQLITE_MAX_COMPOUND_SELECT` default is 500).
+const MAX_BULK_DOC_FREQ_KEYWORDS: usize = 500;
+
 /// KNN-only query over `vec_chunks`. Returns `(chunk_id, distance)` pairs
 /// ordered by ascending distance. Shared by [`vec_search`] (single embedding)
 /// and [`vec_search_multi`] (multiple embeddings sharing one metadata fetch).
@@ -27,39 +37,6 @@ fn knn_only(conn: &Connection, embedding: &[f32], k: u32) -> Result<Vec<(i64, f3
         Ok((row.get(0)?, row.get(1)?))
     })?;
     rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
-}
-
-/// Bulk-fetch chunk metadata by ids with type/path filters applied at the
-/// SQL layer. Used by both [`vec_search`] and [`vec_search_multi`] so that
-/// N-embedding searches share a single round-trip for metadata.
-fn fetch_filtered_chunks(
-    conn: &Connection,
-    chunk_ids: &[i64],
-    type_filter: Option<&[ChunkType]>,
-    path_filter: &[String],
-) -> Result<HashMap<i64, Chunk>, StorageError> {
-    if chunk_ids.is_empty() {
-        return Ok(HashMap::new());
-    }
-    let mut sql = format!(
-        "SELECT id, file_path, chunk_type, name, content, start_line, end_line, parent_chunk_id \
-         FROM chunks WHERE id IN ({})",
-        anon_placeholders(chunk_ids.len())
-    );
-    let mut params: Vec<Box<dyn ToSql>> = chunk_ids
-        .iter()
-        .map(|id| Box::new(*id) as Box<dyn ToSql>)
-        .collect();
-    append_like_prefix_filter(&mut sql, &mut params, "file_path", path_filter);
-    append_chunk_type_filter(&mut sql, &mut params, "chunk_type", type_filter);
-
-    let mut stmt = conn.prepare(&sql)?;
-    let meta = stmt
-        .query_map(params_from_iter(params.iter()), |row| {
-            Ok((row.get::<_, i64>(0)?, chunk_from_row(row, 1)?))
-        })?
-        .collect::<Result<HashMap<_, _>, _>>()?;
-    Ok(meta)
 }
 
 /// Assemble [`SearchResult`]s from a `chunk_id → min distance` map and a
@@ -146,7 +123,7 @@ pub fn vec_search(
     }
 
     let chunk_ids: Vec<i64> = best.keys().copied().collect();
-    let meta = fetch_filtered_chunks(conn, &chunk_ids, type_filter, path_filter)?;
+    let meta = get_chunks_by_ids(conn, &chunk_ids, type_filter, path_filter)?;
     Ok(build_semantic_results(best, &meta, limit))
 }
 
@@ -243,23 +220,33 @@ pub fn get_chunk_by_id(conn: &Connection, chunk_id: i64) -> Result<Option<Chunk>
     }
 }
 
+/// Bulk-fetch chunk metadata by ids with optional type/path filters applied
+/// at the SQL layer. Shared by [`vec_search`], [`vec_search_multi`], and
+/// callers that need a plain id→chunk lookup.
 pub fn get_chunks_by_ids(
     conn: &Connection,
     ids: &[i64],
+    type_filter: Option<&[ChunkType]>,
+    path_filter: &[String],
 ) -> Result<HashMap<i64, Chunk>, StorageError> {
     if ids.is_empty() {
         return Ok(HashMap::new());
     }
-    let placeholders = in_placeholders(ids.len());
-    let sql = format!(
-        "SELECT id, file_path, chunk_type, name, content, start_line, end_line, parent_chunk_id
-         FROM chunks WHERE id IN ({placeholders})"
+    let mut sql = format!(
+        "SELECT id, file_path, chunk_type, name, content, start_line, end_line, parent_chunk_id \
+         FROM chunks WHERE id IN ({})",
+        anon_placeholders(ids.len())
     );
+    let mut params: Vec<Box<dyn ToSql>> = ids
+        .iter()
+        .map(|id| Box::new(*id) as Box<dyn ToSql>)
+        .collect();
+    append_like_prefix_filter(&mut sql, &mut params, "file_path", path_filter);
+    append_chunk_type_filter(&mut sql, &mut params, "chunk_type", type_filter);
+
     let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map(params_from_iter(ids.iter()), |row| {
-        let id: i64 = row.get(0)?;
-        let chunk = chunk_from_row(row, 1)?;
-        Ok((id, chunk))
+    let rows = stmt.query_map(params_from_iter(params.iter()), |row| {
+        Ok((row.get::<_, i64>(0)?, chunk_from_row(row, 1)?))
     })?;
     rows.collect::<Result<HashMap<_, _>, _>>()
         .map_err(Into::into)
@@ -292,12 +279,18 @@ pub fn get_keyword_doc_frequencies(
         return Ok(Vec::new());
     }
 
-    // Bulk path: 1 round-trip via UNION ALL. SQLite preserves the SELECT
-    // order across UNION ALL in practice, but we attach an explicit `idx`
-    // and ORDER BY to defend against re-ordering.
+    // Above SQLite's SQLITE_MAX_COMPOUND_SELECT (default 500) the UNION ALL
+    // refuses to compile. Drop to per-keyword immediately rather than build
+    // a SQL string we know will fail.
+    if keywords.len() > MAX_BULK_DOC_FREQ_KEYWORDS {
+        return doc_frequencies_per_keyword(conn, keywords, total_chunks);
+    }
+
+    // SQLite preserves SELECT order across UNION ALL in practice, but we
+    // attach an explicit `idx` + ORDER BY to defend against re-ordering.
     let terms: Vec<String> = keywords.iter().map(|k| fts_quote(k)).collect();
     let mut sql = String::with_capacity(terms.len() * 80);
-    for (i, _) in terms.iter().enumerate() {
+    for i in 0..terms.len() {
         if i > 0 {
             sql.push_str(" UNION ALL ");
         }
@@ -385,8 +378,8 @@ pub fn vec_search_multi(
     }
     let k = limit.saturating_mul(VEC_MAXSIM_OVERSAMPLE);
 
-    // KNN per embedding, MaxSim merge across all embeddings before metadata
-    // fetch. Old impl did N round-trips for metadata; this does 1.
+    // KNN per embedding, MaxSim merge across all embeddings before the shared
+    // metadata fetch.
     let mut best: HashMap<i64, f32> = HashMap::new();
     for emb in query_embeddings {
         for (chunk_id, distance) in knn_only(conn, emb, k)? {
@@ -403,8 +396,19 @@ pub fn vec_search_multi(
         return Ok(Vec::new());
     }
 
+    // Cap candidates by min distance so the IN-clause stays under SQLite's
+    // SQLITE_MAX_VARIABLE_NUMBER (32766). Without this, large-corpus searches
+    // through `search_from_file` (up to 20 sub-embeddings × fetch_limit × 10
+    // oversample) can overflow the prepared-statement parameter limit.
+    if best.len() > MAX_VEC_CANDIDATES {
+        let mut pairs: Vec<(i64, f32)> = best.into_iter().collect();
+        pairs.sort_unstable_by(|a, b| a.1.total_cmp(&b.1));
+        pairs.truncate(MAX_VEC_CANDIDATES);
+        best = pairs.into_iter().collect();
+    }
+
     let chunk_ids: Vec<i64> = best.keys().copied().collect();
-    let meta = fetch_filtered_chunks(conn, &chunk_ids, type_filter, path_filter)?;
+    let meta = get_chunks_by_ids(conn, &chunk_ids, type_filter, path_filter)?;
     Ok(build_semantic_results(best, &meta, limit))
 }
 

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -29,6 +29,64 @@ fn knn_only(conn: &Connection, embedding: &[f32], k: u32) -> Result<Vec<(i64, f3
     rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
 }
 
+/// Bulk-fetch chunk metadata by ids with type/path filters applied at the
+/// SQL layer. Used by both [`vec_search`] and [`vec_search_multi`] so that
+/// N-embedding searches share a single round-trip for metadata.
+fn fetch_filtered_chunks(
+    conn: &Connection,
+    chunk_ids: &[i64],
+    type_filter: Option<&[ChunkType]>,
+    path_filter: &[String],
+) -> Result<HashMap<i64, Chunk>, StorageError> {
+    if chunk_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let mut sql = format!(
+        "SELECT id, file_path, chunk_type, name, content, start_line, end_line, parent_chunk_id \
+         FROM chunks WHERE id IN ({})",
+        anon_placeholders(chunk_ids.len())
+    );
+    let mut params: Vec<Box<dyn ToSql>> = chunk_ids
+        .iter()
+        .map(|id| Box::new(*id) as Box<dyn ToSql>)
+        .collect();
+    append_like_prefix_filter(&mut sql, &mut params, "file_path", path_filter);
+    append_chunk_type_filter(&mut sql, &mut params, "chunk_type", type_filter);
+
+    let mut stmt = conn.prepare(&sql)?;
+    let meta = stmt
+        .query_map(params_from_iter(params.iter()), |row| {
+            Ok((row.get::<_, i64>(0)?, chunk_from_row(row, 1)?))
+        })?
+        .collect::<Result<HashMap<_, _>, _>>()?;
+    Ok(meta)
+}
+
+/// Assemble [`SearchResult`]s from a `chunk_id → min distance` map and a
+/// filtered metadata map. Entries missing from `meta` (filtered out) are
+/// dropped. Result is sorted by ascending distance and truncated to `limit`.
+fn build_semantic_results(
+    best: HashMap<i64, f32>,
+    meta: &HashMap<i64, Chunk>,
+    limit: u32,
+) -> Vec<SearchResult> {
+    let mut results: Vec<SearchResult> = best
+        .into_iter()
+        .filter_map(|(chunk_id, distance)| {
+            meta.get(&chunk_id).map(|chunk| SearchResult {
+                chunk: chunk.clone(),
+                chunk_id: Some(chunk_id),
+                distance,
+                match_source: MatchSource::Semantic,
+                score: 1.0 / (1.0 + distance),
+            })
+        })
+        .collect();
+    results.sort_by(|a, b| a.distance.total_cmp(&b.distance));
+    results.truncate(limit as usize);
+    results
+}
+
 fn chunk_from_row(row: &Row<'_>, offset: usize) -> rusqlite::Result<Chunk> {
     Ok(Chunk {
         file_path: row.get(offset)?,
@@ -88,52 +146,8 @@ pub fn vec_search(
     }
 
     let chunk_ids: Vec<i64> = best.keys().copied().collect();
-    let mut sql = format!(
-        "SELECT id, file_path, chunk_type, name, content, start_line, end_line, parent_chunk_id \
-         FROM chunks WHERE id IN ({})",
-        anon_placeholders(chunk_ids.len())
-    );
-    let mut params: Vec<Box<dyn ToSql>> = chunk_ids
-        .iter()
-        .map(|id| Box::new(*id) as Box<dyn ToSql>)
-        .collect();
-    append_like_prefix_filter(&mut sql, &mut params, "file_path", path_filter);
-    append_chunk_type_filter(&mut sql, &mut params, "chunk_type", type_filter);
-
-    let mut stmt2 = conn.prepare(&sql)?;
-    let meta: HashMap<i64, Chunk> = stmt2
-        .query_map(params_from_iter(params.iter()), |row| {
-            Ok((
-                row.get::<_, i64>(0)?,
-                Chunk {
-                    file_path: row.get(1)?,
-                    chunk_type: ChunkType::from_db(row.get::<_, String>(2)?.as_ref()),
-                    name: row.get(3)?,
-                    content: row.get(4)?,
-                    start_line: row.get(5)?,
-                    end_line: row.get(6)?,
-                    parent_chunk_id: row.get(7)?,
-                },
-            ))
-        })?
-        .collect::<Result<HashMap<_, _>, _>>()?;
-
-    let mut results: Vec<SearchResult> = best
-        .into_iter()
-        .filter_map(|(chunk_id, distance)| {
-            meta.get(&chunk_id).map(|chunk| SearchResult {
-                chunk: chunk.clone(),
-                chunk_id: Some(chunk_id),
-                distance,
-                match_source: MatchSource::Semantic,
-                score: 1.0 / (1.0 + distance),
-            })
-        })
-        .collect();
-
-    results.sort_by(|a, b| a.distance.total_cmp(&b.distance));
-    results.truncate(limit as usize);
-    Ok(results)
+    let meta = fetch_filtered_chunks(conn, &chunk_ids, type_filter, path_filter)?;
+    Ok(build_semantic_results(best, &meta, limit))
 }
 
 #[allow(clippy::cast_possible_truncation)]
@@ -313,27 +327,29 @@ pub fn vec_search_multi(
     if query_embeddings.is_empty() {
         return Ok(Vec::new());
     }
+    let k = limit.saturating_mul(VEC_MAXSIM_OVERSAMPLE);
 
-    let mut best: HashMap<i64, SearchResult> = HashMap::new();
+    // KNN per embedding, MaxSim merge across all embeddings before metadata
+    // fetch. Old impl did N round-trips for metadata; this does 1.
+    let mut best: HashMap<i64, f32> = HashMap::new();
     for emb in query_embeddings {
-        for result in vec_search(conn, emb, limit, type_filter, path_filter)? {
-            if let Some(chunk_id) = result.chunk_id {
-                best.entry(chunk_id)
-                    .and_modify(|existing| {
-                        if result.distance < existing.distance {
-                            existing.distance = result.distance;
-                            existing.score = result.score;
-                        }
-                    })
-                    .or_insert(result);
-            }
+        for (chunk_id, distance) in knn_only(conn, emb, k)? {
+            best.entry(chunk_id)
+                .and_modify(|d| {
+                    if distance < *d {
+                        *d = distance;
+                    }
+                })
+                .or_insert(distance);
         }
     }
+    if best.is_empty() {
+        return Ok(Vec::new());
+    }
 
-    let mut merged: Vec<SearchResult> = best.into_values().collect();
-    merged.sort_by(|a, b| a.distance.total_cmp(&b.distance));
-    merged.truncate(limit as usize);
-    Ok(merged)
+    let chunk_ids: Vec<i64> = best.keys().copied().collect();
+    let meta = fetch_filtered_chunks(conn, &chunk_ids, type_filter, path_filter)?;
+    Ok(build_semantic_results(best, &meta, limit))
 }
 
 pub fn get_chunks_for_from_target(

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -13,6 +13,22 @@ use super::{
 
 const VEC_MAXSIM_OVERSAMPLE: u32 = 10;
 
+/// KNN-only query over `vec_chunks`. Returns `(chunk_id, distance)` pairs
+/// ordered by ascending distance. Shared by [`vec_search`] (single embedding)
+/// and [`vec_search_multi`] (multiple embeddings sharing one metadata fetch).
+fn knn_only(conn: &Connection, embedding: &[f32], k: u32) -> Result<Vec<(i64, f32)>, StorageError> {
+    let query_bytes = f32_as_bytes(embedding);
+    let mut stmt = conn.prepare_cached(
+        "SELECT chunk_id, distance FROM vec_chunks \
+         WHERE embedding MATCH ?1 AND k = ?2 \
+         ORDER BY distance",
+    )?;
+    let rows = stmt.query_map(params![query_bytes, k], |row| {
+        Ok((row.get(0)?, row.get(1)?))
+    })?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}
+
 fn chunk_from_row(row: &Row<'_>, offset: usize) -> rusqlite::Result<Chunk> {
     Ok(Chunk {
         file_path: row.get(offset)?,
@@ -52,23 +68,8 @@ pub fn vec_search(
     type_filter: Option<&[ChunkType]>,
     path_filter: &[String],
 ) -> Result<Vec<SearchResult>, StorageError> {
-    let query_bytes = f32_as_bytes(query_embedding);
     let k = limit.saturating_mul(VEC_MAXSIM_OVERSAMPLE);
-
-    // KNN query — fetch only chunk_id + distance.
-    // vec0 auxiliary columns (+chunk_id) cannot be used in JOIN conditions,
-    // so we avoid a direct JOIN here.
-    let knn_rows: Vec<(i64, f32)> = {
-        let mut stmt = conn.prepare_cached(
-            "SELECT chunk_id, distance FROM vec_chunks \
-             WHERE embedding MATCH ?1 AND k = ?2 \
-             ORDER BY distance",
-        )?;
-        stmt.query_map(params![query_bytes, k], |row| {
-            Ok((row.get(0)?, row.get(1)?))
-        })?
-        .collect::<Result<Vec<_>, _>>()?
-    };
+    let knn_rows = knn_only(conn, query_embedding, k)?;
 
     if knn_rows.is_empty() {
         return Ok(Vec::new());

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -288,6 +288,62 @@ pub fn get_keyword_doc_frequencies(
     keywords: &[&str],
     total_chunks: u32,
 ) -> Result<Vec<u32>, StorageError> {
+    if keywords.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Bulk path: 1 round-trip via UNION ALL. SQLite preserves the SELECT
+    // order across UNION ALL in practice, but we attach an explicit `idx`
+    // and ORDER BY to defend against re-ordering.
+    let terms: Vec<String> = keywords.iter().map(|k| fts_quote(k)).collect();
+    let mut sql = String::with_capacity(terms.len() * 80);
+    for (i, _) in terms.iter().enumerate() {
+        if i > 0 {
+            sql.push_str(" UNION ALL ");
+        }
+        sql.push_str(&format!(
+            "SELECT {i} AS idx, COUNT(*) AS df FROM fts_chunks WHERE fts_chunks MATCH ?"
+        ));
+    }
+    sql.push_str(" ORDER BY idx");
+
+    let bulk = conn.prepare(&sql).and_then(|mut stmt| {
+        stmt.query_map(params_from_iter(terms.iter()), |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, u32>(1)?))
+        })?
+        .collect::<Result<Vec<(i64, u32)>, _>>()
+    });
+
+    match bulk {
+        Ok(rows) if rows.len() == keywords.len() => {
+            Ok(rows.into_iter().map(|(_, df)| df).collect())
+        }
+        Ok(rows) => {
+            tracing::warn!(
+                expected = keywords.len(),
+                got = rows.len(),
+                "FTS5 bulk doc-freq query returned unexpected row count, falling back to per-keyword"
+            );
+            doc_frequencies_per_keyword(conn, keywords, total_chunks)
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                count = keywords.len(),
+                "FTS5 bulk doc-freq query failed, falling back to per-keyword"
+            );
+            doc_frequencies_per_keyword(conn, keywords, total_chunks)
+        }
+    }
+}
+
+/// Per-keyword fallback used when the bulk UNION ALL query fails. Substitutes
+/// `total_chunks` for individual keyword failures so IDF stays neutral.
+fn doc_frequencies_per_keyword(
+    conn: &Connection,
+    keywords: &[&str],
+    total_chunks: u32,
+) -> Result<Vec<u32>, StorageError> {
     let mut dfs = Vec::with_capacity(keywords.len());
     let mut failed: Vec<(&str, String)> = Vec::new();
     for kw in keywords {

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -3563,8 +3563,7 @@ fn bench_search_hot_path_5emb_50kw() {
         emb[(i + 7) % EMBEDDING_DIMS] = 0.5;
         let content = format!(
             "function handler{i}() {{ render token{i} update cache{i} fetch async await }} \
-             const cfg{i} = {{ value: {i}, label: \"item{i}\" }};",
-            i = i
+             const cfg{i} = {{ value: {i}, label: \"item{i}\" }};"
         );
         insert_chunk(
             &conn,
@@ -3584,7 +3583,6 @@ fn bench_search_hot_path_5emb_50kw() {
         .unwrap();
     }
 
-    // 5 query embeddings.
     let mut embs: Vec<Vec<f32>> = Vec::with_capacity(N_EMBEDDINGS);
     for j in 0..N_EMBEDDINGS {
         let mut emb = vec![0.0_f32; EMBEDDING_DIMS];
@@ -3593,7 +3591,6 @@ fn bench_search_hot_path_5emb_50kw() {
     }
     let emb_refs: Vec<&[f32]> = embs.iter().map(Vec::as_slice).collect();
 
-    // 50 keywords.
     let keywords: Vec<String> = (0..N_KEYWORDS).map(|k| format!("token{k}")).collect();
     let kw_refs: Vec<&str> = keywords.iter().map(String::as_str).collect();
 

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -3593,10 +3593,11 @@ fn bench_search_hot_path_5emb_50kw() {
 
     let keywords: Vec<String> = (0..N_KEYWORDS).map(|k| format!("token{k}")).collect();
     let kw_refs: Vec<&str> = keywords.iter().map(String::as_str).collect();
+    let total_chunks = u32::try_from(N_CHUNKS).expect("N_CHUNKS fits in u32");
 
     // Warm up.
     let _ = vec_search_multi(&conn, &emb_refs, 20, None, &[]).unwrap();
-    let _ = get_keyword_doc_frequencies(&conn, &kw_refs, N_CHUNKS as u32).unwrap();
+    let _ = get_keyword_doc_frequencies(&conn, &kw_refs, total_chunks).unwrap();
 
     // Time vec_search_multi.
     let t0 = Instant::now();
@@ -3608,7 +3609,7 @@ fn bench_search_hot_path_5emb_50kw() {
     // Time get_keyword_doc_frequencies.
     let t1 = Instant::now();
     for _ in 0..ITERATIONS {
-        let _ = get_keyword_doc_frequencies(&conn, &kw_refs, N_CHUNKS as u32).unwrap();
+        let _ = get_keyword_doc_frequencies(&conn, &kw_refs, total_chunks).unwrap();
     }
     let gkdf_elapsed = t1.elapsed();
 

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -3542,3 +3542,87 @@ fn search_by_fts_fallback_to_quoted_literal_on_sanitize_error() {
         "fts_quote fallback should find content containing 'NOT', got empty"
     );
 }
+
+// T-580: wall-clock timing for #133 bulk-fetch refactor.
+// Run with: cargo test --release -- --ignored --nocapture bench_search_hot_path_5emb_50kw
+#[test]
+#[ignore]
+fn bench_search_hot_path_5emb_50kw() {
+    use std::time::Instant;
+    const N_CHUNKS: usize = 200;
+    const N_EMBEDDINGS: usize = 5;
+    const N_KEYWORDS: usize = 50;
+    const ITERATIONS: u32 = 20;
+
+    let (conn, _dir) = test_db();
+
+    // Seed corpus: 200 chunks, varied content + embeddings.
+    for i in 0..N_CHUNKS {
+        let mut emb = vec![0.0_f32; EMBEDDING_DIMS];
+        emb[i % EMBEDDING_DIMS] = 1.0;
+        emb[(i + 7) % EMBEDDING_DIMS] = 0.5;
+        let content = format!(
+            "function handler{i}() {{ render token{i} update cache{i} fetch async await }} \
+             const cfg{i} = {{ value: {i}, label: \"item{i}\" }};",
+            i = i
+        );
+        insert_chunk(
+            &conn,
+            &format!("src/mod_{}.tsx", i % 20),
+            &NewChunk {
+                chunk_type: &ChunkType::Component,
+                name: Some(&format!("Component{i}")),
+                content: &content,
+                start_line: 1,
+                end_line: 5,
+                parent_index: None,
+            },
+            &format!("hash{i}"),
+            &ce(emb),
+            None,
+        )
+        .unwrap();
+    }
+
+    // 5 query embeddings.
+    let mut embs: Vec<Vec<f32>> = Vec::with_capacity(N_EMBEDDINGS);
+    for j in 0..N_EMBEDDINGS {
+        let mut emb = vec![0.0_f32; EMBEDDING_DIMS];
+        emb[j * 13 % EMBEDDING_DIMS] = 1.0;
+        embs.push(emb);
+    }
+    let emb_refs: Vec<&[f32]> = embs.iter().map(Vec::as_slice).collect();
+
+    // 50 keywords.
+    let keywords: Vec<String> = (0..N_KEYWORDS).map(|k| format!("token{k}")).collect();
+    let kw_refs: Vec<&str> = keywords.iter().map(String::as_str).collect();
+
+    // Warm up.
+    let _ = vec_search_multi(&conn, &emb_refs, 20, None, &[]).unwrap();
+    let _ = get_keyword_doc_frequencies(&conn, &kw_refs, N_CHUNKS as u32).unwrap();
+
+    // Time vec_search_multi.
+    let t0 = Instant::now();
+    for _ in 0..ITERATIONS {
+        let _ = vec_search_multi(&conn, &emb_refs, 20, None, &[]).unwrap();
+    }
+    let vsm_elapsed = t0.elapsed();
+
+    // Time get_keyword_doc_frequencies.
+    let t1 = Instant::now();
+    for _ in 0..ITERATIONS {
+        let _ = get_keyword_doc_frequencies(&conn, &kw_refs, N_CHUNKS as u32).unwrap();
+    }
+    let gkdf_elapsed = t1.elapsed();
+
+    println!(
+        "vec_search_multi: {N_EMBEDDINGS} embs × {ITERATIONS} iters, {N_CHUNKS} chunks corpus → {:.2}ms total, {:.3}ms/call",
+        vsm_elapsed.as_secs_f64() * 1000.0,
+        vsm_elapsed.as_secs_f64() * 1000.0 / f64::from(ITERATIONS)
+    );
+    println!(
+        "get_keyword_doc_frequencies: {N_KEYWORDS} kw × {ITERATIONS} iters, {N_CHUNKS} chunks corpus → {:.2}ms total, {:.3}ms/call",
+        gkdf_elapsed.as_secs_f64() * 1000.0,
+        gkdf_elapsed.as_secs_f64() * 1000.0 / f64::from(ITERATIONS)
+    );
+}

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -727,7 +727,7 @@ impl Yomu {
         if parent_ids.is_empty() {
             return Ok(HashMap::new());
         }
-        self.with_db(move |conn| storage::get_chunks_by_ids(conn, &parent_ids))
+        self.with_db(move |conn| storage::get_chunks_by_ids(conn, &parent_ids, None, &[]))
     }
 
     fn semantic_search(


### PR DESCRIPTION
## 概要

#133 (RC-006) の解消。`src/storage/search.rs` の N+1 ホットパス 2 箇所を bulk-fetch にリファクタリング。

- **`vec_search_multi`**: 旧実装は embedding ごとに `vec_search` を呼んでいたため 2N DB round-trip（KNN + metadata）。新実装は全 embedding で共有する 1 回の filtered metadata fetch にまとめ、N+1 round-trip に削減。
- **`get_keyword_doc_frequencies`**: 旧実装は keyword ごとに `COUNT(*)` を発行（N round-trip）。新実装は `UNION ALL` で 1 query にまとめ、明示的な `idx` で順序保証。bulk fail 時は per-keyword fallback。

privateヘルパー (`knn_only`, `build_semantic_results`) を追加して `vec_search` / `vec_search_multi` 間で共有。metadata fetch は既存の `get_chunks_by_ids` を type/path filter 受けに拡張する形で統合。

## ベンチマーク (debug profile, 200-chunk corpus, 20 iters × 3 runs)

| 関数 | 形状 | Before (main) | After | 改善 |
|---|---|---|---|---|
| `vec_search_multi` | 5 embeddings | 15.43 ms/call | **10.40 ms/call** | **33%** |
| `get_keyword_doc_frequencies` | 50 keywords | 1.42 ms/call | **1.28 ms/call** | **9%** |

doc-freq の改善が小さいのは local SQLite で FTS5 MATCH が round-trip overhead を支配しているため。構造的な改善 (N→1 queries) は higher-latency storage や larger N で意味あり。

再検証コマンド:
```
cargo test --release -- --ignored --nocapture bench_search_hot_path_5emb_50kw
```

## /polish レビューで追加した安全策

- **MAX_VEC_CANDIDATES = 30,000**: `vec_search_multi` の共有 IN-clause を SQLite の `SQLITE_MAX_VARIABLE_NUMBER` (32766) 以下に bound。これがないと `search_from_file` で 150+ chunks の source file 経由でオーバーフロー可能。
- **MAX_BULK_DOC_FREQ_KEYWORDS = 500**: SQLite の `SQLITE_MAX_COMPOUND_SELECT` デフォルト以下で UNION ALL bulk path を skip、pathological 入力では per-keyword に fallback。

## 挙動同値性

`vec_search_multi` の「merge してから truncate」は、`k = limit * VEC_MAXSIM_OVERSAMPLE` (10×) という前提のもとで旧実装の「emb 毎に truncate してから merge」と同じ top-`limit` ranking を返す。既存 3 つの behavioral test (T-563/T-545/T-008) で確認済み。

## コミット

1. `refactor(search): extract knn_only helper from vec_search`
2. `refactor(search): share metadata fetch across vec_search_multi (#133)`
3. `refactor(search): bulk doc-frequency via UNION ALL (#133)`
4. `test(search): wall-clock bench for #133 bulk-fetch refactor`
5. `refactor(search): polish review fixes for #133 bulk-fetch` (EFF-001 / REUSE-001 / EFF-002 + readability)

## テスト計画

- [x] `cargo test --lib` → 460 pass, 0 fail
- [x] vec_search_multi 既存 3 テスト不変 (T-563/T-545/T-008)
- [x] get_keyword_doc_frequencies regression test 不変
- [x] T-580 bench harness 追加 (`#[ignore]`)
- [ ] CI clippy + tests
- [ ] (follow-up) MAX_VEC_CANDIDATES / MAX_BULK_DOC_FREQ_KEYWORDS cap 分岐の unit test