### PR TITLE
FTS5 を trigram tokenizer に切り替えて Markdown 内の日本語 prose 検索を有効化

### DIFF
--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -8,9 +8,7 @@ use rurico::storage::ensure_sqlite_vec;
 use rusqlite::Connection;
 use rusqlite::ffi::{Error as FfiError, ErrorCode};
 
-use crate::text::split_identifier;
-
-use super::{EMBEDDING_DIMS, StorageError, fts_normalization, normalize_for_fts};
+use super::{EMBEDDING_DIMS, StorageError};
 
 pub fn open_db(path: &Path) -> Result<Connection, StorageError> {
     ensure_sqlite_vec().map_err(|e| StorageError::Io(io::Error::other(e)))?;
@@ -51,8 +49,7 @@ pub fn open_db(path: &Path) -> Result<Connection, StorageError> {
 
 const SCHEMA_VERSION: u32 = 8;
 
-const DDL_FTS_CHUNKS: &str =
-    "CREATE VIRTUAL TABLE IF NOT EXISTS fts_chunks USING fts5(name, content, file_path)";
+const DDL_FTS_CHUNKS: &str = "CREATE VIRTUAL TABLE IF NOT EXISTS fts_chunks USING fts5(name, content, file_path, tokenize='trigram')";
 
 const DDL_FTS_CHUNKS_VOCAB: &str =
     "CREATE VIRTUAL TABLE IF NOT EXISTS fts_chunks_vocab USING fts5vocab(fts_chunks, row)";
@@ -198,20 +195,8 @@ fn migrate(conn: &Connection, from: u32, path: &Path) -> Result<(), StorageError
     }
     tracing::info!(from, to, "Migrating schema from v{from} to v{to}");
 
-    // v2 → v3: populate fts_chunks from existing chunks
-    if from < 3 {
-        let _automerge = FtsAutomergeGuard::new(conn)?;
-        conn.execute_batch(
-            "INSERT OR IGNORE INTO fts_chunks(rowid, content)
-             SELECT id, content FROM chunks",
-        )?;
-        fts_optimize(conn)?;
-    }
-
-    // v3 → v4: add fts5vocab table for short-term expansion
-    if from < 4 {
-        conn.execute_batch(DDL_FTS_CHUNKS_VOCAB)?;
-    }
+    // v2 → v4 are intentionally skipped: v6 → v7 below drops fts_chunks and
+    // clears file_hash, so any earlier FTS work would just be overwritten.
 
     // v4 → v5: add parent_chunk_id for subchunk extraction
     if from < 5 && !column_exists(conn, "SELECT parent_chunk_id FROM chunks LIMIT 0")? {
@@ -225,22 +210,17 @@ fn migrate(conn: &Connection, from: u32, path: &Path) -> Result<(), StorageError
         conn.execute_batch("ALTER TABLE file_context ADD COLUMN mtime_epoch INTEGER")?;
     }
 
-    // v6 → v7: rebuild FTS with 3 columns (name, content, file_path)
+    // v6 → v7: rebuild FTS with 3 columns (name, content, file_path).
+    // Drop fts_chunks/vocab and let `yomu index` repopulate on the next run.
     if from < 7 {
-        conn.execute_batch("SAVEPOINT fts_v7")?;
-        match rebuild_fts_v7(conn) {
-            Ok(()) => conn.execute_batch("RELEASE fts_v7")?,
-            Err(e) => {
-                if let Err(rb_err) = conn.execute_batch("ROLLBACK TO fts_v7") {
-                    tracing::error!(
-                        error = %rb_err,
-                        original_error = %e,
-                        "ROLLBACK TO fts_v7 failed"
-                    );
-                }
-                return Err(e);
-            }
-        }
+        conn.execute_batch(
+            "DROP TABLE IF EXISTS fts_chunks_vocab; DROP TABLE IF EXISTS fts_chunks;",
+        )?;
+        conn.execute_batch(DDL_FTS_CHUNKS)?;
+        conn.execute_batch(DDL_FTS_CHUNKS_VOCAB)?;
+        conn.execute_batch("UPDATE chunks SET file_hash = ''")?;
+        let _span = tracing::info_span!("migration_v7", path = %path.display()).entered();
+        notify_schema_change("yomu", "FTS index", 0, "yomu index");
     }
 
     // v7 → v8: migrate vec_chunks to multi-sub-chunk schema, add embedded_chunk_ids
@@ -256,43 +236,6 @@ fn migrate(conn: &Connection, from: u32, path: &Path) -> Result<(), StorageError
         notify_schema_change("yomu", "embeddings", 0, "yomu index");
     }
 
