### PR TITLE
feat(query_log): opt-in JSONL クエリログ primitive (#182 Phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3554,6 +3554,7 @@ dependencies = [
  "strsim",
  "tempfile",
  "thiserror",
+ "time",
  "tracing",
  "tracing-subscriber",
  "tracing-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde_json = "1"
 sha2 = "0.11"
 strsim = "0.11"
 thiserror = "2"
+time = { version = "0.3", features = ["formatting"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tree-sitter = "0.26"

--- a/README.md
+++ b/README.md
@@ -312,6 +312,16 @@ src/
 
 Single binary, zero runtime dependencies. SQLite and sqlite-vec are statically linked.
 
+## Query Log
+
+検索パイプラインの観測用に append-only JSONL の query log を出力できる (default off、Issue #182)。
+
+- Opt-in: `yomu --log-query search "..."` で 1 search = 1 record が書き込まれる
+- 書き込み先: `$XDG_DATA_HOME/yomu/query_log.jsonl` (env 未設定時は `~/.local/share/yomu/query_log.jsonl`)
+- 用途: Hit@k 低下の query 抽出、ranking 実験の baseline 蓄積、回帰検知
+
+`original_query` には実際の検索文字列がそのまま記録される。bug report として共有する前に内容を確認すること。yomu はローカル個人利用前提のため default で redact しない。
+
 ## License
 
 MIT

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod indexer;
 pub mod io;
 pub mod query;
+pub mod query_log;
 pub mod resolver;
 pub mod rust_resolver;
 pub mod storage;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,9 @@ struct Cli {
     /// Output as JSON
     #[arg(long, global = true)]
     json: bool,
+    /// Append a JSONL record per search to the XDG-resolved query log (default off, see Issue #182)
+    #[arg(long, global = true)]
+    log_query: bool,
     #[command(subcommand)]
     command: Option<Command>,
 }
@@ -176,8 +179,12 @@ fn main() -> ExitCode {
     let yomu_options = match &command {
         Command::Search { no_embed, .. } | Command::Brief { no_embed, .. } => YomuOptions {
             no_embed: *no_embed,
+            log_query: cli.log_query,
         },
-        _ => YomuOptions::default(),
+        _ => YomuOptions {
+            log_query: cli.log_query,
+            ..YomuOptions::default()
+        },
     };
 
     let yomu = match Yomu::new(yomu_options) {

--- a/src/query_log.rs
+++ b/src/query_log.rs
@@ -205,15 +205,22 @@ mod tests {
         );
     }
 
-    // T-QL-008: latency_ms field is u64 (matches amici QueryResult::latency_ms).
+    // T-QL-008: latency_ms serializes as a non-negative integer (amici
+    // QueryResult::latency_ms is u64). A weak `let _: u64 = ...` compile-time
+    // check would pass even if the field were later widened, so assert the
+    // wire representation instead.
     #[test]
-    fn latency_ms_field_is_u64() {
+    fn latency_ms_serializes_as_u64_integer() {
         let record = QueryLogRecord {
             latency_ms: 123,
             ..sample_record()
         };
-        let v: u64 = record.latency_ms;
-        assert_eq!(v, 123_u64);
+        let value = serde_json::to_value(&record).expect("to_value");
+        let latency = value
+            .get("latency_ms")
+            .and_then(serde_json::Value::as_u64)
+            .expect("latency_ms must be a u64 JSON number");
+        assert_eq!(latency, 123);
     }
 
     // T-QL-011: resolve_log_path falls back to $HOME/.local/share when XDG is unset.
@@ -244,6 +251,9 @@ mod tests {
     }
 
     // T-QL-012: log emit median latency ≤ 10ms over 10 samples (in-memory writer).
+    // CI-skipped because wall-clock thresholds flake under load; run locally
+    // with `cargo test --lib log_emit_latency -- --ignored`.
+    #[ignore]
     #[test]
     fn log_emit_latency_median_under_10ms() {
         use std::time::Instant;

--- a/src/query_log.rs
+++ b/src/query_log.rs
@@ -1,0 +1,266 @@
+//! Append-only JSONL query log for search pipeline observability.
+//!
+//! Opt-in via the `--log-query` CLI flag (default off). Each `Yomu::search`
+//! invocation appends 1 record to `$XDG_DATA_HOME/yomu/query_log.jsonl`
+//! (or `$HOME/.local/share/yomu/query_log.jsonl` when the env var is unset).
+//!
+//! Schema is intentionally a superset of amici `QueryResult` so future
+//! amici extraction can read yomu logs after a documented conversion
+//! (`i64::to_string()` + `Some(_)` for chunk ids). Stage-wise fields
+//! (`fts_results` etc.) are yomu-observability-only.
+
+use std::env;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+const LOG_DIR_NAME: &str = "yomu";
+const LOG_FILE_NAME: &str = "query_log.jsonl";
+
+/// Resolves the log file path. Reads `$XDG_DATA_HOME` first, falling back
+/// to `$HOME/.local/share` per the XDG Base Directory Specification.
+///
+/// Parameters are taken via injection so unit tests can drive resolution
+/// without touching process environment.
+pub fn resolve_log_path(xdg_data_home: Option<&str>, home: &str) -> PathBuf {
+    let base = match xdg_data_home {
+        Some(s) if !s.is_empty() => PathBuf::from(s),
+        _ => PathBuf::from(home).join(".local").join("share"),
+    };
+    base.join(LOG_DIR_NAME).join(LOG_FILE_NAME)
+}
+
+/// Convenience wrapper that reads the live process environment.
+pub fn resolve_log_path_from_env() -> Option<PathBuf> {
+    let home = env::var("HOME").ok()?;
+    let xdg = env::var("XDG_DATA_HOME").ok();
+    Some(resolve_log_path(xdg.as_deref(), &home))
+}
+
+/// Append-only writer over a `Write` sink. Production callers wrap a
+/// `std::fs::File`; tests inject `Vec<u8>` to assert serialized content.
+pub struct QueryLogWriter<W: Write> {
+    writer: W,
+}
+
+impl<W: Write> QueryLogWriter<W> {
+    pub fn new(writer: W) -> Self {
+        Self { writer }
+    }
+
+    /// Serializes `record` as a single JSONL line. Newlines within string
+    /// fields are escaped as `\n` by `serde_json`, preserving the 1
+    /// record = 1 line invariant.
+    pub fn write_record(&mut self, record: &QueryLogRecord) -> io::Result<()> {
+        serde_json::to_writer(&mut self.writer, record).map_err(io::Error::other)?;
+        self.writer.write_all(b"\n")
+    }
+}
+
+/// Opens the log file at `path` in append-only mode, creating the parent
+/// directory if missing. Errors propagate so callers can degrade to
+/// `tracing::warn` per FR-012 without failing the search.
+pub fn open_append_writer(path: &Path) -> io::Result<QueryLogWriter<File>> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let file = OpenOptions::new().append(true).create(true).open(path)?;
+    Ok(QueryLogWriter::new(file))
+}
+
+/// Per-stage hit shape, repeated across `fts_results`, `vec_results`,
+/// `rrf_results`, `reranked_results`. Keeping a single shape lets consumers
+/// write one parser for all stages.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StageHit {
+    pub chunk_id: i64,
+    pub score: f32,
+    pub source: String,
+}
+
+/// One JSONL record per `Yomu::search` invocation. Field order is stable
+/// and field types are pinned for forward-compat with amici (see
+/// `approaches.md` mapping table).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QueryLogRecord {
+    pub timestamp: String,
+    pub yomu_version: String,
+    pub original_query: String,
+    pub fts_results: Vec<StageHit>,
+    pub vec_results: Vec<StageHit>,
+    pub rrf_results: Vec<StageHit>,
+    pub reranked_results: Vec<StageHit>,
+    pub final_context_ids: Vec<i64>,
+    pub latency_ms: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_record() -> QueryLogRecord {
+        QueryLogRecord {
+            timestamp: "2026-05-19T03:33:27Z".to_owned(),
+            yomu_version: "0.16.0".to_owned(),
+            original_query: "auth handler".to_owned(),
+            fts_results: vec![StageHit {
+                chunk_id: 1,
+                score: 0.5,
+                source: "fts".to_owned(),
+            }],
+            vec_results: vec![],
+            rrf_results: vec![],
+            reranked_results: vec![],
+            final_context_ids: vec![1, 2, 3],
+            latency_ms: 123,
+        }
+    }
+
+    // T-QL-001: serde round-trip preserves every field.
+    #[test]
+    fn record_round_trips_through_json() {
+        let original = sample_record();
+        let json = serde_json::to_string(&original).expect("serialize");
+        let parsed: QueryLogRecord = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed, original);
+    }
+
+    // T-QL-002: multi-line query escapes to a single JSONL line.
+    #[test]
+    fn multi_line_query_serializes_to_one_line() {
+        let mut record = sample_record();
+        record.original_query = "line1\nline2".to_owned();
+        let mut buf: Vec<u8> = Vec::new();
+        QueryLogWriter::new(&mut buf)
+            .write_record(&record)
+            .expect("write");
+        let s = String::from_utf8(buf).expect("utf8");
+        assert!(s.ends_with('\n'), "trailing newline required");
+        let body = &s[..s.len() - 1];
+        assert!(
+            !body.contains('\n'),
+            "record body must occupy one line, got: {body}"
+        );
+        assert!(
+            body.contains("line1\\nline2"),
+            "newline must be JSON-escaped as \\\\n, got: {body}"
+        );
+    }
+
+    // T-QL-003: unicode (Japanese + emoji) round-trips as UTF-8 bytes.
+    #[test]
+    fn unicode_query_serializes_as_utf8() {
+        let mut record = sample_record();
+        record.original_query = "認証 🔐".to_owned();
+        let json = serde_json::to_string(&record).expect("serialize");
+        assert!(
+            json.contains("認証 🔐"),
+            "expected literal UTF-8 bytes, got: {json}"
+        );
+        let parsed: QueryLogRecord = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed.original_query, "認証 🔐");
+    }
+
+    // T-QL-004: append-only writer preserves pre-existing file contents.
+    #[test]
+    fn append_only_preserves_existing_lines() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("query_log.jsonl");
+        fs::write(&path, "pre1\npre2\npre3\n").expect("seed");
+        let mut writer = open_append_writer(&path).expect("open");
+        writer.write_record(&sample_record()).expect("write");
+        drop(writer);
+        let content = fs::read_to_string(&path).expect("read");
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 4, "expected 4 lines, got: {content}");
+        assert_eq!(lines[0], "pre1");
+        assert_eq!(lines[1], "pre2");
+        assert_eq!(lines[2], "pre3");
+    }
+
+    // T-QL-007a: final_context_ids type and rank order on the yomu side.
+    #[test]
+    fn final_context_ids_is_vec_i64_in_rank_order() {
+        let record = QueryLogRecord {
+            final_context_ids: vec![10, 20, 30],
+            ..sample_record()
+        };
+        assert_eq!(record.final_context_ids, vec![10_i64, 20, 30]);
+    }
+
+    // T-QL-007b: documented conversion produces Vec<Option<String>>.
+    #[test]
+    fn final_context_ids_extracts_to_option_string_vec() {
+        let ids: Vec<i64> = vec![10, 20, 30];
+        let extracted: Vec<Option<String>> = ids.iter().map(|id| Some(id.to_string())).collect();
+        assert_eq!(
+            extracted,
+            vec![
+                Some("10".to_owned()),
+                Some("20".to_owned()),
+                Some("30".to_owned())
+            ]
+        );
+    }
+
+    // T-QL-008: latency_ms field is u64 (matches amici QueryResult::latency_ms).
+    #[test]
+    fn latency_ms_field_is_u64() {
+        let record = QueryLogRecord {
+            latency_ms: 123,
+            ..sample_record()
+        };
+        let v: u64 = record.latency_ms;
+        assert_eq!(v, 123_u64);
+    }
+
+    // T-QL-011: resolve_log_path falls back to $HOME/.local/share when XDG is unset.
+    #[test]
+    fn resolve_log_path_falls_back_to_home_local_share() {
+        let resolved = resolve_log_path(None, "/tmp/test-home");
+        assert_eq!(
+            resolved,
+            PathBuf::from("/tmp/test-home/.local/share/yomu/query_log.jsonl")
+        );
+    }
+
+    // T-QL-011 supplement: XDG_DATA_HOME set is honoured.
+    #[test]
+    fn resolve_log_path_uses_xdg_when_set() {
+        let resolved = resolve_log_path(Some("/var/xdg"), "/tmp/test-home");
+        assert_eq!(resolved, PathBuf::from("/var/xdg/yomu/query_log.jsonl"));
+    }
+
+    // T-QL-011 supplement: empty XDG falls back per spec.
+    #[test]
+    fn resolve_log_path_empty_xdg_falls_back() {
+        let resolved = resolve_log_path(Some(""), "/tmp/test-home");
+        assert_eq!(
+            resolved,
+            PathBuf::from("/tmp/test-home/.local/share/yomu/query_log.jsonl")
+        );
+    }
+
+    // T-QL-012: log emit median latency ≤ 10ms over 10 samples (in-memory writer).
+    #[test]
+    fn log_emit_latency_median_under_10ms() {
+        use std::time::Instant;
+        let mut samples_us: Vec<u128> = Vec::with_capacity(10);
+        for _ in 0..10 {
+            let mut buf: Vec<u8> = Vec::with_capacity(4096);
+            let start = Instant::now();
+            QueryLogWriter::new(&mut buf)
+                .write_record(&sample_record())
+                .expect("write");
+            samples_us.push(start.elapsed().as_micros());
+        }
+        samples_us.sort_unstable();
+        let median = samples_us[samples_us.len() / 2];
+        assert!(
+            median <= 10_000,
+            "median latency {median}us exceeded 10ms budget"
+        );
+    }
+}

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -8,6 +8,10 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Instant;
+
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
 
 use amici::cli::embed_with_spinners;
 use amici::cli::env_lookup;
