### PR TITLE
chore(ci): zizmor の code scanning アラートに対応

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: cargo
     directory: /
@@ -21,6 +23,8 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    cooldown:
+      default-days: 7
     groups:
       patch-and-minor:
         update-types:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: cargo check
 
       - name: Install nextest
-        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
         with:
           tool: cargo-nextest
 


### PR DESCRIPTION
## 概要
- `taiki-e/install-action` の pin コメントを実 SHA に合わせて `v2` → `v2.78.1` に修正し、zizmor の `ref-version-mismatch` を解消。
- Dependabot に `cooldown: default-days: 7` を `github-actions` / `cargo` 両 ecosystem へ追加し、`dependabot-cooldown` を解消。リリース直後の compromised package を取り込むリスクを 7 日間ぶん抑制する。

対象アラート (https://github.com/thkt/yomu/security/code-scanning):
- `zizmor/ref-version-mismatch` — `.github/workflows/ci.yml:38`
- `zizmor/dependabot-cooldown` — `.github/dependabot.yml:3,14`

## 動作確認
- [ ] CI (cargo check / nextest / clippy / fmt / cargo-deny / cargo-audit) が green
- [ ] マージ後、3 件の code scanning アラートが `main` で自動 close される
- [ ] 次回 Dependabot 実行時に 7 日の cooldown が効く