### PR TITLE
fix: run_index のデッドコードを削除 (issue #132)

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -6,18 +6,17 @@ use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::fs;
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::UNIX_EPOCH;
 
-use rurico::embed::{Embed, EmbedError};
+use rurico::embed::EmbedError;
 
 use crate::resolver::{Resolve, Resolver};
 use crate::rust_resolver::RustResolver;
 use crate::storage::{self, Db, RefKind, Reference, StorageError};
 use chunker::ParsedImport;
 
-use embed::embed_and_store;
 pub use embed::{EmbedResult, run_incremental_embed, run_incremental_embed_with_progress};
 #[cfg(test)]
 use embed::{MAX_CONSECUTIVE_EMBED_ERRORS, enrich_for_embedding, order_files_for_embedding};
@@ -77,7 +76,6 @@ impl PendingFile {
 }
 
 const MAX_FILE_SIZE: u64 = 1_000_000;
-const LARGE_PROJECT_THRESHOLD: usize = 5_000;
 
 enum FileAction {
     Skip,
@@ -236,58 +234,6 @@ fn process_file(
     };
     storage::replace_file_data(conn, &data, None)?;
     Ok(FileOutcome::Processed(n))
-}
-
-struct CollectResult {
-    pending: Vec<PendingFile>,
-    files_skipped: u32,
-    files_errored: u32,
-    rel_paths: HashSet<String>,
-}
-
-fn collect_pending_files(
-    conn: &Arc<Mutex<Db>>,
-    root: &Path,
-    files: &[PathBuf],
-    force: bool,
-    crate_name: Option<&str>,
-) -> Result<CollectResult, IndexError> {
-    let mut pending: Vec<PendingFile> = Vec::new();
-    let mut files_skipped = 0u32;
-    let mut files_errored = 0u32;
-    let mut rel_paths = HashSet::with_capacity(files.len());
-
-    for file_path in files {
-        let rel_path = to_rel_path(root, file_path);
-        rel_paths.insert(rel_path.clone());
-        let checked = {
-            let conn_guard = conn.lock().unwrap();
-            match check_file(&conn_guard, rel_path, file_path, force)? {
-                CheckResult::Changed(c) => c,
-                CheckResult::Skip => {
-                    files_skipped += 1;
-                    continue;
-                }
-                CheckResult::Error => {
-                    files_errored += 1;
-                    continue;
-                }
-            }
-        };
-        match prepare_chunks(checked, file_path, crate_name) {
-            Some(pf) => pending.push(pf),
-            None => {
-                files_skipped += 1;
-            }
-        }
-    }
-
-    Ok(CollectResult {
-        pending,
-        files_skipped,
-        files_errored,
-        rel_paths,
-    })
 }
 
 fn remove_orphans(
@@ -505,52 +451,6 @@ pub fn run_chunk_only_index_force(
     root: &Path,
 ) -> Result<IndexResult, IndexError> {
     run_chunk_only_index_inner(conn, root, true)
-}
-
-/// Per-file embed+store ensures partial progress survives embedding failures.
-pub fn run_index(
-    conn: &Arc<Mutex<Db>>,
-    root: &Path,
-    embedder: &(impl Embed + ?Sized),
-    force: bool,
-) -> Result<IndexResult, IndexError> {
-    let files = walker::walk_source_files(root);
-    if files.len() > LARGE_PROJECT_THRESHOLD {
-        tracing::warn!(
-            count = files.len(),
-            "Large number of files detected — indexing may be slow"
-        );
-    }
-    tracing::info!(file_count = files.len(), force, "Starting indexing");
-
-    let resolver = Resolver::new(root);
-    let rust_resolver = RustResolver::new(root);
-
-    let collected = collect_pending_files(conn, root, &files, force, rust_resolver.crate_name())?;
-    let files_skipped = collected.files_skipped;
-    let mut files_errored = collected.files_errored;
-
-    remove_orphans(conn, &collected.rel_paths)?;
-    let embed_result =
-        embed_and_store(conn, embedder, collected.pending, &resolver, &rust_resolver)?;
-    let files_processed = embed_result.files_processed;
-    let chunks_created = embed_result.chunks_created;
-    files_errored += embed_result.files_errored;
-
-    tracing::info!(
-        files_processed,
-        chunks_created,
-        files_skipped,
-        files_errored,
-        "Indexing complete"
-    );
-
-    Ok(IndexResult {
-        files_processed,
-        chunks_created,
-        files_skipped,
-        files_errored,
-    })
 }
 
 #[cfg(test)]

--- a/src/indexer/embed.rs
+++ b/src/indexer/embed.rs
@@ -2,11 +2,9 @@ use std::sync::{Arc, Mutex};
 
 use rurico::embed::{ChunkedEmbedding, Embed, EmbedError};
 
-use crate::resolver::Resolver;
-use crate::rust_resolver::RustResolver;
-use crate::storage::{self, Db, Reference, StorageError};
+use crate::storage::{self, Db, StorageError};
 
-use super::{IndexError, PendingFile, build_references};
+use super::IndexError;
 
 pub(super) const MAX_CONSECUTIVE_EMBED_ERRORS: u32 = 5;
 
@@ -14,12 +12,6 @@ pub(super) const MAX_CONSECUTIVE_EMBED_ERRORS: u32 = 5;
 pub struct EmbedResult {
     pub chunks_embedded: u32,
     pub files_completed: u32,
-}
-
-pub(super) struct EmbedStoreResult {
-    pub files_processed: u32,
-    pub chunks_created: u32,
-    pub files_errored: u32,
 }
 
 enum EmbedFailure {
@@ -101,100 +93,6 @@ fn run_embed_batch(
         }
         Err(e) => Err(classify_embed_error(e, consecutive_errors, file_path)),
     }
-}
-
-fn store_file_data(
-    conn: &Db,
-    pf: &PendingFile,
-    embeddings: &[ChunkedEmbedding],
-    refs: &[Reference],
-) -> Result<(), StorageError> {
-    let new_chunks = pf.to_new_chunks();
-    let data = storage::FileData {
-        file_path: &pf.rel_path,
-        chunks: &new_chunks,
-        file_hash: &pf.hash,
-        imports_text: &pf.imports_text,
-        refs,
-        mtime_epoch: pf.mtime_epoch,
-    };
-    storage::replace_file_chunks_with(conn, &data, embeddings)
-}
-
-#[allow(clippy::cast_possible_truncation)]
-pub(super) fn embed_and_store(
-    conn: &Arc<Mutex<Db>>,
-    embedder: &(impl Embed + ?Sized),
-    pending: Vec<PendingFile>,
-    resolver: &Resolver,
-    rust_resolver: &RustResolver,
-) -> Result<EmbedStoreResult, IndexError> {
-    let pending_total = pending.len();
-    let mut files_processed = 0u32;
-    let mut chunks_created = 0u32;
-    let mut files_errored = 0u32;
-    let mut consecutive_errors = 0u32;
-
-    for pf in pending {
-        let texts: Vec<String> = pf
-            .raw_chunks
-            .iter()
-            .filter(|c| c.chunk_type != storage::ChunkType::InnerFn)
-            .map(|c| {
-                let parent_name = c
-                    .parent_index
-                    .and_then(|i| pf.raw_chunks[i].name.as_deref());
-                enrich_for_embedding(
-                    &pf.rel_path,
-                    c.chunk_type.as_str(),
-                    c.name.as_deref(),
-                    parent_name,
-                    &pf.imports_text,
-                    &c.content,
-                )
-            })
-            .collect();
-
-        let embeddings =
-            match run_embed_batch(embedder, &texts, &mut consecutive_errors, &pf.rel_path) {
-                Ok(embs) => embs,
-                Err(EmbedFailure::Abort(e)) => return Err(IndexError::Embed(e)),
-                Err(EmbedFailure::Contract) => {
-                    return Err(IndexError::Internal(
-                        "rurico returned empty ChunkedEmbedding.chunks (contract violation)".into(),
-                    ));
-                }
-                Err(EmbedFailure::Skip) => {
-                    files_errored += 1;
-                    continue;
-                }
-            };
-
-        let n = embeddings.len() as u32;
-        let refs = if pf.rel_path.ends_with(".rs") {
-            build_references(&pf.parsed_imports, &pf.rel_path, rust_resolver)
-        } else {
-            build_references(&pf.parsed_imports, &pf.rel_path, resolver)
-        };
-        tracing::debug!(file = %pf.rel_path, chunks = n, "Indexing file");
-
-        {
-            let conn = conn.lock().unwrap();
-            store_file_data(&conn, &pf, &embeddings, &refs)?;
-        }
-
-        chunks_created += n;
-        files_processed += 1;
-        if files_processed.is_multiple_of(10) {
-            tracing::info!(files_processed, total = pending_total, "Indexing progress");
-        }
-    }
-
-    Ok(EmbedStoreResult {
-        files_processed,
-        chunks_created,
-        files_errored,
-    })
 }
 
 pub(super) fn order_files_for_embedding(

--- a/src/indexer/tests.rs
+++ b/src/indexer/tests.rs
@@ -136,140 +136,6 @@ fn test_db() -> (storage::Db, TempDir) {
     (conn, dir)
 }
 
-// T-372: run_index_with_mock_embedder
-#[test]
-fn run_index_with_mock_embedder() {
-    let dir = tempdir().unwrap();
-
-    let src_dir = dir.path().join("src");
-    fs::create_dir_all(&src_dir).unwrap();
-    fs::write(
-        src_dir.join("Button.tsx"),
-        "function Button() { return <div/>; }",
-    )
-    .unwrap();
-    fs::write(
-        src_dir.join("App.tsx"),
-        "function App() { return <main/>; }",
-    )
-    .unwrap();
-
-    let db_path = dir.path().join(".yomu").join("index.db");
-    let conn = storage::open_db(&db_path).unwrap();
-    let conn = Arc::new(Mutex::new(conn));
-
-    let result = run_index(&conn, dir.path(), &MockEmbedder::default(), false).unwrap();
-
-    assert_eq!(result.files_processed, 2);
-    assert!(result.chunks_created >= 2);
-    assert_eq!(result.files_errored, 0);
-
-    let stats = storage::get_stats(&conn.lock().unwrap()).unwrap();
-    assert_eq!(stats.total_files, 2);
-    assert!(stats.total_chunks >= 2);
-}
-
-// T-373: run_index_with_multi_chunk_embedder_keeps_first_only
-#[test]
-fn run_index_with_multi_chunk_embedder_keeps_first_only() {
-    let dir = tempdir().unwrap();
-
-    let src_dir = dir.path().join("src");
-    fs::create_dir_all(&src_dir).unwrap();
-    fs::write(
-        src_dir.join("App.tsx"),
-        "function App() { return <main/>; }",
-    )
-    .unwrap();
-
-    let db_path = dir.path().join(".yomu").join("index.db");
-    let conn = storage::open_db(&db_path).unwrap();
-    let conn = Arc::new(Mutex::new(conn));
-
-    // MockChunkedEmbedder returns 3 chunks per document; first_chunk keeps only the first.
-    let result = run_index(&conn, dir.path(), &MockChunkedEmbedder::new(3), false).unwrap();
-
-    assert_eq!(result.files_processed, 1);
-    assert_eq!(result.files_errored, 0);
-
-    let stats = storage::get_stats(&conn.lock().unwrap()).unwrap();
-    // Embedding count must equal embeddable chunk count (1:1), NOT chunk_count * 3.
-    assert_eq!(stats.embedded_chunks, stats.embeddable_chunks);
-}
-
-// T-374: run_index_skips_unchanged_files
-#[test]
-fn run_index_skips_unchanged_files() {
-    let dir = tempdir().unwrap();
-    let src_dir = dir.path().join("src");
-    fs::create_dir_all(&src_dir).unwrap();
-    fs::write(src_dir.join("A.tsx"), "function A() { return 1; }").unwrap();
-
-    let db_path = dir.path().join(".yomu").join("index.db");
-    let conn = storage::open_db(&db_path).unwrap();
-    let conn = Arc::new(Mutex::new(conn));
-
-    // First run: processes file
-    let r1 = run_index(&conn, dir.path(), &MockEmbedder::default(), false).unwrap();
-    assert_eq!(r1.files_processed, 1);
-
-    // Second run: skips unchanged file
-    let r2 = run_index(&conn, dir.path(), &MockEmbedder::default(), false).unwrap();
-    assert_eq!(r2.files_processed, 0);
-    assert_eq!(r2.files_skipped, 1);
-}
-
-// T-375: run_index_force_reindexes
-#[test]
-fn run_index_force_reindexes() {
-    let dir = tempdir().unwrap();
-    let src_dir = dir.path().join("src");
-    fs::create_dir_all(&src_dir).unwrap();
-    fs::write(src_dir.join("A.tsx"), "function A() { return 1; }").unwrap();
-
-    let db_path = dir.path().join(".yomu").join("index.db");
-    let conn = storage::open_db(&db_path).unwrap();
-    let conn = Arc::new(Mutex::new(conn));
-
-    run_index(&conn, dir.path(), &MockEmbedder::default(), false).unwrap();
-
-    let r2 = run_index(&conn, dir.path(), &MockEmbedder::default(), true).unwrap();
-    assert_eq!(r2.files_processed, 1);
-    assert_eq!(r2.files_skipped, 0);
-}
-
-// T-376: run_index_removes_deleted_file_chunks
-#[test]
-fn run_index_removes_deleted_file_chunks() {
-    let dir = tempdir().unwrap();
-    let src_dir = dir.path().join("src");
-    fs::create_dir_all(&src_dir).unwrap();
-    fs::write(src_dir.join("A.tsx"), "function A() { return 1; }").unwrap();
-    fs::write(src_dir.join("B.tsx"), "function B() { return 2; }").unwrap();
-
-    let db_path = dir.path().join(".yomu").join("index.db");
-    let conn = storage::open_db(&db_path).unwrap();
-    let conn = Arc::new(Mutex::new(conn));
-
-    // Index both files
-    let r1 = run_index(&conn, dir.path(), &MockEmbedder::default(), false).unwrap();
-    assert_eq!(r1.files_processed, 2);
-    assert_eq!(
-        storage::get_stats(&conn.lock().unwrap())
-            .unwrap()
-            .total_files,
-        2
-    );
-
-    // Delete B.tsx from disk
-    fs::remove_file(src_dir.join("B.tsx")).unwrap();
-
-    // Re-index: should remove orphaned B.tsx chunks
-    run_index(&conn, dir.path(), &MockEmbedder::default(), false).unwrap();
-    let stats = storage::get_stats(&conn.lock().unwrap()).unwrap();
-    assert_eq!(stats.total_files, 1, "orphaned file should be removed");
-}
-
 // T-377: build_references_named_import
 #[test]
 fn build_references_named_import() {
@@ -357,36 +223,6 @@ fn build_references_rust_crate_import() {
     assert_eq!(refs[0].target_file, "src/foo/bar.rs");
     assert_eq!(refs[0].symbol_name, Some("Bar".to_owned()));
     assert_eq!(refs[0].ref_kind, RefKind::Named);
-}
-
-// T-381: run_index_stores_imports_in_file_context
-#[test]
-fn run_index_stores_imports_in_file_context() {
-    let dir = tempdir().unwrap();
-    let src_dir = dir.path().join("src");
-    fs::create_dir_all(&src_dir).unwrap();
-    fs::write(
-        src_dir.join("App.tsx"),
-        "import { useState } from 'react';\nimport { useAuth } from './useAuth';\nfunction App() { return <div/>; }",
-    ).unwrap();
-
-    let db_path = dir.path().join(".yomu").join("index.db");
-    let conn = storage::open_db(&db_path).unwrap();
-    let conn = Arc::new(Mutex::new(conn));
-
-    run_index(&conn, dir.path(), &MockEmbedder::default(), false).unwrap();
-
-    let contexts = storage::get_file_contexts(&conn.lock().unwrap(), &["src/App.tsx"]).unwrap();
-    assert_eq!(contexts.len(), 1);
-    let imports = &contexts["src/App.tsx"];
-    assert!(
-        imports.contains("import { useState } from 'react'"),
-        "expected useState import, got: {imports}"
-    );
-    assert!(
-        imports.contains("import { useAuth } from './useAuth'"),
-        "expected useAuth import, got: {imports}"
-    );
 }
 
 // T-382: run_chunk_only_index_stores_chunks_without_embeddings
@@ -710,38 +546,6 @@ fn run_incremental_embed_aborts_after_consecutive_failures() {
     assert!(err_msg.contains("mock failure"), "got: {err_msg}");
 }
 
-// T-390: embed_and_store_aborts_after_consecutive_failures
-#[test]
-fn embed_and_store_aborts_after_consecutive_failures() {
-    let dir = tempdir().unwrap();
-    let src_dir = dir.path().join("src");
-    fs::create_dir_all(&src_dir).unwrap();
-
-    for i in 0..6 {
-        fs::write(
-            src_dir.join(format!("F{i}.tsx")),
-            format!("function F{i}() {{ return {i}; }}"),
-        )
-        .unwrap();
-    }
-
-    let db_path = dir.path().join(".yomu").join("index.db");
-    let conn = storage::open_db(&db_path).unwrap();
-    let conn = Arc::new(Mutex::new(conn));
-
-    let result = run_index(
-        &conn,
-        dir.path(),
-        &FailingEmbedder::all_fail("mock failure"),
-        false,
-    );
-
-    assert!(
-        result.is_err(),
-        "should abort after {MAX_CONSECUTIVE_EMBED_ERRORS} consecutive failures"
-    );
-}
-
 // T-391: order_files_for_embedding_most_imported_first
 #[test]
 fn order_files_for_embedding_most_imported_first() {
@@ -908,44 +712,6 @@ fn order_files_for_embedding_empty_hints_no_reorder() {
     assert_eq!(ordered[0], "src/A.tsx");
 }
 
-// T-395: embed_and_store_catches_count_mismatch_via_storage
-#[test]
-fn embed_and_store_catches_count_mismatch_via_storage() {
-    let dir = tempdir().unwrap();
-    let src_dir = dir.path().join("src");
-    fs::create_dir_all(&src_dir).unwrap();
-
-    // File with multiple top-level functions → multiple chunks
-    fs::write(
-        src_dir.join("Multi.tsx"),
-        "function A() { return 1; }\nfunction B() { return 2; }\nfunction C() { return 3; }",
-    )
-    .unwrap();
-
-    let db_path = dir.path().join(".yomu").join("index.db");
-    let conn = storage::open_db(&db_path).unwrap();
-    let conn = Arc::new(Mutex::new(conn));
-
-    // MismatchEmbedder returns 1 vector regardless of input count.
-    // Storage layer catches embeddings.len() != chunks.len() via LengthMismatch.
-    let result = run_index(&conn, dir.path(), &MismatchEmbedder, false);
-
-    if let Ok(outcome) = &result {
-        let stats = storage::get_stats(&conn.lock().unwrap()).unwrap();
-        assert_eq!(
-            stats.embedded_chunks, 0,
-            "mismatched embeddings should not be stored"
-        );
-        assert!(
-            outcome.files_errored > 0 || outcome.chunks_created == 0,
-            "mismatch should be detected: errored={}, embedded={}",
-            outcome.files_errored,
-            outcome.chunks_created
-        );
-    }
-    // If Err, the mismatch was caught — also acceptable
-}
-
 // T-396: run_incremental_embed_skips_count_mismatch
 #[test]
 fn run_incremental_embed_skips_count_mismatch() {
@@ -1055,20 +821,116 @@ fn run_chunk_only_index_handles_rust_files() {
     assert_eq!(ref_count, 0, "Rust files should have no import references");
 }
 
-#[cfg(unix)]
-// T-398: run_index_counts_unreadable_files_as_errors
+// T-374: run_chunk_only_index_skips_unchanged_files
 #[test]
-fn run_index_counts_unreadable_files_as_errors() {
+fn run_chunk_only_index_skips_unchanged_files() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::write(src_dir.join("A.tsx"), "function A() { return 1; }").unwrap();
+
+    let db_path = dir.path().join(".yomu").join("index.db");
+    let conn = storage::open_db(&db_path).unwrap();
+    let conn = Arc::new(Mutex::new(conn));
+
+    let r1 = run_chunk_only_index(&conn, dir.path()).unwrap();
+    assert_eq!(r1.files_processed, 1);
+
+    let r2 = run_chunk_only_index(&conn, dir.path()).unwrap();
+    assert_eq!(r2.files_processed, 0);
+    assert_eq!(r2.files_skipped, 1);
+}
+
+// T-375: run_chunk_only_index_force_reindexes
+#[test]
+fn run_chunk_only_index_force_reindexes() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::write(src_dir.join("A.tsx"), "function A() { return 1; }").unwrap();
+
+    let db_path = dir.path().join(".yomu").join("index.db");
+    let conn = storage::open_db(&db_path).unwrap();
+    let conn = Arc::new(Mutex::new(conn));
+
+    run_chunk_only_index(&conn, dir.path()).unwrap();
+
+    let r2 = run_chunk_only_index_force(&conn, dir.path()).unwrap();
+    assert_eq!(r2.files_processed, 1);
+    assert_eq!(r2.files_skipped, 0);
+}
+
+// T-376: run_chunk_only_index_removes_deleted_file_chunks
+#[test]
+fn run_chunk_only_index_removes_deleted_file_chunks() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::write(src_dir.join("A.tsx"), "function A() { return 1; }").unwrap();
+    fs::write(src_dir.join("B.tsx"), "function B() { return 2; }").unwrap();
+
+    let db_path = dir.path().join(".yomu").join("index.db");
+    let conn = storage::open_db(&db_path).unwrap();
+    let conn = Arc::new(Mutex::new(conn));
+
+    let r1 = run_chunk_only_index(&conn, dir.path()).unwrap();
+    assert_eq!(r1.files_processed, 2);
+    assert_eq!(
+        storage::get_stats(&conn.lock().unwrap())
+            .unwrap()
+            .total_files,
+        2
+    );
+
+    fs::remove_file(src_dir.join("B.tsx")).unwrap();
+
+    run_chunk_only_index(&conn, dir.path()).unwrap();
+    let stats = storage::get_stats(&conn.lock().unwrap()).unwrap();
+    assert_eq!(stats.total_files, 1, "orphaned file should be removed");
+}
+
+// T-381: run_chunk_only_index_stores_imports_in_file_context
+#[test]
+fn run_chunk_only_index_stores_imports_in_file_context() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::write(
+        src_dir.join("App.tsx"),
+        "import { useState } from 'react';\nimport { useAuth } from './useAuth';\nfunction App() { return <div/>; }",
+    ).unwrap();
+
+    let db_path = dir.path().join(".yomu").join("index.db");
+    let conn = storage::open_db(&db_path).unwrap();
+    let conn = Arc::new(Mutex::new(conn));
+
+    run_chunk_only_index(&conn, dir.path()).unwrap();
+
+    let contexts = storage::get_file_contexts(&conn.lock().unwrap(), &["src/App.tsx"]).unwrap();
+    assert_eq!(contexts.len(), 1);
+    let imports = &contexts["src/App.tsx"];
+    assert!(
+        imports.contains("import { useState } from 'react'"),
+        "expected useState import, got: {imports}"
+    );
+    assert!(
+        imports.contains("import { useAuth } from './useAuth'"),
+        "expected useAuth import, got: {imports}"
+    );
+}
+
+#[cfg(unix)]
+// T-398: run_chunk_only_index_counts_unreadable_files_as_errors
+#[test]
+fn run_chunk_only_index_counts_unreadable_files_as_errors() {
     use std::os::unix::fs::PermissionsExt;
 
     let dir = tempdir().unwrap();
     let src_dir = dir.path().join("src");
     fs::create_dir_all(&src_dir).unwrap();
 
-    // Normal file
     fs::write(src_dir.join("Good.tsx"), "function Good() { return 1; }").unwrap();
 
-    // Unreadable file (permission 000)
     let bad_path = src_dir.join("Bad.tsx");
     fs::write(&bad_path, "function Bad() { return 2; }").unwrap();
     fs::set_permissions(&bad_path, fs::Permissions::from_mode(0o000)).unwrap();
@@ -1077,9 +939,8 @@ fn run_index_counts_unreadable_files_as_errors() {
     let conn = storage::open_db(&db_path).unwrap();
     let conn = Arc::new(Mutex::new(conn));
 
-    let result = run_index(&conn, dir.path(), &MockEmbedder::default(), false).unwrap();
+    let result = run_chunk_only_index(&conn, dir.path()).unwrap();
 
-    // Restore permissions for cleanup
     fs::set_permissions(&bad_path, fs::Permissions::from_mode(0o644)).unwrap();
 
     assert!(

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -331,7 +331,8 @@ fn search_degraded_with_results_shows_note() {
         Arc::new(MockEmbedder::default()),
     );
 
-    indexer::run_index(&y.conn, y.root.as_path(), &MockEmbedder::default(), false).unwrap();
+    indexer::run_chunk_only_index(&y.conn, y.root.as_path()).unwrap();
+    indexer::run_incremental_embed(&y.conn, &MockEmbedder::default(), 3, None).unwrap();
 
     let db_path = dir.path().join(".yomu").join("index.db");
     let conn2 = storage::open_db(&db_path).unwrap();
@@ -1025,7 +1026,8 @@ fn integration_index_then_impact() {
         ("src/C.tsx", "export function C() { return <div/>; }"),
     ]);
 
-    indexer::run_index(&y.conn, y.root.as_path(), &MockEmbedder::default(), false).unwrap();
+    indexer::run_chunk_only_index(&y.conn, y.root.as_path()).unwrap();
+    indexer::run_incremental_embed(&y.conn, &MockEmbedder::default(), 6, None).unwrap();
 
     let text = y.impact("src/C.tsx", None, 3, false, false).unwrap();
     assert!(
@@ -1198,59 +1200,6 @@ fn ensure_indexed_partially_embedded_triggers_embed() {
     assert!(
         stats_after.embedded_chunks > 0,
         "should have embeddings after search"
-    );
-}
-
-// T-220: ensure_indexed_fully_embedded_skips_embed
-#[test]
-fn ensure_indexed_fully_embedded_skips_embed() {
-    let (y, _dir) = test_yomu_with_files_and_embedder(
-        &[(
-            "src/Button.tsx",
-            "export function Button() { return <button/>; }",
-        )],
-        Arc::new(MockEmbedder::default()),
-    );
-
-    indexer::run_index(&y.conn, y.root.as_path(), &MockEmbedder::default(), false).unwrap();
-
-    let stats = {
-        let c = y.conn.lock().unwrap();
-        storage::get_stats(&c).unwrap()
-    };
-    assert_eq!(
-        stats.embedded_chunks, stats.total_chunks,
-        "should be fully embedded"
-    );
-
-    let result = y.search(Some("Button"), 10, 0, &[], false, None).unwrap();
-    assert!(result.contains("Button"), "should find Button: {result}");
-}
-
-// T-221: ensure_indexed_fully_embedded_with_failing_embedder
-#[test]
-fn ensure_indexed_fully_embedded_with_failing_embedder() {
-    let (y, dir) = test_yomu_with_files_and_embedder(
-        &[("src/Card.tsx", "export function Card() { return <div/>; }")],
-        Arc::new(MockEmbedder::default()),
-    );
-
-    indexer::run_index(&y.conn, y.root.as_path(), &MockEmbedder::default(), false).unwrap();
-
-    let db_path = dir.path().join(".yomu").join("index.db");
-    let conn2 = storage::open_db(&db_path).unwrap();
-    let y_failing = Yomu::for_test(
-        conn2,
-        dir.path().to_path_buf(),
-        Some(Arc::new(FailingEmbedder::all_fail("service unavailable")) as Arc<dyn Embed>),
-    );
-
-    let result = y_failing
-        .search(Some("Card"), 10, 0, &[], false, None)
-        .unwrap();
-    assert!(
-        result.contains("Card"),
-        "should find Card with existing embeddings: {result}"
     );
 }
 


### PR DESCRIPTION
## 概要

- `pub fn run_index` および関連コード (`collect_pending_files`, `embed_and_store` パイプライン) を削除
- RC-008 の atomicity 問題 (embedding 失敗時に orphan 削除がロールバックされない) は、当該経路が production CLI から呼ばれないデッドコードだったため削除で解決
- 削除対象に依存していたテスト 11 件を削除し、本来の挙動を検証する 5 件は `run_chunk_only_index` (本番経路) 利用に書き換えて保持

## 動作確認

- [x] `cargo test --lib` で全テスト pass (471 lib tests)
- [x] `cargo test --doc` で全 doctest pass (21 doc tests)
- [x] `cargo test --test cli_integration` で integration test pass (44 tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `/polish` による code review 完了 (test naming convention 修正、embedding budget 最適化)

Fixes #132