@@ -21,6 +25,7 @@ use crate::config;
 use crate::error::ErrorCode;
 use crate::indexer;
 use crate::query::{self, QueryError};
+use crate::query_log::{self, QueryLogRecord};
 use crate::storage;
 
 #[cfg(any(test, feature = "test-support"))]
@@ -95,6 +100,8 @@ pub struct YomuOptions {
     /// Disable embedding-based search; falls back to FTS5 only.
     /// OR-merged with `YOMU_EMBED=0`.
     pub no_embed: bool,
+    /// Opt in to query log JSONL output (`--log-query`). Default off per #182.
+    pub log_query: bool,
 }
 
 /// Env-derived runtime configuration for [`Yomu::with_root`].
@@ -176,6 +183,7 @@ pub struct Yomu {
     embed_disabled: bool,
     rerank_enabled: bool,
     reranker: OnceLock<ModelLoad<Box<dyn Rerank>>>,
+    log_query: bool,
 }
 
 impl Yomu {
@@ -203,6 +211,7 @@ impl Yomu {
             embed_disabled,
             rerank_enabled: config.rerank_enabled,
             reranker: OnceLock::new(),
+            log_query: options.log_query,
         })
     }
 
@@ -222,6 +231,7 @@ impl Yomu {
             embed_disabled: false,
             rerank_enabled: false,
             reranker: OnceLock::new(),
+            log_query: false,
         }
     }
 
