### PR TITLE
ci: cargo test を nextest に移行 (#167)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,7 @@
+[profile.default]
+fail-fast = false
+
+[profile.ci]
+fail-fast = false
+slow-timeout = { period = "120s", terminate-after = 2 }
+final-status-level = "flaky"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,13 @@ jobs:
       - name: Check
         run: cargo check
 
+      - name: Install nextest
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2
+        with:
+          tool: cargo-nextest
+
       - name: Test
-        run: cargo test
+        run: cargo nextest run --profile ci
 
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings

--- a/README.ja.md
+++ b/README.ja.md
@@ -265,7 +265,7 @@ git config --local core.hooksPath .githooks
 ### よく使うコマンド
 
 ```sh
-cargo test                                                # 全テスト
+cargo nextest run                                         # 全テスト（導入: cargo install cargo-nextest --locked）
 cargo clippy --all-targets --all-features -- -D warnings  # lint（CI と同条件）
 cargo fmt -- --check                                      # フォーマット検査
 ```

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ This installs a pre-commit hook that runs `cargo fmt --check` and `cargo clippy 
 ### Common commands
 
 ```sh
-cargo test                                                # all tests
+cargo nextest run                                         # all tests (install: cargo install cargo-nextest --locked)
 cargo clippy --all-targets --all-features -- -D warnings  # lint (matches CI)
 cargo fmt -- --check                                      # format check
 ```


### PR DESCRIPTION
## 概要

- `.github/workflows/ci.yml` の Test step を `cargo nextest run --profile ci` へ置換
- `.config/nextest.toml` を新規作成 (profile.default / profile.ci, flaky 検出と slow-timeout 設定)
- README.md / README.ja.md の `cargo test` 例を `cargo nextest run` へ更新

cli 配下リポでの nextest 横展開 ([rurico@17c10f5](https://github.com/thkt/rurico/commit/17c10f5)) に追従。doctest は src 配下に存在しないため `cargo test --doc` 別 step は追加しない。yomu には justfile / serial_test も無いため `#[serial]` 撤去対応も不要。

Closes #167

## テスト計画

- [x] ローカルで `cargo nextest run --profile ci` 実行 → 522 tests passed, 3 skipped (40.140s)
- [ ] CI 上で `cargo nextest run --profile ci` が green
- [x] README.md / README.ja.md の置換漏れなし