### PR TITLE
refactor(yomu): YomuConfig を amici::cli::env_lookup で DI 化 (#150)

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -10,6 +10,7 @@ use std::process::ExitCode;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use amici::cli::embed_with_spinners;
+use amici::cli::env_lookup;
 use amici::cli::exit_code::CliError;
 use amici::model::{ModelLoad, degrade_with_warn, download_and_verify_model, record_degraded};
 use rurico::embed::Embed;
@@ -24,7 +25,7 @@ use crate::storage;
 
 #[cfg(any(test, feature = "test-support"))]
 use embedder::DEFAULT_EMBED_BUDGET;
-use embedder::{DegradedReason, degraded_reason_user_note, parse_embed_budget};
+use embedder::{DegradedReason, degraded_reason_user_note, parse_budget_value};
 use format::{
     EnrichmentContext, format_coverage, format_coverage_note, format_dry_run_json,
     format_embed_result, format_impact_all, format_impact_json, format_impact_results,
@@ -96,6 +97,39 @@ pub struct YomuOptions {
     pub no_embed: bool,
 }
 
+/// Env-derived runtime configuration for [`Yomu::with_root`].
+///
+/// Production callers obtain this via [`YomuConfig::from_env`]; tests use
+/// [`YomuConfig::from_env_with`] to inject a deterministic lookup closure.
+#[derive(Debug, Clone, Copy)]
+pub struct YomuConfig {
+    pub embed_disabled: bool,
+    pub rerank_enabled: bool,
+    pub embed_budget: u32,
+}
+
+impl YomuConfig {
+    /// Read configuration from the process environment.
+    pub fn from_env() -> Self {
+        Self::from_env_with(env_lookup())
+    }
+
+    /// Read configuration through an injected lookup closure.
+    pub fn from_env_with<F: Fn(&str) -> Option<String>>(get: F) -> Self {
+        Self {
+            embed_disabled: get("YOMU_EMBED").as_deref() == Some("0"),
+            rerank_enabled: get("YOMU_RERANK").as_deref() == Some("1"),
+            embed_budget: parse_budget_value(get("YOMU_EMBED_BUDGET").as_deref()),
+        }
+    }
+}
+
+impl Default for YomuConfig {
+    fn default() -> Self {
+        Self::from_env_with(|_| None)
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum YomuError {
     #[error("storage error: {0}")]
@@ -148,23 +182,26 @@ impl Yomu {
     pub fn new(options: YomuOptions) -> Result<Self, YomuError> {
         let cwd = env::current_dir()?;
         let root = config::detect_root(&cwd);
-        Self::with_root(root, options)
+        Self::with_root(root, options, YomuConfig::from_env())
     }
 
-    pub fn with_root(root: PathBuf, options: YomuOptions) -> Result<Self, YomuError> {
+    pub fn with_root(
+        root: PathBuf,
+        options: YomuOptions,
+        config: YomuConfig,
+    ) -> Result<Self, YomuError> {
         tracing::info!(root = %root.display(), "Detected project root");
         let db_path = root.join(".yomu").join("index.db");
         let conn = storage::open_db(&db_path)?;
 
-        let embed_disabled = options.no_embed || env::var("YOMU_EMBED").as_deref() == Ok("0");
-        let rerank_enabled = env::var("YOMU_RERANK").as_deref() == Ok("1");
+        let embed_disabled = options.no_embed || config.embed_disabled;
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
             embedder: OnceLock::new(),
             root,
-            embed_budget: parse_embed_budget(),
+            embed_budget: config.embed_budget,
             embed_disabled,
-            rerank_enabled,
+            rerank_enabled: config.rerank_enabled,
             reranker: OnceLock::new(),
         })
     }

--- a/src/tools/embedder.rs
+++ b/src/tools/embedder.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::sync::Arc;
 
 use amici::model::embedder::try_load_embedder_with;
@@ -70,10 +69,6 @@ pub(super) fn parse_budget_value(value: Option<&str>) -> u32 {
         },
         None => DEFAULT_EMBED_BUDGET,
     }
-}
-
-pub(super) fn parse_embed_budget() -> u32 {
-    parse_budget_value(env::var("YOMU_EMBED_BUDGET").ok().as_deref())
 }
 
 fn try_load_embedder(disabled: bool) -> Result<Arc<dyn Embed>, DegradedReason> {

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -1258,7 +1258,11 @@ fn ensure_indexed_fully_embedded_with_failing_embedder() {
 #[test]
 fn with_root_creates_db_and_returns_yomu() {
     let dir = tempdir().unwrap();
-    let result = Yomu::with_root(dir.path().to_path_buf(), Default::default());
+    let result = Yomu::with_root(
+        dir.path().to_path_buf(),
+        Default::default(),
+        Default::default(),
+    );
     assert!(
         result.is_ok(),
         "with_root should succeed: {:?}",
@@ -2699,4 +2703,73 @@ fn error_code_embedder_unavailable_is_temp_failure() {
     let err = YomuError::EmbedderUnavailable("offline".into());
     assert_eq!(err.error_code(), ErrorCode::TempFailure);
     assert_eq!(err.exit_code(), ExitCode::from(75));
+}
+
+// T-CFG001: from_env_with returns defaults when lookup yields nothing
+#[test]
+fn yomu_config_from_env_with_empty_lookup_uses_defaults() {
+    let cfg = YomuConfig::from_env_with(|_| None);
+    assert!(!cfg.embed_disabled);
+    assert!(!cfg.rerank_enabled);
+    assert_eq!(cfg.embed_budget, DEFAULT_EMBED_BUDGET);
+}
+
+// T-CFG002: YOMU_EMBED=0 sets embed_disabled
+#[test]
+fn yomu_config_yomu_embed_zero_disables_embedding() {
+    let cfg = YomuConfig::from_env_with(|k| match k {
+        "YOMU_EMBED" => Some("0".into()),
+        _ => None,
+    });
+    assert!(cfg.embed_disabled);
+}
+
+// T-CFG003: YOMU_EMBED non-"0" leaves embed_disabled false
+#[test]
+fn yomu_config_yomu_embed_non_zero_keeps_embedding() {
+    let cfg = YomuConfig::from_env_with(|k| match k {
+        "YOMU_EMBED" => Some("1".into()),
+        _ => None,
+    });
+    assert!(!cfg.embed_disabled);
+}
+
+// T-CFG004: YOMU_RERANK=1 enables reranker
+#[test]
+fn yomu_config_yomu_rerank_one_enables_reranker() {
+    let cfg = YomuConfig::from_env_with(|k| match k {
+        "YOMU_RERANK" => Some("1".into()),
+        _ => None,
+    });
+    assert!(cfg.rerank_enabled);
+}
+
+// T-CFG005: YOMU_RERANK non-"1" leaves reranker disabled
+#[test]
+fn yomu_config_yomu_rerank_non_one_keeps_reranker_off() {
+    let cfg = YomuConfig::from_env_with(|k| match k {
+        "YOMU_RERANK" => Some("0".into()),
+        _ => None,
+    });
+    assert!(!cfg.rerank_enabled);
+}
+
+// T-CFG006: YOMU_EMBED_BUDGET valid value flows through
+#[test]
+fn yomu_config_yomu_embed_budget_valid_value_applied() {
+    let cfg = YomuConfig::from_env_with(|k| match k {
+        "YOMU_EMBED_BUDGET" => Some("10".into()),
+        _ => None,
+    });
+    assert_eq!(cfg.embed_budget, 10);
+}
+
+// T-CFG007: Default impl equals from_env_with empty lookup
+#[test]
+fn yomu_config_default_matches_empty_lookup() {
+    let default = YomuConfig::default();
+    let empty = YomuConfig::from_env_with(|_| None);
+    assert_eq!(default.embed_disabled, empty.embed_disabled);
+    assert_eq!(default.rerank_enabled, empty.rerank_enabled);
+    assert_eq!(default.embed_budget, empty.embed_budget);
 }


### PR DESCRIPTION
## 概要

- `Yomu::with_root` 内の `env::var(YOMU_EMBED|YOMU_RERANK|YOMU_EMBED_BUDGET)` を `YomuConfig::from_env_with(impl Fn(&str) -> Option<String>)` に集約
- production caller は `YomuConfig::from_env()` 経由で `amici::cli::env_lookup()` を利用
- `with_root` signature を `(root, options, config)` の 3 引数に拡張 (workspace 内のみの破壊的変更)

Closes #150

## 動機

`Yomu::with_root` が env を直読みしていたため、production 経路 (env 反映) が unit test で踏まれず deterministic test ができなかった (RC-013)。`for_test` ヘルパは env を完全にバイパスしていた。

## 変更点

### 新規

- `YomuConfig { embed_disabled, rerank_enabled, embed_budget }`
- `YomuConfig::from_env()` (production)
- `YomuConfig::from_env_with<F>` (DI)
- `Default for YomuConfig` (手書き — derive だと `embed_budget` が `0` になり `DEFAULT_EMBED_BUDGET` と乖離)

### 削除

- `parse_embed_budget()` (env 読みラッパー)
- `embedder.rs` の `use std::env;`

### テスト

- T-CFG001..T-CFG007 (7 件) — `from_env_with` の各 env path を直接検証

## 検証

- `cargo build --workspace --all-features` clean
- `cargo nextest run --workspace` 542/542 passed
- `cargo clippy --all-targets --all-features -- -D warnings` clean

## 破壊的変更

`Yomu::with_root` の signature を `(root, options) → (root, options, config)` に拡張。pub API だが workspace 内に外部 caller 無し (grep 確認済)。