### PR TITLE
fix(brief): 0 chunk 出力で degraded を立てて warn を発火 (RC-014)

### DIFF
--- a/src/brief.rs
+++ b/src/brief.rs
@@ -353,6 +353,15 @@ pub fn render_plain(output: &BriefOutput) -> String {
 #[allow(clippy::cast_possible_truncation)]
 pub fn expand_plan(conn: &Connection, task: &TaskBrief) -> Result<BriefOutput, StorageError> {
     let seeds = collect_seed_paths(task);
+    if seeds.is_empty() {
+        tracing::warn!("expand_plan called with empty seeds; returning empty");
+        return Ok(BriefOutput {
+            chunks: Vec::new(),
+            degraded: true,
+            total_chunks: 0,
+            total_bytes: 0,
+        });
+    }
     let depth_by_path = collect_closure(conn, &seeds, task.depth)?;
 
     let paths: Vec<&str> = depth_by_path.keys().map(String::as_str).collect();

--- a/src/brief/tests.rs
+++ b/src/brief/tests.rs
@@ -2,12 +2,33 @@ use std::collections::HashMap;
 
 use rusqlite::Connection;
 use tempfile::{TempDir, tempdir};
+use tracing_test::traced_test;
 
 use super::*;
 use crate::storage::{
     EMBEDDING_DIMS, NewChunk, RefKind, Reference, ce, insert_chunk, open_db,
     replace_file_references,
 };
+
+// T-574: expand_plan_empty_seeds_returns_empty_degraded [RC-014 #140]
+#[traced_test]
+#[test]
+fn expand_plan_empty_seeds_returns_empty_degraded() {
+    let (conn, _dir) = test_db();
+    let task = task_with_seeds(vec![], 1);
+    let output = expand_plan(&conn, &task).unwrap();
+    assert!(output.chunks.is_empty(), "empty seeds yield empty chunks");
+    assert!(
+        output.degraded,
+        "empty seeds must mark degraded as invariant violation"
+    );
+    assert_eq!(output.total_chunks, 0);
+    assert_eq!(output.total_bytes, 0);
+    assert!(
+        logs_contain("expand_plan called with empty seeds"),
+        "expected warn for empty seeds"
+    );
+}
 
 fn test_db() -> (Connection, TempDir) {
     let dir = tempdir().unwrap();

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -680,6 +680,16 @@ impl Yomu {
 
         let mut output = self.with_db(|conn| brief::expand_plan(conn, &effective))?;
         output.degraded |= degraded;
+
+        if output.chunks.is_empty() {
+            tracing::warn!(
+                seeds = effective.seeds.len(),
+                degraded = output.degraded,
+                "brief produced zero chunks"
+            );
+            output.degraded = true;
+        }
+
         Ok(if json {
             brief::render_json(&output)
         } else {

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -2629,6 +2629,29 @@ fn brief_emits_warn_on_seed_inference_embed_query_failure() {
     );
 }
 
+// T-573: brief_emits_warn_and_degraded_on_zero_chunks [RC-014 #140]
+#[traced_test]
+#[test]
+fn brief_emits_warn_and_degraded_on_zero_chunks() {
+    let (yomu, _dir) = test_yomu();
+    let task = brief_task("src/nonexistent_seed.rs");
+    let output = yomu.brief(&task, true).unwrap();
+    let parsed = parse_json(&output);
+    assert_eq!(
+        parsed["chunks"].as_array().unwrap().len(),
+        0,
+        "missing seed file must yield zero chunks, got: {output}"
+    );
+    assert_eq!(
+        parsed["degraded"], true,
+        "zero chunks must mark degraded, got: {output}"
+    );
+    assert!(
+        logs_contain("brief produced zero chunks"),
+        "expected warn for zero chunks"
+    );
+}
+
 // T-570: yomu_brief_rejects_empty_task [Spec FR-010b prep]
 #[test]
 fn yomu_brief_rejects_empty_task() {


### PR DESCRIPTION
## 概要

- `Yomu::brief()` 末尾で `output.chunks.is_empty()` を判定し、warn 発火 + `degraded=true` を強制
- `brief::expand_plan()` 先頭で `seeds.is_empty()` の invariant チェックを追加し、warn 発火 + 早期 return (空の degraded BriefOutput)
- T-573 / T-574 を追加 (`tracing_test::traced_test` + `logs_contain` で warn 確認、`degraded` field で動作確認)

## 動機

Issue #140 / RC-014。`brief()` の出力が 0 chunk のとき `degraded:false` で返るケースがあり、caller (Claude Code 等の AI agent) には正常完了と silent zero が区別できなかった。本 PR で caller が `degraded` signal だけで区別できる契約を確立する。

## スコープ

- Step 1 (`Yomu::brief()` 出力チェック) と Step 2 (`expand_plan` invariant) のみ。
- Step 3 (JsonOutput / plain に totals 反映) は OPS-006 として別 Issue 扱い。

## テスト

- [x] `cargo test --lib brief` (18 tests pass、新規 T-573 / T-574 含む)
- [x] `cargo test --lib` (480 tests pass、regression なし)
- [x] `cargo clippy --lib --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)

Closes #140