### PR TITLE
embedder 不在時の FTS フォールバックで seed 選択を補完

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -585,46 +585,46 @@ impl Yomu {
     }
 
     fn infer_seed_paths(&self, task: &str, max_seeds: u32) -> (Vec<String>, bool) {
-        if let Some(paths) = self.embedder_seed_paths(task, max_seeds) {
-            return (paths, false);
+        match self.embedder_seed_paths(task, max_seeds) {
+            Ok(paths) => (paths, false),
+            Err(reason) => {
+                record_degraded(reason, "brief: seed inference");
+                (self.fts_fallback_seed_paths(task, max_seeds), true)
+            }
         }
-        let reason = self
-            .degraded_reason()
-            .copied()
-            .unwrap_or(DegradedReason::ProbeFailed);
-        record_degraded(reason, "brief: seed inference");
-        (self.fts_fallback_seed_paths(task, max_seeds), true)
     }
 
-    fn embedder_seed_paths(&self, task: &str, max_seeds: u32) -> Option<Vec<String>> {
-        let embedder = self.try_embedder_arc().ok()?;
-        let task_emb = embedder
-            .embed_query(task)
-            .map_err(degrade_with_warn(
-                "brief seed inference: embed_query",
-                DegradedReason::ProbeFailed,
-            ))
-            .ok()?;
+    fn embedder_seed_paths(
+        &self,
+        task: &str,
+        max_seeds: u32,
+    ) -> Result<Vec<String>, DegradedReason> {
+        let embedder = self.try_embedder_arc()?;
+        let task_emb = embedder.embed_query(task).map_err(degrade_with_warn(
+            "brief seed inference: embed_query",
+            DegradedReason::ProbeFailed,
+        ))?;
         let conn = self
             .conn
             .lock()
             .expect("brief seed inference: lock poisoned");
-        let results = storage::vec_search(&conn, &task_emb, max_seeds, None, &[])
-            .map_err(degrade_with_warn(
+        let results = storage::vec_search(&conn, &task_emb, max_seeds, None, &[]).map_err(
+            degrade_with_warn(
                 "brief seed inference: vec_search",
                 DegradedReason::ProbeFailed,
-            ))
-            .ok()?;
+            ),
+        )?;
         drop(conn);
 
-        Some(dedupe_seed_paths(results, max_seeds as usize))
+        Ok(dedupe_seed_paths(results, max_seeds as usize))
     }
 
     fn fts_fallback_seed_paths(&self, task: &str, max_seeds: u32) -> Vec<String> {
-        let keywords: Vec<&str> = task.split_whitespace().collect();
+        let keywords = query::extract_keywords(task);
         if keywords.is_empty() {
             return Vec::new();
         }
+        let keyword_refs: Vec<&str> = keywords.iter().map(String::as_str).collect();
         let oversample = max_seeds.saturating_mul(3);
         let conn = self
             .conn
@@ -632,7 +632,7 @@ impl Yomu {
             .expect("brief seed inference fts fallback: lock poisoned");
         let results = storage::search_by_fts(
             &conn,
-            &keywords,
+            &keyword_refs,
             None,
             &HashSet::new(),
             None,

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -584,37 +584,69 @@ impl Yomu {
         }
     }
 
-    fn infer_seed_paths(&self, task: &str, max_seeds: u32) -> Result<Vec<String>, DegradedReason> {
-        let embedder = self.try_embedder_arc()?;
-        let task_emb = embedder.embed_query(task).map_err(degrade_with_warn(
-            "brief seed inference: embed_query",
-            DegradedReason::ProbeFailed,
-        ))?;
+    fn infer_seed_paths(&self, task: &str, max_seeds: u32) -> (Vec<String>, bool) {
+        if let Some(paths) = self.embedder_seed_paths(task, max_seeds) {
+            return (paths, false);
+        }
+        let reason = self
+            .degraded_reason()
+            .copied()
+            .unwrap_or(DegradedReason::ProbeFailed);
+        record_degraded(reason, "brief: seed inference");
+        (self.fts_fallback_seed_paths(task, max_seeds), true)
+    }
+
+    fn embedder_seed_paths(&self, task: &str, max_seeds: u32) -> Option<Vec<String>> {
+        let embedder = self.try_embedder_arc().ok()?;
+        let task_emb = embedder
+            .embed_query(task)
+            .map_err(degrade_with_warn(
+                "brief seed inference: embed_query",
+                DegradedReason::ProbeFailed,
+            ))
+            .ok()?;
         let conn = self
             .conn
             .lock()
             .expect("brief seed inference: lock poisoned");
-        let results = storage::vec_search(&conn, &task_emb, max_seeds, None, &[]).map_err(
-            degrade_with_warn(
+        let results = storage::vec_search(&conn, &task_emb, max_seeds, None, &[])
+            .map_err(degrade_with_warn(
                 "brief seed inference: vec_search",
                 DegradedReason::ProbeFailed,
-            ),
-        )?;
+            ))
+            .ok()?;
         drop(conn);
 
-        let cap = max_seeds as usize;
-        let mut paths = Vec::with_capacity(cap);
-        let mut seen = HashSet::new();
-        for r in results {
-            if !seen.insert(r.chunk.file_path.clone()) {
-                continue;
-            }
-            paths.push(r.chunk.file_path);
-            if paths.len() >= cap {
-                break;
-            }
+        Some(dedupe_seed_paths(results, max_seeds as usize))
+    }
+
+    fn fts_fallback_seed_paths(&self, task: &str, max_seeds: u32) -> Vec<String> {
+        let keywords: Vec<&str> = task.split_whitespace().collect();
+        if keywords.is_empty() {
+            return Vec::new();
         }
-        Ok(paths)
+        let oversample = max_seeds.saturating_mul(3);
+        let conn = self
+            .conn
+            .lock()
+            .expect("brief seed inference fts fallback: lock poisoned");
+        let results = storage::search_by_fts(
+            &conn,
+            &keywords,
+            None,
+            &HashSet::new(),
+            None,
+            oversample,
+            &[],
+        )
+        .map_err(degrade_with_warn(
+            "brief seed inference: fts fallback",
+            DegradedReason::ProbeFailed,
+        ))
+        .unwrap_or_default();
+        drop(conn);
+
+        dedupe_seed_paths(results, max_seeds as usize)
     }
 
     pub fn brief(&self, task: &brief::TaskBrief, json: bool) -> Result<String, YomuError> {
@@ -634,21 +666,16 @@ impl Yomu {
         let mut effective = task.clone();
         let mut degraded = false;
         if effective.seeds.is_empty() {
-            match self.infer_seed_paths(&effective.task, BRIEF_MAX_INFERRED_SEEDS) {
-                Ok(paths) => {
-                    effective.seeds = paths
-                        .into_iter()
-                        .map(|value| brief::Seed {
-                            kind: brief::SeedKind::File,
-                            value,
-                        })
-                        .collect();
-                }
-                Err(reason) => {
-                    record_degraded(reason, "brief: seed inference");
-                    degraded = true;
-                }
-            }
+            let (paths, seed_degraded) =
+                self.infer_seed_paths(&effective.task, BRIEF_MAX_INFERRED_SEEDS);
+            effective.seeds = paths
+                .into_iter()
+                .map(|value| brief::Seed {
+                    kind: brief::SeedKind::File,
+                    value,
+                })
+                .collect();
+            degraded |= seed_degraded;
         }
 
         let mut output = self.with_db(|conn| brief::expand_plan(conn, &effective))?;
@@ -829,6 +856,21 @@ impl Yomu {
             Ok("Model downloaded and verified".to_owned())
         }
     }
+}
+
+fn dedupe_seed_paths(results: Vec<storage::SearchResult>, cap: usize) -> Vec<String> {
+    let mut paths = Vec::with_capacity(cap);
+    let mut seen = HashSet::new();
+    for r in results {
+        if !seen.insert(r.chunk.file_path.clone()) {
+            continue;
+        }
+        paths.push(r.chunk.file_path);
+        if paths.len() >= cap {
+            break;
+        }
+    }
+    paths
 }
 
 #[cfg(test)]

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -2516,7 +2516,55 @@ fn yomu_brief_with_json_returns_valid_json() {
     );
 }
 
-// T-571: brief_falls_back_to_degraded_when_no_embedder
+// T-014b [Spec FR-014b]: brief_fts_seeds_when_no_embedder_and_keyword_matches
+#[test]
+fn brief_fts_seeds_when_no_embedder_and_keyword_matches() {
+    let (conn, dir) = test_db();
+    let emb = vec![0.0_f32; storage::EMBEDDING_DIMS];
+    storage::insert_chunk(
+        &conn,
+        "src/auth_handler.rs",
+        &storage::NewChunk {
+            chunk_type: &storage::ChunkType::RustFn,
+            name: Some("auth"),
+            content: "fn auth() { /* auth logic */ }",
+            start_line: 1,
+            end_line: 3,
+            parent_index: None,
+        },
+        "h",
+        &storage::ce(emb),
+        None,
+    )
+    .unwrap();
+    let yomu = Yomu::for_test(conn, dir.path().to_path_buf(), None);
+
+    let task = brief::TaskBrief {
+        task: "auth".to_owned(),
+        seeds: vec![],
+        depth: 1,
+        max_chunks: 80,
+        max_bytes: 80_000,
+    };
+
+    let output = yomu.brief(&task, true).unwrap();
+    let parsed = parse_json(&output);
+
+    assert_eq!(
+        parsed["degraded"], true,
+        "no embedder must mark degraded, got: {output}"
+    );
+    let chunks = parsed["chunks"].as_array().unwrap();
+    assert!(
+        !chunks.is_empty(),
+        "FTS hit on 'auth' must produce at least one seed chunk, got: {output}"
+    );
+}
+
+// T-014c [Spec FR-014b] / T-571: brief_falls_back_to_degraded_when_no_embedder
+// T-014c covers the FTS-0-hit branch: task keyword `infer something` finds no
+// matching chunk in `fn body() {}`, so closure stays empty even after FTS
+// fallback. Behavior identical to the original T-571 assertion.
 #[test]
 fn brief_falls_back_to_degraded_when_no_embedder() {
     let (conn, dir) = test_db();


### PR DESCRIPTION
## 概要

`yomu brief "task"` を embedder 不在 (`--no-embed` / `YOMU_EMBED=0` / model 未インストール / probe 失敗) で実行したとき、CLI ヘルプに「FTS-only seed selection」と書かれていたにもかかわらず実際は空 closure を返していた。`infer_seed_paths` に FTS による seed 選択経路を追加し、embedder 不在でも task キーワードから seed ファイルを推論できるようにした。

## 変更点

- `infer_seed_paths`: embedder 経路が失敗したら `fts_fallback_seed_paths` にディスパッチ。戻り値を `(Vec<String>, bool)` に変更し degraded フラグを呼び出し側に伝播
- `embedder_seed_paths` (新規): 既存の embed → vec_search → dedupe 経路を分離。`Result<Vec<String>, DegradedReason>` を返す
- `fts_fallback_seed_paths` (新規): `query::extract_keywords` でトークン化し `storage::search_by_fts` を実行。embedder 不在を維持するため `degraded=true` 確定
- `dedupe_seed_paths` (新規 free function): file_path の dedupe ロジックを共通化

## 設計判断

- `query::extract_keywords` を再利用: `task.split_whitespace()` を直接呼ぶ代替案もあったが、既存の FTS パイプライン (`query.rs::search_pipeline`) と同じ前処理 (stop word 除去 + camelCase 分解 + 2 文字以上) を通すことで挙動を統一
- `embedder_seed_paths` を `Result<_, DegradedReason>` に: `Option<_>` 案では失敗理由が caller に伝わらず `unwrap_or(ProbeFailed)` で補正が必要だった
- FTS fallback でも `degraded=true` を維持: embedder 不在は変わらないため (Issue #125 の方針通り)

## 検証手順

1. `cargo test --lib brief_` で 6 tests pass (T-014b 新規 + T-014c trace + 既存 4)
2. `cargo test --lib` で全 476 tests pass
3. `cargo clippy --lib --all-features -- -D warnings` で clean

## 関連

- Closes #125
- Spec: `.claude/workspace/planning/2026-04-30-brief/spec.md` (FR-014b, T-014b, T-014c 追加)
- 参考: `sae/src/commands/search.rs:120` の `falling back to FTS` パターン