### PR TITLE
chore(deps): rurico/amici を bump して bytemuck::cast_slice へ移行

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,8 +34,9 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=6ca986d#6ca986df827ba213761dd947dd607099ca2f1055"
+source = "git+https://github.com/thkt/amici?rev=2b54c72#2b54c728f745a88794a7b9084b06d4b7723158af"
 dependencies = [
+ "bytemuck",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rurico",
@@ -2106,13 +2107,11 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=0c0e0f6#0c0e0f6c93c2705d1d76304a15fc8549da07052b"
+source = "git+https://github.com/thkt/rurico?rev=bb25a06#bb25a06cd32b5e83df291d6a7cf251de738ac7bb"
 dependencies = [
  "bytemuck",
  "hf-hub",
  "mlx-rs",
- "rand 0.10.1",
- "rand_chacha 0.10.0",
  "rurico-ffi",
  "rusqlite",
  "serde",
@@ -2126,7 +2125,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=0c0e0f6#0c0e0f6c93c2705d1d76304a15fc8549da07052b"
+source = "git+https://github.com/thkt/rurico?rev=bb25a06#bb25a06cd32b5e83df291d6a7cf251de738ac7bb"
 dependencies = [
  "mlx-sys",
  "rusqlite",
@@ -3555,6 +3554,7 @@ name = "yomu"
 version = "0.15.0"
 dependencies = [
  "amici",
+ "bytemuck",
  "clap",
  "ignore",
  "rurico",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,11 @@ repository = "https://github.com/thkt/yomu"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "6ca986d" }
+amici = { git = "https://github.com/thkt/amici", rev = "2b54c72" }
+bytemuck = "1"
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
-rurico = { git = "https://github.com/thkt/rurico", rev = "0c0e0f6" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "bb25a06" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -30,7 +31,7 @@ tree-sitter-rust = "0.24"
 tree-sitter-typescript = "0.23"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "0c0e0f6", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "bb25a06", features = ["test-support"] }
 tempfile = "3"
 tracing-test = { version = "0.2", features = ["no-env-filter"] }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use amici::cli::{deprecation_warn, exit_error, hint_arrow, try_expand_shorthand}
 use amici::logging::init_subscriber;
 use clap::error::ErrorKind;
 use clap::{CommandFactory, Parser, Subcommand};
-use rurico::model_probe::handle_probe_if_needed;
+use rurico::handle_probe_if_needed;
 use yomu::brief;
 use yomu::tools::{
     MAX_IMPACT_DEPTH, MAX_SEARCH_LIMIT, MAX_SEARCH_OFFSET, Yomu, YomuError, YomuOptions,

--- a/src/query/tests.rs
+++ b/src/query/tests.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
+use bytemuck::cast_slice;
 use rurico::embed::{Embedder, FailingEmbedder, MockEmbedder, ModelId};
 use rurico::reranker::{MockReranker, RankedResult, Rerank, RerankerError};
 use tempfile::tempdir;
@@ -1529,7 +1530,7 @@ fn bench_knn_round_trips() {
 
     let run = |n: usize, label: &str| {
         let emb_bytes: Vec<Vec<u8>> = (0..n)
-            .map(|i| storage::f32_as_bytes(&emb_axis(i % 32)).to_vec())
+            .map(|i| cast_slice::<f32, u8>(&emb_axis(i % 32)).to_vec())
             .collect();
         let iters = 50;
         let t = Instant::now();
@@ -1606,7 +1607,7 @@ fn search_from_file_excludes_source_chunks() {
     )
     .unwrap();
 
-    let emb_bytes = vec![storage::f32_as_bytes(&emb_axis(0)).to_vec()];
+    let emb_bytes = vec![cast_slice::<f32, u8>(&emb_axis(0)).to_vec()];
     let source_ids = HashSet::from([id_src1, id_src2]);
 
     let results = search_from_file(&conn, &emb_bytes, &source_ids, None, 10, &[]).unwrap();
@@ -1670,7 +1671,7 @@ fn search_from_file_with_query_applies_fts_filter() {
     )
     .unwrap();
 
-    let emb_bytes = vec![storage::f32_as_bytes(&emb_axis(0)).to_vec()];
+    let emb_bytes = vec![cast_slice::<f32, u8>(&emb_axis(0)).to_vec()];
     let source_ids = HashSet::from([id_source]);
 
     let results = search_from_file(&conn, &emb_bytes, &source_ids, Some("error"), 10, &[]).unwrap();
@@ -1716,7 +1717,7 @@ fn search_from_file_fts_zero_matches_returns_empty() {
     )
     .unwrap();
 
-    let emb_bytes = vec![storage::f32_as_bytes(&emb_axis(0)).to_vec()];
+    let emb_bytes = vec![cast_slice::<f32, u8>(&emb_axis(0)).to_vec()];
     let source_ids = HashSet::from([id_source]);
 
     let results =
@@ -1756,7 +1757,7 @@ fn search_from_file_caps_sub_embeddings_at_20() {
     .unwrap();
 
     // Generate 25 sub-embeddings (all same vector for simplicity)
-    let emb_bytes = storage::f32_as_bytes(&emb_axis(0)).to_vec();
+    let emb_bytes = cast_slice::<f32, u8>(&emb_axis(0)).to_vec();
     let entries: Vec<Vec<u8>> = (0..25).map(|_| emb_bytes.clone()).collect();
     let source_ids = HashSet::new();
 
@@ -1842,7 +1843,7 @@ fn search_from_file_fts_uses_fetch_limit_not_limit() {
     )
     .unwrap();
 
-    let emb_bytes = vec![storage::f32_as_bytes(&emb_axis(0)).to_vec()];
+    let emb_bytes = vec![cast_slice::<f32, u8>(&emb_axis(0)).to_vec()];
     let source_ids = HashSet::from([id_source]);
 
     // limit=1: with bug, FTS picks top BM25 (far_handler); with fix, all pass through to rerank
@@ -1950,7 +1951,7 @@ fn search_from_file_3x_overfetch_reaches_third_candidate() {
     .unwrap();
 
     // Search from emb_axis(0) with query "magic", limit=1 → fetch_limit=3
-    let emb_bytes = vec![storage::f32_as_bytes(&emb_axis(0)).to_vec()];
+    let emb_bytes = vec![cast_slice::<f32, u8>(&emb_axis(0)).to_vec()];
     let source_ids = HashSet::from([id_source]);
 
     let results = search_from_file(&conn, &emb_bytes, &source_ids, Some("magic"), 1, &[]).unwrap();
@@ -2006,7 +2007,7 @@ fn search_from_file_source_exclusion_does_not_empty_results_at_limit_1() {
     )
     .unwrap();
 
-    let emb_bytes = vec![storage::f32_as_bytes(&emb_axis(0)).to_vec()];
+    let emb_bytes = vec![cast_slice::<f32, u8>(&emb_axis(0)).to_vec()];
     let source_ids = HashSet::from([id_source]);
 
     let results = search_from_file(&conn, &emb_bytes, &source_ids, None, 1, &[]).unwrap();
@@ -2057,7 +2058,7 @@ fn search_from_file_stopword_query_falls_back_to_semantic() {
     )
     .unwrap();
 
-    let emb_bytes = vec![storage::f32_as_bytes(&emb_axis(0)).to_vec()];
+    let emb_bytes = vec![cast_slice::<f32, u8>(&emb_axis(0)).to_vec()];
     let source_ids = HashSet::from([id_source]);
 
     // "a" is a stopword → extract_keywords returns [] → must behave like query=None

--- a/src/query/tests.rs
+++ b/src/query/tests.rs
@@ -1529,9 +1529,7 @@ fn bench_knn_round_trips() {
     let source_ids = HashSet::new();
 
     let run = |n: usize, label: &str| {
-        let emb_bytes: Vec<Vec<u8>> = (0..n)
-            .map(|i| cast_slice::<f32, u8>(&emb_axis(i % 32)).to_vec())
-            .collect();
+        let emb_bytes: Vec<Vec<u8>> = (0..n).map(|i| emb_axis_bytes(i % 32)).collect();
         let iters = 50;
         let t = Instant::now();
         for _ in 0..iters {
@@ -1551,6 +1549,10 @@ fn emb_axis(axis: usize) -> Vec<f32> {
     let mut v = vec![0.0_f32; storage::EMBEDDING_DIMS];
     v[axis] = 1.0;
     v
+}
+
+fn emb_axis_bytes(axis: usize) -> Vec<u8> {
+    cast_slice::<f32, u8>(&emb_axis(axis)).to_vec()
 }
 
 // T-009: search_from_file excludes source chunk_ids
@@ -1607,7 +1609,7 @@ fn search_from_file_excludes_source_chunks() {
     )
     .unwrap();
 
-    let emb_bytes = vec![cast_slice::<f32, u8>(&emb_axis(0)).to_vec()];
+    let emb_bytes = vec![emb_axis_bytes(0)];
     let source_ids = HashSet::from([id_src1, id_src2]);
 
     let results = search_from_file(&conn, &emb_bytes, &source_ids, None, 10, &[]).unwrap();
@@ -1671,7 +1673,7 @@ fn search_from_file_with_query_applies_fts_filter() {
     )
     .unwrap();
 
-    let emb_bytes = vec![cast_slice::<f32, u8>(&emb_axis(0)).to_vec()];
+    let emb_bytes = vec![emb_axis_bytes(0)];
     let source_ids = HashSet::from([id_source]);
 
     let results = search_from_file(&conn, &emb_bytes, &source_ids, Some("error"), 10, &[]).unwrap();
@@ -1717,7 +1719,7 @@ fn search_from_file_fts_zero_matches_returns_empty() {
     )
     .unwrap();
 
-    let emb_bytes = vec![cast_slice::<f32, u8>(&emb_axis(0)).to_vec()];
+    let emb_bytes = vec![emb_axis_bytes(0)];
     let source_ids = HashSet::from([id_source]);
 
     let results =
@@ -1757,7 +1759,7 @@ fn search_from_file_caps_sub_embeddings_at_20() {
     .unwrap();
 
     // Generate 25 sub-embeddings (all same vector for simplicity)
-    let emb_bytes = cast_slice::<f32, u8>(&emb_axis(0)).to_vec();
+    let emb_bytes = emb_axis_bytes(0);
     let entries: Vec<Vec<u8>> = (0..25).map(|_| emb_bytes.clone()).collect();
     let source_ids = HashSet::new();
 
@@ -1843,7 +1845,7 @@ fn search_from_file_fts_uses_fetch_limit_not_limit() {
     )
     .unwrap();
 
-    let emb_bytes = vec![cast_slice::<f32, u8>(&emb_axis(0)).to_vec()];
+    let emb_bytes = vec![emb_axis_bytes(0)];
     let source_ids = HashSet::from([id_source]);
 
     // limit=1: with bug, FTS picks top BM25 (far_handler); with fix, all pass through to rerank
@@ -1951,7 +1953,7 @@ fn search_from_file_3x_overfetch_reaches_third_candidate() {
     .unwrap();
 
     // Search from emb_axis(0) with query "magic", limit=1 → fetch_limit=3
-    let emb_bytes = vec![cast_slice::<f32, u8>(&emb_axis(0)).to_vec()];
+    let emb_bytes = vec![emb_axis_bytes(0)];
     let source_ids = HashSet::from([id_source]);
 
     let results = search_from_file(&conn, &emb_bytes, &source_ids, Some("magic"), 1, &[]).unwrap();
@@ -2007,7 +2009,7 @@ fn search_from_file_source_exclusion_does_not_empty_results_at_limit_1() {
     )
     .unwrap();
 
-    let emb_bytes = vec![cast_slice::<f32, u8>(&emb_axis(0)).to_vec()];
+    let emb_bytes = vec![emb_axis_bytes(0)];
     let source_ids = HashSet::from([id_source]);
 
     let results = search_from_file(&conn, &emb_bytes, &source_ids, None, 1, &[]).unwrap();
@@ -2058,7 +2060,7 @@ fn search_from_file_stopword_query_falls_back_to_semantic() {
     )
     .unwrap();
 
-    let emb_bytes = vec![cast_slice::<f32, u8>(&emb_axis(0)).to_vec()];
+    let emb_bytes = vec![emb_axis_bytes(0)];
     let source_ids = HashSet::from([id_source]);
 
     // "a" is a stopword → extract_keywords returns [] → must behave like query=None

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -22,7 +22,6 @@ use rusqlite::Connection;
 pub type Db = Connection;
 
 pub use rurico::embed::EMBEDDING_DIMS;
-pub use rurico::storage::f32_as_bytes;
 pub(crate) use rurico::storage::{QueryNormalizationConfig, normalize_for_fts};
 
 /// FTS normalization shared by index INSERT and query MATCH paths.

--- a/src/storage/mutation.rs
+++ b/src/storage/mutation.rs
@@ -1,7 +1,7 @@
+use bytemuck::cast_slice;
 use rusqlite::Connection;
 
 use rurico::embed::ChunkedEmbedding;
-use rurico::storage::f32_as_bytes;
 
 use crate::text::split_identifier;
 
@@ -58,7 +58,7 @@ pub(super) fn insert_sub_embeddings(
     chunked_emb: &ChunkedEmbedding,
 ) -> Result<(), StorageError> {
     for (sub_idx, emb_slice) in chunked_emb.chunks.iter().enumerate() {
-        let bytes = f32_as_bytes(emb_slice);
+        let bytes = cast_slice::<f32, u8>(emb_slice);
         conn.prepare_cached(
             "INSERT INTO vec_chunks (embedding, chunk_id, sub_idx) VALUES (?1, ?2, ?3)",
         )?

--- a/src/storage/mutation.rs
+++ b/src/storage/mutation.rs
@@ -58,7 +58,7 @@ pub(super) fn insert_sub_embeddings(
     chunked_emb: &ChunkedEmbedding,
 ) -> Result<(), StorageError> {
     for (sub_idx, emb_slice) in chunked_emb.chunks.iter().enumerate() {
-        let bytes = cast_slice::<f32, u8>(emb_slice);
+        let bytes: &[u8] = cast_slice(emb_slice);
         conn.prepare_cached(
             "INSERT INTO vec_chunks (embedding, chunk_id, sub_idx) VALUES (?1, ?2, ?3)",
         )?

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -28,7 +28,7 @@ const MAX_BULK_DOC_FREQ_KEYWORDS: usize = 500;
 /// ordered by ascending distance. Shared by [`vec_search`] (single embedding)
 /// and [`vec_search_multi`] (multiple embeddings sharing one metadata fetch).
 fn knn_only(conn: &Connection, embedding: &[f32], k: u32) -> Result<Vec<(i64, f32)>, StorageError> {
-    let query_bytes = cast_slice::<f32, u8>(embedding);
+    let query_bytes: &[u8] = cast_slice(embedding);
     let mut stmt = conn.prepare_cached(
         "SELECT chunk_id, distance FROM vec_chunks \
          WHERE embedding MATCH ?1 AND k = ?2 \

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -3,11 +3,12 @@ use std::collections::{HashMap, HashSet};
 use amici::storage::filter::{
     append_exclude_ids, append_in_filter, append_include_ids, append_like_prefix_filter,
 };
+use bytemuck::cast_slice;
 use rurico::storage::{fts_quote, prepare_match_query};
 use rusqlite::{Connection, Error as RusqliteError, Row, params, params_from_iter, types::ToSql};
 
 use super::{
-    Chunk, ChunkType, MatchSource, SearchResult, StorageError, anon_placeholders, f32_as_bytes,
+    Chunk, ChunkType, MatchSource, SearchResult, StorageError, anon_placeholders,
     fts_normalization, in_placeholders,
 };
 
@@ -27,7 +28,7 @@ const MAX_BULK_DOC_FREQ_KEYWORDS: usize = 500;
 /// ordered by ascending distance. Shared by [`vec_search`] (single embedding)
 /// and [`vec_search_multi`] (multiple embeddings sharing one metadata fetch).
 fn knn_only(conn: &Connection, embedding: &[f32], k: u32) -> Result<Vec<(i64, f32)>, StorageError> {
-    let query_bytes = f32_as_bytes(embedding);
+    let query_bytes = cast_slice::<f32, u8>(embedding);
     let mut stmt = conn.prepare_cached(
         "SELECT chunk_id, distance FROM vec_chunks \
          WHERE embedding MATCH ?1 AND k = ?2 \


### PR DESCRIPTION
## 概要

- rurico `0c0e0f6` → `bb25a06` (PR #126 ModelKind generics / PR #127 reranker sub-batching / PR #144 visibility tightening)
- amici `6ca986d` → `2b54c72` — `amici@6ca986d` が古い rurico rev に pin されてたため、co-bump せんと dep graph に 2 つの rurico ビルドが入ってコンパイル失敗する
- `bytemuck = "1"` を直接依存に追加し、削除された `rurico::storage::f32_as_bytes` re-export を `bytemuck::cast_slice` に置換 (11 箇所)

## 追従した breaking change

| 変更 | 出所 |
| --- | --- |
| `rurico::storage::f32_as_bytes` 削除 | rurico PR #144 (Issue #162) |
| `rurico::model_probe::handle_probe_if_needed` → `rurico::handle_probe_if_needed` (crate root へ移動) | rurico PR #126 — build 中に判明、issue には未記載 |
| `amici@6ca986d` が古い rurico に依存 | 初回 `cargo build` で dual-rurico エラーが出て発覚 — amici 同時 bump で対応 |

下 2 件は元 issue に記載がなく、bumped rurico に対する `cargo build` 実行中に発覚したため本 PR でまとめて対応。

## テスト計画

- [x] `cargo build --workspace`
- [x] `cargo build --workspace --all-features`
- [x] `cargo nextest run --workspace` → 522 pass, 3 skipped
- [x] `cargo clippy --all-targets --all-features -- -D warnings` → clean

## クリーンアップ

`cast_slice::<f32, u8>(&emb_axis(0)).to_vec()` がテストで 8 箇所重複してたので `emb_axis_bytes(axis)` ヘルパーを `emb_axis` の隣に抽出。本番側は `let x: &[u8] = cast_slice(s);` 形式で turbofish 不要。

Closes #161
Closes #162