### PR TITLE
fix(cli): BrokenPipe を SUCCESS に丸める write_output ヘルパー (#156 Phase 1)

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,82 @@
+//! Stdout writer that converts `BrokenPipe` (EPIPE) to a clean exit.
+//!
+//! When yomu's stdout is piped to a consumer that closes early (`| head -0`,
+//! `| true`), Rust's default panic-on-broken-pipe surfaces as ExitCode 101
+//! and a noisy stderr message. AI agents reading the output then misclassify
+//! this as a yomu failure even though the consumer chose to stop reading.
+//! `write_output` drains `BrokenPipe` into `ExitCode::SUCCESS` while still
+//! reporting other I/O failures with the `IO_ERR` sysexits code so genuine
+//! disk / encoding faults remain observable.
+
+use std::io::{self, Write};
+use std::process::ExitCode;
+
+use amici::cli::exit_code::codes;
+
+/// Writes `output` followed by a newline to stdout. `BrokenPipe` is treated as
+/// successful completion (consumer chose to stop reading); other I/O errors
+/// surface as `IO_ERR` exit code.
+pub fn write_output(output: &str) -> ExitCode {
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    write_output_to(&mut handle, output)
+}
+
+pub(crate) fn write_output_to<W: Write>(writer: &mut W, output: &str) -> ExitCode {
+    match writeln!(writer, "{output}") {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) if e.kind() == io::ErrorKind::BrokenPipe => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("yomu: stdout write failed: {e}");
+            ExitCode::from(codes::IO_ERR)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FailingWriter {
+        kind: io::ErrorKind,
+    }
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::new(self.kind, "induced"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    // T-IO-001: write_output_to writes the payload plus a trailing newline.
+    #[test]
+    fn write_output_to_appends_newline_and_succeeds() {
+        let mut buf: Vec<u8> = Vec::new();
+        let code = write_output_to(&mut buf, "hello");
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(buf, b"hello\n");
+    }
+
+    // T-IO-002: BrokenPipe collapses to SUCCESS (pipe consumer closed early).
+    #[test]
+    fn write_output_to_broken_pipe_returns_success() {
+        let mut w = FailingWriter {
+            kind: io::ErrorKind::BrokenPipe,
+        };
+        let code = write_output_to(&mut w, "ignored");
+        assert_eq!(code, ExitCode::SUCCESS);
+    }
+
+    // T-IO-003: non-pipe I/O failures surface as IO_ERR (74).
+    #[test]
+    fn write_output_to_other_io_error_returns_io_err() {
+        let mut w = FailingWriter {
+            kind: io::ErrorKind::PermissionDenied,
+        };
+        let code = write_output_to(&mut w, "ignored");
+        assert_eq!(code, ExitCode::from(codes::IO_ERR));
+    }
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -11,23 +11,22 @@
 use std::io::{self, Write};
 use std::process::ExitCode;
 
-use amici::cli::exit_code::codes;
+use amici::cli::{exit_code::codes, exit_error};
 
-/// Writes `output` followed by a newline to stdout. `BrokenPipe` is treated as
-/// successful completion (consumer chose to stop reading); other I/O errors
-/// surface as `IO_ERR` exit code.
+/// Writes `output` plus a newline to stdout. See module docs for the
+/// `BrokenPipe` / `IO_ERR` exit-code contract.
 pub fn write_output(output: &str) -> ExitCode {
     let stdout = io::stdout();
     let mut handle = stdout.lock();
     write_output_to(&mut handle, output)
 }
 
-pub(crate) fn write_output_to<W: Write>(writer: &mut W, output: &str) -> ExitCode {
+fn write_output_to<W: Write>(writer: &mut W, output: &str) -> ExitCode {
     match writeln!(writer, "{output}") {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) if e.kind() == io::ErrorKind::BrokenPipe => ExitCode::SUCCESS,
         Err(e) => {
-            eprintln!("yomu: stdout write failed: {e}");
+            exit_error(&format!("stdout write failed: {e}"));
             ExitCode::from(codes::IO_ERR)
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod brief;
 pub mod config;
 pub mod error;
 pub mod indexer;
+pub mod io;
 pub mod query;
 pub mod resolver;
 pub mod rust_resolver;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use clap::{CommandFactory, Parser, Subcommand};
 use rurico::handle_probe_if_needed;
 use yomu::brief;
 use yomu::error::{self, ErrorCode};
+use yomu::io::write_output;
 use yomu::tools::{
     MAX_IMPACT_DEPTH, MAX_SEARCH_LIMIT, MAX_SEARCH_OFFSET, Yomu, YomuError, YomuOptions,
 };
@@ -167,10 +168,7 @@ fn main() -> ExitCode {
             ModelCommand::Download => Yomu::model_download(json),
         };
         return match result {
-            Ok(output) => {
-                println!("{output}");
-                ExitCode::SUCCESS
-            }
+            Ok(output) => write_output(&output),
             Err(e) => emit_error(&e, json),
         };
     }
@@ -280,10 +278,7 @@ fn main() -> ExitCode {
     };
 
     match result {
-        Ok(output) => {
-            println!("{output}");
-            ExitCode::SUCCESS
-        }
+        Ok(output) => write_output(&output),
         Err(e) => emit_error(&e, json),
     }
 }


### PR DESCRIPTION
## 概要

- `src/io.rs` (新規) に `write_output` ヘルパーを実装し、stdout の `BrokenPipe` を `ExitCode::SUCCESS` に丸める。他の I/O 失敗は `IO_ERR` (74) で surface
- `main.rs` の `println!("{output}"); ExitCode::SUCCESS` 2 箇所 (`model_download` 成功パス、全コマンド共通成功パス) を `write_output(&output)` に差し替え
- T-IO-001 (newline + SUCCESS) / T-IO-002 (BrokenPipe → SUCCESS) / T-IO-003 (PermissionDenied → IO_ERR) の 3 unit test を追加

## 動機

ADR-0060 (agent-friendly CLI) の Phase 1 (#156)。`yomu status | true` や `yomu status | head -0` のように stdout が早期 close されるシナリオで、Rust runtime の panic + ExitCode 101 が発生していた。AI agent が読む stderr では「yomu が落ちた」と誤認する経路。

## スコープ

- Phase 1 のみ。Phase 2.2 (envelope の `next_step` / `candidates` 拡張、`degraded` / `notes` を全 6 経路に展開) と Phase 2.3 (`after_help` Examples 7 コマンド) は別 PR で扱う

## ポリッシュ反映

`/polish` のレビュー (simplify + reviewer-reuse + reviewer-readability + reviewer-efficiency + CodeRabbit) で出た 3 件を別 commit (`577d53e`) で反映済み:

- `write_output_to` の `pub(crate)` を private に (LANG.md visibility 最小化)
- `eprintln!` を `amici::cli::exit_error` に置換 (stderr format 統一)
- `write_output` の docstring を contract のみに簡潔化

Codex は usage limit、Gemini は 429 で skip。CodeRabbit は 0 findings、reviewer-efficiency も 0 findings、enhancer-code Phase 2 audit も追加変更なし。

## テスト

- [x] `cargo test --lib io::` (3 tests pass、T-IO-001/002/003)
- [x] `cargo test --lib` (483 tests pass、regression なし)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)

Refs #156