@@ -275,6 +285,7 @@ impl Yomu {
         let state = determine_index_state(&stats);
         let index_notes = self.ensure_indexed(embedder, state, hints_ref)?;
 
+        let start = Instant::now();
         let outcome = query::search(
             &self.conn,
             embedder,
@@ -284,6 +295,8 @@ impl Yomu {
             self.get_reranker(),
             paths,
         )?;
+        let latency_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+        maybe_emit_query_log(self.log_query, query, &outcome, latency_ms);
 
         let mut notes: Vec<String> = Vec::new();
         if let Some(msg) = index_notes {
@@ -881,6 +894,45 @@ fn dedupe_seed_paths(results: Vec<storage::SearchResult>, cap: usize) -> Vec<Str
         }
     }
     paths
+}
+
+fn maybe_emit_query_log(
+    log_query: bool,
+    query: &str,
+    outcome: &query::SearchOutcome,
+    latency_ms: u64,
+) {
+    if !log_query {
+        return;
+    }
+    let Some(path) = query_log::resolve_log_path_from_env() else {
+        tracing::warn!("query log path unresolved (HOME unset); skipping emit");
+        return;
+    };
+    let timestamp = OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_default();
+    let record = QueryLogRecord {
+        timestamp,
+        yomu_version: env!("CARGO_PKG_VERSION").to_owned(),
+        original_query: query.to_owned(),
+        fts_results: Vec::new(),
+        vec_results: Vec::new(),
+        rrf_results: Vec::new(),
+        reranked_results: Vec::new(),
+        final_context_ids: outcome.results.iter().filter_map(|r| r.chunk_id).collect(),
+        latency_ms,
+    };
+    match query_log::open_append_writer(&path) {
+        Ok(mut writer) => {
+            if let Err(e) = writer.write_record(&record) {
+                tracing::warn!(error = %e, "query log write failed");
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, path = %path.display(), "query log open failed");
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -295,8 +295,10 @@ impl Yomu {
             self.get_reranker(),
             paths,
         )?;
-        let latency_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
-        maybe_emit_query_log(self.log_query, query, &outcome, latency_ms);
+        if self.log_query {
+            let latency_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+            self.emit_query_log(query, &outcome, latency_ms);
+        }
 
         let mut notes: Vec<String> = Vec::new();
         if let Some(msg) = index_notes {
@@ -896,41 +898,35 @@ fn dedupe_seed_paths(results: Vec<storage::SearchResult>, cap: usize) -> Vec<Str
     paths
 }
 
-fn maybe_emit_query_log(
-    log_query: bool,
-    query: &str,
-    outcome: &query::SearchOutcome,
-    latency_ms: u64,
-) {
-    if !log_query {
-        return;
-    }
-    let Some(path) = query_log::resolve_log_path_from_env() else {
-        tracing::warn!("query log path unresolved (HOME unset); skipping emit");
-        return;
-    };
-    let timestamp = OffsetDateTime::now_utc()
-        .format(&Rfc3339)
-        .unwrap_or_default();
-    let record = QueryLogRecord {
-        timestamp,
-        yomu_version: env!("CARGO_PKG_VERSION").to_owned(),
-        original_query: query.to_owned(),
-        fts_results: Vec::new(),
-        vec_results: Vec::new(),
-        rrf_results: Vec::new(),
-        reranked_results: Vec::new(),
-        final_context_ids: outcome.results.iter().filter_map(|r| r.chunk_id).collect(),
-        latency_ms,
-    };
-    match query_log::open_append_writer(&path) {
-        Ok(mut writer) => {
-            if let Err(e) = writer.write_record(&record) {
-                tracing::warn!(error = %e, "query log write failed");
+impl Yomu {
+    fn emit_query_log(&self, query: &str, outcome: &query::SearchOutcome, latency_ms: u64) {
+        let Some(path) = query_log::resolve_log_path_from_env() else {
+            tracing::warn!("query log path unresolved (HOME unset); skipping emit");
+            return;
+        };
+        let timestamp = OffsetDateTime::now_utc()
+            .format(&Rfc3339)
+            .unwrap_or_default();
+        let record = QueryLogRecord {
+            timestamp,
+            yomu_version: env!("CARGO_PKG_VERSION").to_owned(),
+            original_query: query.to_owned(),
+            fts_results: Vec::new(),
+            vec_results: Vec::new(),
+            rrf_results: Vec::new(),
+            reranked_results: Vec::new(),
+            final_context_ids: outcome.results.iter().filter_map(|r| r.chunk_id).collect(),
+            latency_ms,
+        };
+        match query_log::open_append_writer(&path) {
+            Ok(mut writer) => {
+                if let Err(e) = writer.write_record(&record) {
+                    tracing::warn!(error = %e, "query log write failed");
+                }
             }
-        }
-        Err(e) => {
-            tracing::warn!(error = %e, path = %path.display(), "query log open failed");
+            Err(e) => {
+                tracing::warn!(error = %e, path = %path.display(), "query log open failed");
+            }
         }
     }
 }

--- a/src/tools/embedder.rs
+++ b/src/tools/embedder.rs
@@ -147,6 +147,7 @@ impl Yomu {
             embed_disabled: false,
             rerank_enabled: false,
             reranker: OnceLock::new(),
+            log_query: false,
         }
     }
 
@@ -160,6 +161,7 @@ impl Yomu {
             embed_disabled: true,
             rerank_enabled: false,
             reranker: OnceLock::new(),
+            log_query: false,
         }
     }
 }


### PR DESCRIPTION
## 概要

- `src/query_log.rs` (新規) に `QueryLogRecord` schema + append-only `QueryLogWriter` + XDG path resolver を実装
- `Yomu` に `log_query: bool` field と `impl Yomu::emit_query_log` private method を追加、`Yomu::search` hot path で `if self.log_query` guard 経由で emit
- `--log-query` を global CLI flag (default off) として追加、`YomuOptions` 経由で `Yomu` まで伝搬
- `time` crate (formatting feature) を依存追加 (RFC3339 timestamp 用)
- `README.md` に Query Log section を追加 (default off / 書き込み先 / 共有時の PII 注意)

## 動機

ADR-0037 pattern に従う Issue #182 Phase 1。yomu の search パイプラインが black box で、Hit@1 低下 / 誤一致 / 漏れの「どこで失敗したか」(fts / vec / rrf / rerank) が観測できない。1 query = 1 record の append-only JSONL を `$XDG_DATA_HOME/yomu/query_log.jsonl` (env 未設定時 `~/.local/share/yomu/query_log.jsonl`) に opt-in で出力する基盤を追加する。

## スコープ

### 含む
- query log primitive (`QueryLogRecord` schema、`QueryLogWriter`、XDG path 解決)
- search 経路からの emit hook
- `--log-query` flag
- amici `QueryResult` への forward-compat 構造 (final_context_ids + latency_ms)

### 含まない
- 中間 stage (`fts_results` / `vec_results` / `rrf_results` / `reranked_results`) の populate (現状は空 Vec)。`query::search` の return type 拡張を含むため別 Issue で fork 予定
- amici 側の external_log replay subcommand (incident driven、別 Issue)
- 統合テスト (T-QL-005 / T-QL-006 / T-QL-010、env override が unsafe edition のため別 PR)

## ポリッシュ反映

`/polish` のレビュー (simplify + reviewer-reuse + reviewer-readability + reviewer-efficiency + CodeRabbit) で出た主要 finding を別 commit (`5fa0b67`) で反映済み:

- T-QL-008 (weak assertion): `let _: u64 = ...` の compile-time ascription を `serde_json::to_value` + `Value::as_u64` の wire 検証に置換
- T-QL-012 (CI flake): wall-clock 10ms 閾値 test を `#[ignore]` 化
- `maybe_emit_query_log` free function を `impl Yomu::emit_query_log` method に refactor (control parameter / `maybe_` prefix / context 分断 を同時解消)
- caller 側 guard 移動で `Instant::now()` 計測も flag off では skip

Codex は usage limit、Gemini は 429 で skip。CodeRabbit は findings 0。

## テスト

- [x] `cargo test --lib query_log::` (10 pass + 1 ignored)
- [x] `cargo test --lib` (493 pass、regression なし)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)

## 関連

- Issue #182
- 設計成果物: `.claude/workspace/planning/2026-05-19-query-log-primitive/` (ローカル、gitignore 除外)
  - sow.md / spec.md / approaches.md (reviewer-spec gate Loop 3 で Ready)
  - amici forward-compat mapping table 含む