### PR TITLE
fix: 再帰CTEのvisited文字列をUNION重複排除に置き換え (#142)

### DIFF
--- a/src/storage/graph.rs
+++ b/src/storage/graph.rs
@@ -54,19 +54,20 @@ pub fn get_transitive_dependents(
     max_depth: u32,
 ) -> Result<Vec<Dependent>, StorageError> {
     let max_depth = max_depth.min(10);
+    // Cycle handling: `UNION` (vs `UNION ALL`) lets SQLite deduplicate the
+    // `(file_path, depth)` tuple, so a node only re-expands while its depth
+    // grows. `d.depth < ?2` then bounds total work. Excluding the seed
+    // (`source_file != ?1`) keeps target_file itself out of the result.
     let mut stmt = conn.prepare_cached(
-        "WITH RECURSIVE deps(file_path, depth, visited) AS (
-            SELECT DISTINCT source_file, 1,
-                   ',' || ?1 || ',' || source_file || ','
+        "WITH RECURSIVE deps(file_path, depth) AS (
+            SELECT source_file, 1
             FROM file_references
-            WHERE target_file = ?1
+            WHERE target_file = ?1 AND source_file != ?1
           UNION
-            SELECT r.source_file, d.depth + 1,
-                   d.visited || r.source_file || ','
+            SELECT r.source_file, d.depth + 1
             FROM file_references r
             INNER JOIN deps d ON r.target_file = d.file_path
-            WHERE d.depth < ?2
-              AND INSTR(d.visited, ',' || r.source_file || ',') = 0
+            WHERE d.depth < ?2 AND r.source_file != ?1
         )
         SELECT file_path, MIN(depth) as depth
         FROM deps GROUP BY file_path ORDER BY depth, file_path",
@@ -114,16 +115,18 @@ pub fn get_transitive_dependencies(
     max_depth: u32,
 ) -> Result<Vec<Dependent>, StorageError> {
     let max_depth = max_depth.min(10);
+    // See `get_transitive_dependents` for the cycle-handling rationale.
+    // `r.target_file != ?1` blocks back-edges to the seed; the seed is
+    // injected once at depth=0 in the anchor, so this only suppresses
+    // wasteful re-visits inside the recursion.
     let mut stmt = conn.prepare_cached(
-        "WITH RECURSIVE deps(file_path, depth, visited) AS (
-            SELECT ?1, 0, ',' || ?1 || ','
+        "WITH RECURSIVE deps(file_path, depth) AS (
+            SELECT ?1, 0
           UNION
-            SELECT r.target_file, d.depth + 1,
-                   d.visited || r.target_file || ','
+            SELECT r.target_file, d.depth + 1
             FROM file_references r
             INNER JOIN deps d ON r.source_file = d.file_path
-            WHERE d.depth < ?2
-              AND INSTR(d.visited, ',' || r.target_file || ',') = 0
+            WHERE d.depth < ?2 AND r.target_file != ?1
         )
         SELECT file_path, MIN(depth) as depth
         FROM deps GROUP BY file_path ORDER BY depth, file_path",

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -965,6 +965,200 @@ fn get_transitive_dependencies_circular() {
     );
 }
 
+// T-581: get_transitive_dependents_path_with_comma_delimiter
+//
+// Invariant: a path containing ',' inside the closure must not mask a
+// separately-named file whose path appears as a comma-bounded fragment
+// of it. Graph: src/a -> src/a,b.rs -> src/target.rs. Walking back from
+// target must reach both src/a,b.rs (depth 1) and src/a (depth 2).
+#[test]
+fn get_transitive_dependents_path_with_comma_delimiter() {
+    let (conn, _dir) = test_db();
+    replace_file_references(
+        &conn,
+        "src/a,b.rs",
+        &[Reference {
+            source_file: "src/a,b.rs".into(),
+            target_file: "src/target.rs".into(),
+            symbol_name: None,
+            ref_kind: RefKind::Named,
+        }],
+    )
+    .unwrap();
+    replace_file_references(
+        &conn,
+        "src/a",
+        &[Reference {
+            source_file: "src/a".into(),
+            target_file: "src/a,b.rs".into(),
+            symbol_name: None,
+            ref_kind: RefKind::Named,
+        }],
+    )
+    .unwrap();
+
+    let deps = get_transitive_dependents(&conn, "src/target.rs", 5).unwrap();
+    assert_eq!(
+        deps,
+        vec![
+            Dependent {
+                file_path: "src/a,b.rs".into(),
+                depth: 1
+            },
+            Dependent {
+                file_path: "src/a".into(),
+                depth: 2
+            },
+        ],
+        "src/a must reach the closure even though src/a,b.rs contains a comma",
+    );
+}
+
+// T-582: get_transitive_dependencies_path_with_comma_delimiter
+//
+// Forward direction of T-581.
+// Graph: src/seed.rs -> src/a,b.rs -> src/a
+#[test]
+fn get_transitive_dependencies_path_with_comma_delimiter() {
+    let (conn, _dir) = test_db();
+    replace_file_references(
+        &conn,
+        "src/seed.rs",
+        &[Reference {
+            source_file: "src/seed.rs".into(),
+            target_file: "src/a,b.rs".into(),
+            symbol_name: None,
+            ref_kind: RefKind::Named,
+        }],
+    )
+    .unwrap();
+    replace_file_references(
+        &conn,
+        "src/a,b.rs",
+        &[Reference {
+            source_file: "src/a,b.rs".into(),
+            target_file: "src/a".into(),
+            symbol_name: None,
+            ref_kind: RefKind::Named,
+        }],
+    )
+    .unwrap();
+
+    let deps = get_transitive_dependencies(&conn, "src/seed.rs", 5).unwrap();
+    assert_eq!(
+        deps,
+        vec![
+            Dependent {
+                file_path: "src/seed.rs".into(),
+                depth: 0
+            },
+            Dependent {
+                file_path: "src/a,b.rs".into(),
+                depth: 1
+            },
+            Dependent {
+                file_path: "src/a".into(),
+                depth: 2
+            },
+        ],
+        "src/a must reach the closure even though src/a,b.rs contains a comma",
+    );
+}
+
+// T-583: get_transitive_dependents_similar_paths_no_collision
+//
+// Substring-similar paths (`a.rs`, `ab.rs`, `a.rs/inner.rs`) must each
+// reach the closure independently. Guard against future cycle-detection
+// schemes that might confuse them.
+#[test]
+fn get_transitive_dependents_similar_paths_no_collision() {
+    let (conn, _dir) = test_db();
+    for src in ["src/a.rs", "src/ab.rs", "src/a.rs/inner.rs"] {
+        replace_file_references(
+            &conn,
+            src,
+            &[Reference {
+                source_file: src.into(),
+                target_file: "src/target.rs".into(),
+                symbol_name: None,
+                ref_kind: RefKind::Named,
+            }],
+        )
+        .unwrap();
+    }
+
+    let mut deps = get_transitive_dependents(&conn, "src/target.rs", 5).unwrap();
+    deps.sort_by(|a, b| a.file_path.cmp(&b.file_path));
+    assert_eq!(
+        deps,
+        vec![
+            Dependent {
+                file_path: "src/a.rs".into(),
+                depth: 1,
+            },
+            Dependent {
+                file_path: "src/a.rs/inner.rs".into(),
+                depth: 1,
+            },
+            Dependent {
+                file_path: "src/ab.rs".into(),
+                depth: 1,
+            },
+        ],
+    );
+}
+
+// T-584: get_transitive_dependencies_similar_paths_no_collision
+//
+// Forward-direction twin of T-583. Walking a chain across substring-similar
+// paths must still resolve every hop without false-positive cycle drops.
+// Graph: src/seed.rs -> src/a.rs -> src/ab.rs -> src/a.rs/inner.rs
+#[test]
+fn get_transitive_dependencies_similar_paths_no_collision() {
+    let (conn, _dir) = test_db();
+    let chain = [
+        ("src/seed.rs", "src/a.rs"),
+        ("src/a.rs", "src/ab.rs"),
+        ("src/ab.rs", "src/a.rs/inner.rs"),
+    ];
+    for (src, tgt) in chain {
+        replace_file_references(
+            &conn,
+            src,
+            &[Reference {
+                source_file: src.into(),
+                target_file: tgt.into(),
+                symbol_name: None,
+                ref_kind: RefKind::Named,
+            }],
+        )
+        .unwrap();
+    }
+
+    let deps = get_transitive_dependencies(&conn, "src/seed.rs", 5).unwrap();
+    assert_eq!(
+        deps,
+        vec![
+            Dependent {
+                file_path: "src/seed.rs".into(),
+                depth: 0,
+            },
+            Dependent {
+                file_path: "src/a.rs".into(),
+                depth: 1,
+            },
+            Dependent {
+                file_path: "src/ab.rs".into(),
+                depth: 2,
+            },
+            Dependent {
+                file_path: "src/a.rs/inner.rs".into(),
+                depth: 3,
+            },
+        ],
+    );
+}
+
 fn get_chunk_ids(conn: &Connection, file_path: &str) -> Vec<i64> {
     let mut stmt = conn
         .prepare("SELECT id FROM chunks WHERE file_path = ?1 ORDER BY id")


### PR DESCRIPTION
## 概要

- `get_transitive_dependents` / `get_transitive_dependencies` の recursive CTE で `INSTR(visited, ',X,')` による cycle 検出を廃止し、SQLite の `UNION` による `(file_path, depth)` tuple 重複排除に置き換え。
- 副次効果: visited 文字列 (chain 長 N に対して O(N²) メモリ) も解消。

## 背景

path にコンマを含むファイル (`src/a,b.rs` 等) が visited 列に入ると、別の独立ファイル `src/a` が `,src/a,` で substring match して **false-positive cycle** 判定され、本来辿るべき依存を silently 捨てていました。

`,src/a,b.rs,` ⊃ `,src/a,` (collision)

## 実装方針

```sql
WITH RECURSIVE deps(file_path, depth) AS (
    SELECT source_file, 1 FROM file_references
    WHERE target_file = ?1 AND source_file != ?1   -- seed exclusion
  UNION
    SELECT r.source_file, d.depth + 1
    FROM file_references r INNER JOIN deps d ON r.target_file = d.file_path
    WHERE d.depth < ?2 AND r.source_file != ?1
)
SELECT file_path, MIN(depth) FROM deps GROUP BY file_path ORDER BY depth, file_path
```

- `UNION` (vs `UNION ALL`) が `(file_path, depth)` の重複を SQLite 側で排除
- `d.depth < ?2` で総走査量を bound
- Seed 除外 (`source_file/target_file != ?1`) を visited initializer 経由ではなく WHERE で明示

## 受け入れ基準

Issue 本文の AC 例 path (`src/a.rs`, `src/ab.rs`, `src/a.rs/inner.rs`) は**現状コードでも substring collision を triggerしません** (`,` で両端囲み)。詳細は [#142 のコメント](https://github.com/thkt/yomu/issues/142#issuecomment-4484485867) で議論済。修正後の AC:

- [x] path 内 delimiter (`,`) collision テスト (T-581 reverse / T-582 forward)
- [x] substring-similar path baseline (T-583 reverse / T-584 forward) — regression baseline として保持
- [x] 既存テスト全 pass (T-142/T-143/T-572/T-573 を含む 475 lib + 42 integration)

## テスト計画

- [x] `cargo test` (475 lib + 42 integration + 2 schema = 全 pass)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Red→Green: T-581/T-582 が修正前 fail、修正後 pass を確認

Closes #142