-    Ok(())
-}
-
-fn rebuild_fts_v7(conn: &Connection) -> Result<(), StorageError> {
-    let _automerge = FtsAutomergeGuard::new(conn)?;
-    conn.execute_batch("DROP TABLE IF EXISTS fts_chunks_vocab")?;
-    conn.execute_batch("DROP TABLE IF EXISTS fts_chunks")?;
-    conn.execute_batch("CREATE VIRTUAL TABLE fts_chunks USING fts5(name, content, file_path)")?;
-
-    let mut stmt = conn.prepare("SELECT id, file_path, name, content FROM chunks")?;
-    let mut rows = stmt.query([])?;
-    {
-        let mut insert = conn.prepare(
-            "INSERT INTO fts_chunks(rowid, name, content, file_path) VALUES (?1, ?2, ?3, ?4)",
-        )?;
-        let normalization = fts_normalization();
-        while let Some(row) = rows.next()? {
-            let id: i64 = row.get(0)?;
-            let path: String = row.get(1)?;
-            let name: Option<String> = row.get(2)?;
-            let content: String = row.get(3)?;
-            let fts_name = name
-                .as_deref()
-                .map(|n| split_identifier(n).join(" "))
-                .unwrap_or_default();
-            insert.execute(rusqlite::params![
-                id,
-                normalize_for_fts(&fts_name, &normalization),
-                normalize_for_fts(&content, &normalization),
-                normalize_for_fts(&path, &normalization),
-            ])?;
-        }
-    }
-
-    fts_optimize(conn)?;
-
-    conn.execute_batch(DDL_FTS_CHUNKS_VOCAB)?;
     Ok(())
 }
 

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -195,8 +195,9 @@ fn migrate(conn: &Connection, from: u32, path: &Path) -> Result<(), StorageError
     }
     tracing::info!(from, to, "Migrating schema from v{from} to v{to}");
 
