### PR TITLE
feat(yomu): degraded note に yomu model download 誘導を追加 (#172)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=2b54c72#2b54c728f745a88794a7b9084b06d4b7723158af"
+source = "git+https://github.com/thkt/amici?rev=1d16d08#1d16d08f9144b7a522fee6a155bd658ad38c8a88"
 dependencies = [
  "bytemuck",
  "rand 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/thkt/yomu"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "2b54c72" }
+amici = { git = "https://github.com/thkt/amici", rev = "1d16d08" }
 bytemuck = "1"
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -293,8 +293,8 @@ impl Yomu {
             notes.push(note);
         }
         if let Some(reason) = self.degraded_reason() {
-            if let Some(note) = degraded_reason_user_note(*reason) {
-                notes.push(note.to_owned());
+            if let Some(note) = degraded_reason_user_note(*reason, "yomu model download") {
+                notes.push(note);
             }
         } else if outcome.degraded {
             notes.push("embedding model not loaded; results from text search only".into());
@@ -555,7 +555,9 @@ impl Yomu {
                         DegradedReason::Disabled => {
                             "embedding is disabled (--no-embed or YOMU_EMBED=0)"
                         }
-                        DegradedReason::NotInstalled => "embedding model not installed",
+                        DegradedReason::NotInstalled => {
+                            "embedding model not installed; run `yomu model download` to enable semantic search"
+                        }
                         DegradedReason::BackendUnavailable | DegradedReason::ProbeFailed => {
                             "embedding model unavailable"
                         }

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -1881,8 +1881,9 @@ fn json_notes_present_when_degraded() {
         "notes should contain degradation reason: {json}"
     );
     assert_eq!(
-        notes[0], "embedding model not installed; results from text search only",
-        "note should match NotInstalled variant: {json}"
+        notes[0],
+        "embedding model not installed; run `yomu model download` to enable semantic search",
+        "note should include `yomu model download` hint: {json}"
     );
 }
 

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -1880,9 +1880,10 @@ fn json_notes_present_when_degraded() {
         !notes.is_empty(),
         "notes should contain degradation reason: {json}"
     );
-    assert_eq!(
-        notes[0],
-        "embedding model not installed; run `yomu model download` to enable semantic search",
+    assert!(
+        notes[0]
+            .as_str()
+            .is_some_and(|n| n.contains("yomu model download")),
         "note should include `yomu model download` hint: {json}"
     );
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -406,7 +406,8 @@ fn search_format_json_includes_index_and_degraded_notes() {
     );
     assert!(
         notes.iter().any(|n| n
-            == "embedding model not installed; run `yomu model download` to enable semantic search"),
+            .as_str()
+            .is_some_and(|s| s.contains("yomu model download"))),
         "should include degraded note with download hint: {stdout}"
     );
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -405,10 +405,9 @@ fn search_format_json_includes_index_and_degraded_notes() {
         "should include re-index note: {stdout}"
     );
     assert!(
-        notes
-            .iter()
-            .any(|n| n == "embedding model not installed; results from text search only"),
-        "should include degraded note: {stdout}"
+        notes.iter().any(|n| n
+            == "embedding model not installed; run `yomu model download` to enable semantic search"),
+        "should include degraded note with download hint: {stdout}"
     );
 }
 


### PR DESCRIPTION
## 概要

- amici を `2b54c72` → `1d16d08` に bump (PR thkt/amici#111 取り込み)
- `degraded_reason_user_note(reason, \"yomu model download\")` で recovery command を note に埋め込み
- `embed_with_spinners` 経路の `EmbedderUnavailable` error msg にも同じ hint を追加

Closes #172

## 動機

未 download 状態で `yomu search` を実行すると `\"embedding model not installed; results from text search only\"` の note が出ていたが、**「`yomu model download` で解決できる」誘導が無く、agent / user が次の action を推測する必要があった**。

amici 側の signature 拡張 (`Option<&'static str>` → `Option<String>` with `download_cmd: &str`) を経由して、yomu 側で具体的なコマンド文字列を埋め込めるようになった。

## 変更点

| ファイル                       | 内容                                                       |
| ------------------------------ | ---------------------------------------------------------- |
| `Cargo.toml` / `Cargo.lock`    | amici rev bump (`2b54c72` → `1d16d08`)                     |
| `src/tools.rs:296`             | search の degraded note で `\"yomu model download\"` を inject |
| `src/tools.rs:558`             | embed の eager error msg にも同じ hint を追加              |
| `src/tools/tests.rs:1885`      | hard-coded note text を新版に更新                          |
| `tests/cli_integration.rs:409` | T-506 の note assertion を新版に更新                       |

## 検証

- `cargo build --workspace --all-features` clean
- `cargo nextest run --workspace` 542/542 passed (3 skipped)
- `cargo clippy --all-targets --all-features -- -D warnings` clean

## 範囲外

- 当初 issue の eager `cached_artifacts` check は **既に lazy load 経路で実施済**だったため見送り
- amici PR #111 は破壊的変更。sae / recall 等の他 consumer は別途追従が必要