### PR TITLE
chore(deps): amici/rurico rev 更新と cargo update (num-conv / tower-http)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=1d16d08#1d16d08f9144b7a522fee6a155bd658ad38c8a88"
+source = "git+https://github.com/thkt/amici?rev=b545722#b54572260e8a7685c7503284de27eec0585dfd28"
 dependencies = [
  "bytemuck",
  "rand 0.10.1",
@@ -1627,9 +1627,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -2096,7 +2096,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=bb25a06#bb25a06cd32b5e83df291d6a7cf251de738ac7bb"
+source = "git+https://github.com/thkt/rurico?rev=a573655#a573655f0a811deeae96f87640d28fcd117dec7b"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -2114,7 +2114,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=bb25a06#bb25a06cd32b5e83df291d6a7cf251de738ac7bb"
+source = "git+https://github.com/thkt/rurico?rev=a573655#a573655f0a811deeae96f87640d28fcd117dec7b"
 dependencies = [
  "mlx-sys",
  "rusqlite",
@@ -2749,9 +2749,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ repository = "https://github.com/thkt/yomu"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "1d16d08" }
+amici = { git = "https://github.com/thkt/amici", rev = "b545722" }
 bytemuck = "1"
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
-rurico = { git = "https://github.com/thkt/rurico", rev = "bb25a06" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "a573655" }
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -31,7 +31,7 @@ tree-sitter-rust = "0.24"
 tree-sitter-typescript = "0.23"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "bb25a06", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "a573655", features = ["test-support"] }
 tempfile = "3"
 tracing-test = { version = "0.2", features = ["no-env-filter"] }
 


### PR DESCRIPTION
## 変更点

- `amici` rev を `1d16d08` → `b545722` に更新 (emit_load_hint helper 経由への refactor を取り込み)
- `rurico` rev を `bb25a06` → `a573655` に更新 (ADR-0004 References drift 解消 + cargo update を取り込み)
- 連動して `Cargo.lock` の `num-conv` 0.2.1 → 0.2.2 と `tower-http` 0.6.10 → 0.6.11 を反映

## 動作確認

- [x] `cargo check --all-targets --all-features` クリーン
- [x] `cargo nextest run --all-features` で 543 passed / 3 skipped
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 警告なし