-    // v2 → v4 are intentionally skipped: v6 → v7 below drops fts_chunks and
-    // clears file_hash, so any earlier FTS work would just be overwritten.
+    // v2 → v4 are no-ops: the v6 → v7 step below drops fts_chunks and the
+    // v7 → v8 step clears file_hash, so any pre-v5 FTS work would be discarded
+    // immediately afterward.
 
     // v4 → v5: add parent_chunk_id for subchunk extraction
     if from < 5 && !column_exists(conn, "SELECT parent_chunk_id FROM chunks LIMIT 0")? {
@@ -212,19 +213,20 @@ fn migrate(conn: &Connection, from: u32, path: &Path) -> Result<(), StorageError
 
     // v6 → v7: rebuild FTS with 3 columns (name, content, file_path).
     // Drop fts_chunks/vocab and let `yomu index` repopulate on the next run.
+    // file_hash reset is handled by the v7 → v8 block below.
     if from < 7 {
+        let _span = tracing::info_span!("migration_v7", path = %path.display()).entered();
         conn.execute_batch(
             "DROP TABLE IF EXISTS fts_chunks_vocab; DROP TABLE IF EXISTS fts_chunks;",
         )?;
         conn.execute_batch(DDL_FTS_CHUNKS)?;
         conn.execute_batch(DDL_FTS_CHUNKS_VOCAB)?;
-        conn.execute_batch("UPDATE chunks SET file_hash = ''")?;
-        let _span = tracing::info_span!("migration_v7", path = %path.display()).entered();
         notify_schema_change("yomu", "FTS index", 0, "yomu index");
     }
 
     // v7 → v8: migrate vec_chunks to multi-sub-chunk schema, add embedded_chunk_ids
     if from < 8 {
+        let _span = tracing::info_span!("migration_v8", path = %path.display()).entered();
         conn.execute_batch("DROP TABLE IF EXISTS vec_chunks")?;
         conn.execute_batch(&ddl_vec_chunks())?;
         conn.execute_batch(DDL_EMBEDDED_CHUNK_IDS)?;
@@ -232,7 +234,6 @@ fn migrate(conn: &Connection, from: u32, path: &Path) -> Result<(), StorageError
         // Without this, should_reindex() would skip every file whose content hasn't changed,
         // leaving embedded_chunk_ids permanently empty after the migration.
         conn.execute_batch("UPDATE chunks SET file_hash = ''")?;
-        let _span = tracing::info_span!("migration_v8", path = %path.display()).entered();
         notify_schema_change("yomu", "embeddings", 0, "yomu index");
     }
 

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -2039,9 +2039,9 @@ fn fts_chunks_vocab_exists_on_new_db() {
     assert!(exists, "fts_chunks_vocab table should exist after open_db");
 }
 
-// T-167: migration_v3_to_v4_creates_vocab_table
+// T-167: migration_v3_to_v4_creates_vocab_and_clears_file_hash
 #[test]
-fn migration_v3_to_v4_creates_vocab_table() {
+fn migration_v3_to_v4_creates_vocab_and_clears_file_hash() {
     let dir = tempdir().unwrap();
     let db_path = dir.path().join("test.db");
     let conn = open_db(&db_path).unwrap();
@@ -3825,6 +3825,8 @@ fn search_by_fts_preserves_ascii_identifier_match() {
 fn search_by_fts_handles_short_query_without_panic() {
     let (conn, _dir) = test_db();
 
+    // Seed a chunk so FTS evaluates the short query against a populated index
+    // rather than an empty one; the vocab expansion path differs in each case.
     let chunks = vec![NewChunk {
         chunk_type: &ChunkType::Hook,
         name: Some("useState"),

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -1866,14 +1866,13 @@ fn fts_chunks_deleted_with_file() {
     assert!(results.is_empty());
 }
 
-// T-160: fts5_migration_from_v2
+// T-160: fts5_migration_from_v2_clears_file_hash
 #[test]
-fn fts5_migration_from_v2() {
+fn fts5_migration_from_v2_clears_file_hash() {
     let dir = tempdir().unwrap();
     let db_path = dir.path().join("test.db");
     let conn = open_db(&db_path).unwrap();
 
-    // Insert a chunk (schema is v3, fts_chunks populated via insert_chunk_row)
     let chunks = vec![NewChunk {
         chunk_type: &ChunkType::Hook,
         name: Some("useX"),
@@ -1892,21 +1891,22 @@ fn fts5_migration_from_v2() {
     )
     .unwrap();
 
-    // Verify FTS5 is empty
-    let results = search_by_fts(&conn, &["loading"], None, &HashSet::new(), None, 10, &[]).unwrap();
-    assert!(
-        results.is_empty(),
-        "fts_chunks should be empty before migration"
-    );
-
-    // Re-init triggers migration v2→v3
+    // Re-init runs migration v2 → current. Migration drops fts_chunks and
+    // clears file_hash so `yomu index` repopulates on the next run.
     drop(conn);
     let conn = open_db(&db_path).unwrap();
 
-    // Migration should have populated fts_chunks from existing chunks
-    let results = search_by_fts(&conn, &["loading"], None, &HashSet::new(), None, 10, &[]).unwrap();
-    assert_eq!(results.len(), 1, "migration should populate fts_chunks");
-    assert_eq!(results[0].chunk.name.as_deref(), Some("useX"));
+    let hash: String = conn
+        .query_row(
+            "SELECT file_hash FROM chunks WHERE file_path = 'src/x.tsx'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        hash, "",
+        "migration should clear file_hash so `yomu index` repopulates fts_chunks"
+    );
 }
 
 // T-161: fts5_handles_special_characters_in_content
@@ -2090,25 +2090,18 @@ fn migration_v3_to_v4_creates_vocab_table() {
         "fts_chunks_vocab should exist after v3->v4 migration"
     );
 
-    // Verify data preserved: chunk should still be searchable
-    let results = search_by_fts(
-        &conn,
-        &["migrationTest"],
-        None,
-        &HashSet::new(),
-        None,
-        10,
-        &[],
-    )
-    .unwrap();
-    assert!(
-        !results.is_empty(),
-        "seeded chunk should survive v3->v4 migration"
-    );
+    // chunks rows are kept across migration even though fts_chunks gets
+    // dropped; file_hash is cleared so `yomu index` repopulates the FTS.
+    let hash: String = conn
+        .query_row(
+            "SELECT file_hash FROM chunks WHERE file_path = 'src/migrate.ts'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
     assert_eq!(
-        results[0].chunk.name.as_deref(),
-        Some("migrationTest"),
-        "chunk name should be preserved after migration"
+        hash, "",
+        "migration should clear file_hash so `yomu index` repopulates fts_chunks"
     );
 }
 
@@ -2855,9 +2848,9 @@ fn fts_stores_file_path() {
     );
 }
 
-// T-557: migration_v6_to_v7_preserves_fts_search
+// T-557: migration_v6_to_v7_clears_file_hash_for_reindex
 #[test]
-fn migration_v6_to_v7_preserves_fts_search() {
+fn migration_v6_to_v7_clears_file_hash_for_reindex() {
     let dir = tempdir().unwrap();
     let db_path = dir.path().join("test.db");
     let conn = open_db(&db_path).unwrap();
@@ -2896,58 +2889,16 @@ fn migration_v6_to_v7_preserves_fts_search() {
         .unwrap();
     assert_eq!(version, "8", "schema_version should be 8 after migration");
 
-    let results =
-        search_by_fts(&conn, &["transform"], None, &HashSet::new(), None, 10, &[]).unwrap();
-    assert_eq!(
-        results.len(),
-        1,
-        "FTS search should return results after v6->v7 migration"
-    );
-    assert_eq!(results[0].chunk.name.as_deref(), Some("processData"));
-}
-
-// T-559: migration_populates_fts_name_with_split_identifier
-#[test]
-fn migration_populates_fts_name_with_split_identifier() {
-    let dir = tempdir().unwrap();
-    let db_path = dir.path().join("test.db");
-    let conn = open_db(&db_path).unwrap();
-
-    let chunks = vec![NewChunk {
-        chunk_type: &ChunkType::RustFn,
-        name: Some("getUserName"),
-        content: "fn get_user_name() { return name; }",
-        start_line: 1,
-        end_line: 3,
-        parent_index: None,
-    }];
-    replace_file_chunks_only(&conn, "src/user.rs", &chunks, "h1", "", &[], None).unwrap();
-
-    // Simulate pre-v7: roll back to v6, drop FTS tables
-    conn.execute(
-        "UPDATE index_meta SET value = '6' WHERE key = 'schema_version'",
-        [],
-    )
-    .unwrap();
-    conn.execute_batch("DROP TABLE IF EXISTS fts_chunks")
-        .unwrap();
-    conn.execute_batch("DROP TABLE IF EXISTS fts_chunks_vocab")
-        .unwrap();
-    drop(conn);
-
-    // Re-open triggers migration to v7
-    let conn = open_db(&db_path).unwrap();
-
-    let fts_name: String = conn
+    let hash: String = conn
         .query_row(
-            "SELECT name FROM fts_chunks WHERE rowid = (SELECT id FROM chunks LIMIT 1)",
+            "SELECT file_hash FROM chunks WHERE file_path = 'src/data.rs'",
             [],
             |row| row.get(0),
         )
         .unwrap();
     assert_eq!(
-        fts_name, "get user name",
-        "migration should populate FTS name with split_identifier output (NFKC + ASCII lowercase via rurico Phase 5 normalization)"
+        hash, "",
+        "migration should clear file_hash so `yomu index` repopulates fts_chunks"
     );
 }
 
@@ -3817,4 +3768,77 @@ fn bench_search_hot_path_5emb_50kw() {
         gkdf_elapsed.as_secs_f64() * 1000.0,
         gkdf_elapsed.as_secs_f64() * 1000.0 / f64::from(ITERATIONS)
     );
+}
+
+// === Issue #157: FTS5 trigram tokenizer for Japanese prose search ===
+
+// T-157-002: search_by_fts_finds_japanese_prose_in_markdown
+#[test]
+fn search_by_fts_finds_japanese_prose_in_markdown() {
+    let (conn, _dir) = test_db();
+
+    let chunks = vec![NewChunk {
+        chunk_type: &ChunkType::MdSection,
+        name: Some("Architecture"),
+        content: "このセクションでは設計判断とドメインモデルについて説明する。",
+        start_line: 1,
+        end_line: 1,
+        parent_index: None,
+    }];
+    replace_file_chunks_only(&conn, "docs/arch.md", &chunks, "h1", "", &[], None).unwrap();
+
+    let results =
+        search_by_fts(&conn, &["設計判断"], None, &HashSet::new(), None, 10, &[]).unwrap();
+    assert_eq!(
+        results.len(),
+        1,
+        "trigram tokenizer should match Japanese prose '設計判断' in Markdown content"
+    );
+}
+
+// T-157-003: search_by_fts_preserves_ascii_identifier_match
+#[test]
+fn search_by_fts_preserves_ascii_identifier_match() {
+    let (conn, _dir) = test_db();
+
+    let chunks = vec![NewChunk {
+        chunk_type: &ChunkType::Hook,
+        name: Some("useState"),
+        content: "const [count, setCount] = useState(0);",
+        start_line: 1,
+        end_line: 1,
+        parent_index: None,
+    }];
+    replace_file_chunks_only(&conn, "src/Counter.tsx", &chunks, "h1", "", &[], None).unwrap();
+
+    let results =
+        search_by_fts(&conn, &["useState"], None, &HashSet::new(), None, 10, &[]).unwrap();
+    assert_eq!(
+        results.len(),
+        1,
+        "trigram tokenizer should still match camelCase identifier 'useState'"
+    );
+}
+
+// T-157-004: search_by_fts_handles_short_query_without_panic
+#[test]
+fn search_by_fts_handles_short_query_without_panic() {
+    let (conn, _dir) = test_db();
+
+    let chunks = vec![NewChunk {
+        chunk_type: &ChunkType::Hook,
+        name: Some("useState"),
+        content: "useState hook",
+        start_line: 1,
+        end_line: 1,
+        parent_index: None,
+    }];
+    replace_file_chunks_only(&conn, "src/x.tsx", &chunks, "h1", "", &[], None).unwrap();
+
+    // Trigram needs ≥3 chars to form a token; 1-2 char queries must return
+    // cleanly (no panic, no error), regardless of whether they hit.
+    for q in ["a", "ab", "あ", "あい"] {
+        search_by_fts(&conn, &[q], None, &HashSet::new(), None, 10, &[])
+            .unwrap_or_else(|e| panic!("short query {q:?} should not error: {e}"));
+    }
 }


### PR DESCRIPTION
## 目的

`fts_chunks` のトークナイザーをデフォルトの `unicode61` から `trigram` に切り替え、Markdown 内の日本語 prose (例: 「設計判断」) を `search_by_fts` で発見可能にする。これにより embedder 不在の degraded path でも日本語キーワード検索が成立する。

## 変更点

- `DDL_FTS_CHUNKS` に `tokenize='trigram'` を追加。ASCII 識別子は 3-gram 経由で従来通り命中する。
- `rebuild_fts_v7` (chunks → FTS INSERT ループ) を削除し、v6→v7 を drop & `yomu index` 再実行に揃えた。v7→v8 と同じパターン。
- v7 ブロックの重複 `UPDATE chunks SET file_hash = ''` を削除 (v7→v8 が同じ `migrate()` 呼び出しで実行)。
- `let _span` の位置を block 先頭に移動し、SQL を実際に instrument するように修正。
- v2→v4 の no-op migration ブロックを削除 (v6→v7 が drop して上書きするため意味がなかった)。
- T-157-002 / T-157-003 / T-157-004 を追加。T-160 / T-167 / T-557 を新方針 (file_hash クリア確認) に書き換え、T-559 を削除 (split_identifier 挙動は T-528 / T-531 でカバー済み)。

## スコープ

- **対象外**: migration 機能全体の削除。「migrate 機能不要な気がしている」というフィードバックは別 issue として整理する。

## 設計判断

- 拡張子別 2 系統ではなく `trigram` で統一。recall (src/db.rs:10) / sae (src/storage.rs:60) が同じ統一構成で実運用済み。precision の実測劣化が観測された段階で分割を後付けする想定。
- 既存 FTS データの保持はせず drop & `yomu index` で repopulate する。chunks 由来の SAVEPOINT + INSERT は normalize / split_identifier の同期維持コストが大きく、ユーザーフィードバック「破壊的でいい、一回削除して index しなおせばいい」に沿う判断。

## 動作確認

1. `cargo test --lib` で 478 件全 Green を確認。
2. `cargo test --test '*'` で integration 42 件 + schema_validation 2 件 全 Green。
3. `cargo clippy --lib --tests` で警告なし。
4. 既存 DB (schema_version < 7) を開き直し、`migration_v7` span が tracing に出ること、`file_hash` が空になることを確認。
5. 日本語 prose を含む Markdown を index 後、`yomu search "設計判断"` で FTS マッチ経由のヒットが返ることを確認。

## 関連

- Closes #157