### PR TITLE
chore(ci): zizmor で GitHub Actions workflow を強化 (#166)

### DIFF
--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -1,5 +1,5 @@
 # Maps Issue Forms dropdown selections to labels.
-# See https://github.com/stefanbuck/advanced-issue-labeler for syntax.
+# See https://github.com/redhat-plumbers-in-action/advanced-issue-labeler for syntax.
 #
 # Per-repo extension: target repos can append additional `policy` entries
 # (e.g. for area:* labels) by editing this file directly. The shared base
@@ -9,12 +9,12 @@ policy:
       - bug.yml
       - feature.yml
     section:
-      - id: priority
-        block-list:
-          - high
-          - medium
-          - low
+      - id: [priority]
+        block-list: []
         label:
-          - priority:high
-          - priority:medium
-          - priority:low
+          - name: 'priority:high'
+            keys: ['high']
+          - name: 'priority:medium'
+            keys: ['medium']
+          - name: 'priority:low'
+            keys: ['low']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
@@ -54,6 +56,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable

--- a/.github/workflows/label-from-issue.yml
+++ b/.github/workflows/label-from-issue.yml
@@ -7,22 +7,46 @@ on:
       - edited
 
 permissions:
+  contents: read
   issues: write
 
 jobs:
   label:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - name: Apply priority labels
-        uses: stefanbuck/[email protected]
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
+
+      - name: Parse bug.yml
+        id: parse-bug
+        uses: stefanbuck/github-issue-parser@cb6e97157cbf851e3a393ff8d57c93a484cc323f # v3
+        with:
+          template-path: .github/ISSUE_TEMPLATE/bug.yml
+        continue-on-error: true
+
+      - name: Apply labels for bug
+        if: steps.parse-bug.outcome == 'success'
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@b80ae64e3e156e9c111b075bfa04b295d54e8e2e # v3.2.4
+        with:
+          issue-form: ${{ steps.parse-bug.outputs.jsonString }}
           template: bug.yml
           section: priority
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Apply priority labels (feature)
-        uses: stefanbuck/[email protected]
+      - name: Parse feature.yml
+        id: parse-feature
+        uses: stefanbuck/github-issue-parser@cb6e97157cbf851e3a393ff8d57c93a484cc323f # v3
         with:
+          template-path: .github/ISSUE_TEMPLATE/feature.yml
+        continue-on-error: true
+
+      - name: Apply labels for feature
+        if: steps.parse-feature.outcome == 'success'
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@b80ae64e3e156e9c111b075bfa04b295d54e8e2e # v3.2.4
+        with:
+          issue-form: ${{ steps.parse-feature.outputs.jsonString }}
           template: feature.yml
           section: priority
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: zizmor
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: zizmor-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,15 @@
+rules:
+  artipacked:
+    ignore:
+      # update-homebrew job requires HOMEBREW_TAP_TOKEN to be persisted for git push
+      - release.yml:109
+  cache-poisoning:
+    ignore:
+      # Swatinem/rust-cache in build job; release workflow runs on tag push only,
+      # no PR-driven cache injection path exists for poisoning to reach release artifacts
+      - release.yml:38
+  superfluous-actions:
+    ignore:
+      # softprops/action-gh-release retained for generate_release_notes feature
+      # which gh CLI does not provide equivalently in script step
+      - release.yml:96


### PR DESCRIPTION
## 概要

[zizmor](https://docs.zizmor.sh) を導入し、yomu の workflow セキュリティ baseline を構築する。scout PR [#89](https://github.com/thkt/scout/pull/89) で実証された pattern を踏襲。

### 4 点セット

- 既存 workflow に `persist-credentials: false` 追加 (ci.yml × 2 job, release.yml の build job × 1)
- `.github/workflows/zizmor.yml` 新規: 専用 audit workflow (SARIF + Code Scanning 統合)
- `.github/zizmor.yml` 新規: release.yml の 3 件の unactionable findings を justification 付きで ignore
- 全 `uses` を SHA pin (label-from-issue.yml 経由で追加された stefanbuck/github-issue-parser, redhat-plumbers-in-action/advanced-issue-labeler, zizmorcore/zizmor-action 含む)

### スコープ拡大 (user 承認済み)

`label-from-issue.yml` が参照していた `stefanbuck/[email protected]` は **404 (タイプミス、実在しないリポジトリ)** であることが発覚。これにより priority label 自動付与は長期間停止していた。本 PR で scout 準拠の parser+labeler 分離アーキテクチャへ移行し復旧:

- `stefanbuck/github-issue-parser@v3` (Issue Form parse)
- `redhat-plumbers-in-action/advanced-issue-labeler@v3.2.4` (label apply)
- `.github/advanced-issue-labeler.yml` の schema を redhat-plumbers-in-action 仕様へ移行

scout の labeler は直近 5 run 全 success の動作実績あり。

### 注意事項

`.github/zizmor.yml` は release.yml の行番号 (109, 38, 96) で finding を ignore している。**release.yml を編集する際は zizmor をローカル再実行して行番号を再同期する** こと。行ズレで意図しない finding を suppress する可能性がある。

Closes #166

## テスト計画

- [x] ローカルで `zizmor .github/workflows/` → `No findings to report. Good job! (3 ignored, 18 suppressed)`
- [x] label-from-issue.yml の parse error 解消 (全 workflow が audit 対象に)
- [ ] CI 上で zizmor workflow が green (Code Scanning findings が空)
- [ ] merge 後に test issue を 1 件開き、priority label 自動付与の挙動を実環境確認