### PR TITLE
feat(query_log): search パイプライン中間 stage capture (#182 Phase 2)

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -1,7 +1,8 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
-use crate::storage::{self, ChunkType, Db, SearchResult, StorageError};
+use crate::query_log::StageHit;
+use crate::storage::{self, ChunkType, Db, MatchSource, SearchResult, StorageError};
 use crate::text::split_identifier;
 use rurico::embed::{Embed, EmbedError};
 use rurico::reranker::Rerank;
@@ -16,10 +17,35 @@ pub enum QueryError {
     Internal(String),
 }
 
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct SearchStages {
+    pub fts_results: Vec<StageHit>,
+    pub vec_results: Vec<StageHit>,
+    pub rrf_results: Vec<StageHit>,
+    pub reranked_results: Vec<StageHit>,
+}
+
 #[derive(Debug)]
 pub struct SearchOutcome {
     pub results: Vec<SearchResult>,
     pub degraded: bool,
+    pub stages: Option<SearchStages>,
+}
+
+fn capture_stage(results: &[SearchResult]) -> Vec<StageHit> {
+    results
+        .iter()
+        .filter_map(|r| {
+            r.chunk_id.map(|id| StageHit {
+                chunk_id: id,
+                score: r.score,
+                source: match r.match_source {
+                    MatchSource::Semantic => "semantic".to_owned(),
+                    MatchSource::Fts => "fts".to_owned(),
+                },
+            })
+        })
+        .collect()
 }
 
 const STOP_WORDS: &[&str] = &["the", "a", "an", "in", "for", "of", "with", "and", "or"];
@@ -390,6 +416,7 @@ pub fn search_from_file(
     Ok(results)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn search_pipeline(
     conn: &Db,
     query: &str,
@@ -398,7 +425,8 @@ fn search_pipeline(
     offset: u32,
     reranker: Option<&dyn Rerank>,
     path_filter: &[String],
-) -> Result<Vec<SearchResult>, StorageError> {
+    capture_stages: bool,
+) -> Result<(Vec<SearchResult>, Option<SearchStages>), StorageError> {
     let keywords = extract_keywords(query);
     let type_hints = extract_type_hints(query);
     let keyword_refs: Vec<&str> = keywords.iter().map(String::as_str).collect();
@@ -415,6 +443,8 @@ fn search_pipeline(
         Some(type_hints.as_slice())
     };
 
+    let mut stages = capture_stages.then(SearchStages::default);
+
     let use_semantic = query_embedding.is_some() && stats.embedded_chunks > 0;
     let mut results = match query_embedding {
         Some(emb) if use_semantic => {
@@ -422,6 +452,9 @@ fn search_pipeline(
         }
         _ => Vec::new(),
     };
+    if let Some(s) = stages.as_mut() {
+        s.vec_results = capture_stage(&results);
+    }
 
     // FTS fallback is independent of reranker's semantic overfetch to avoid
     // handing an excessively large batch to the cross-encoder.
@@ -438,7 +471,13 @@ fn search_pipeline(
             fallback_limit,
             path_filter,
         )?;
+        if let Some(s) = stages.as_mut() {
+            s.fts_results = capture_stage(&fts_results);
+        }
         results.extend(fts_results);
+    }
+    if let Some(s) = stages.as_mut() {
+        s.rrf_results = capture_stage(&results);
     }
     let embed_coverage = stats.embed_coverage();
 
@@ -465,6 +504,9 @@ fn search_pipeline(
     if let Some(ranker) = reranker {
         cross_encoder_rerank(&mut results, query, ranker);
     }
+    if let Some(s) = stages.as_mut() {
+        s.reranked_results = capture_stage(&results);
+    }
     cap_per_file(&mut results, MAX_RESULTS_PER_FILE);
     if offset > 0 {
         let skip = (offset as usize).min(results.len());
@@ -472,9 +514,10 @@ fn search_pipeline(
     }
     results.truncate(limit as usize);
 
-    Ok(results)
+    Ok((results, stages))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn search(
     conn: &Arc<Mutex<Db>>,
     embedder: &(impl Embed + ?Sized),
@@ -483,6 +526,7 @@ pub fn search(
     offset: u32,
     reranker: Option<&dyn Rerank>,
     path_filter: &[String],
+    capture_stages: bool,
 ) -> Result<SearchOutcome, QueryError> {
     let (query_embedding, degraded) = match embedder.embed_query(query) {
         Ok(emb) => (Some(emb), false),
@@ -493,7 +537,7 @@ pub fn search(
     };
 
     let conn = conn.lock().unwrap();
-    let results = search_pipeline(
+    let (results, stages) = search_pipeline(
         &conn,
         query,
         query_embedding.as_deref(),
@@ -501,8 +545,13 @@ pub fn search(
         offset,
         reranker,
         path_filter,
+        capture_stages,
     )?;
-    Ok(SearchOutcome { results, degraded })
+    Ok(SearchOutcome {
+        results,
+        degraded,
+        stages,
+    })
 }
 
 #[cfg(test)]

--- a/src/query/tests.rs
+++ b/src/query/tests.rs
@@ -41,7 +41,17 @@ fn search_with_mock_embedder() {
     .unwrap();
 
     let conn = Arc::new(Mutex::new(conn));
-    let outcome = search(&conn, &MockEmbedder::default(), "button", 10, 0, None, &[]).unwrap();
+    let outcome = search(
+        &conn,
+        &MockEmbedder::default(),
+        "button",
+        10,
+        0,
+        None,
+        &[],
+        false,
+    )
+    .unwrap();
     assert!(!outcome.degraded);
     assert_eq!(outcome.results.len(), 1);
     assert_eq!(outcome.results[0].chunk.name.as_deref(), Some("Button"));
@@ -228,9 +238,18 @@ fn search_fallback_merges_vector_and_name_results() {
     .unwrap();
 
     let conn = Arc::new(Mutex::new(conn));
-    let results = search(&conn, &MockEmbedder::default(), "auth", 5, 0, None, &[])
-        .unwrap()
-        .results;
+    let results = search(
+        &conn,
+        &MockEmbedder::default(),
+        "auth",
+        5,
+        0,
+        None,
+        &[],
+        false,
+    )
+    .unwrap()
+    .results;
 
     assert!(
         results.len() >= 2,
@@ -283,9 +302,18 @@ fn search_deduplicates_vector_and_name_results() {
     .unwrap();
 
     let conn = Arc::new(Mutex::new(conn));
-    let results = search(&conn, &MockEmbedder::default(), "auth", 5, 0, None, &[])
-        .unwrap()
-        .results;
+    let results = search(
+        &conn,
+        &MockEmbedder::default(),
+        "auth",
+        5,
+        0,
+        None,
+        &[],
+        false,
+    )
+    .unwrap()
+    .results;
 
     let auth_count = results
         .iter()
@@ -667,6 +695,7 @@ fn search_returns_results_sorted_by_score() {
         0,
         None,
         &[],
+        false,
     )
     .unwrap()
     .results;
@@ -888,6 +917,7 @@ fn search_degrades_on_embed_failure() {
         0,
         None,
         &[],
+        false,
     )
     .unwrap();
     assert!(outcome.degraded, "should be degraded when embed fails");
@@ -912,7 +942,7 @@ fn search_degrades_on_model_not_available() {
     let conn = storage::open_db(&db_path).unwrap();
     let conn = Arc::new(Mutex::new(conn));
 
-    let outcome = search(&conn, &embedder, "test", 10, 0, None, &[]).unwrap();
+    let outcome = search(&conn, &embedder, "test", 10, 0, None, &[], false).unwrap();
     assert!(
         outcome.degraded,
         "should degrade to FTS5 when model not available"
@@ -1024,6 +1054,7 @@ fn reranker_reorders_results_by_cross_encoder_score() {
         0,
         Some(&reranker),
         &[],
+        false,
     )
     .unwrap();
 
@@ -1066,10 +1097,29 @@ fn no_reranker_produces_rrf_results() {
     .unwrap();
 
     let conn = Arc::new(Mutex::new(conn));
-    let outcome = search(&conn, &MockEmbedder::default(), "auth", 5, 0, None, &[]).unwrap();
+    let outcome = search(
+        &conn,
+        &MockEmbedder::default(),
+        "auth",
+        5,
+        0,
+        None,
+        &[],
+        false,
+    )
+    .unwrap();
 
-    let outcome_existing =
-        search(&conn, &MockEmbedder::default(), "auth", 5, 0, None, &[]).unwrap();
+    let outcome_existing = search(
+        &conn,
+        &MockEmbedder::default(),
+        "auth",
+        5,
+        0,
+        None,
+        &[],
+        false,
+    )
+    .unwrap();
 
     assert_eq!(
         outcome.results.len(),
@@ -1134,6 +1184,7 @@ fn reranker_increases_fetch_limit() {
         offset,
         Some(&reranker),
         &[],
+        false,
     )
     .unwrap();
 
@@ -1223,6 +1274,7 @@ fn reranker_scores_applied_before_cap_per_file() {
         0,
         Some(&reranker),
         &[],
+        false,
     )
     .unwrap();
 
@@ -1290,7 +1342,7 @@ fn search_returns_results() {
     .unwrap();
 
     let conn = Arc::new(Mutex::new(conn));
-    let outcome = search(&conn, &embedder, "button", 10, 0, None, &[]).unwrap();
+    let outcome = search(&conn, &embedder, "button", 10, 0, None, &[], false).unwrap();
     assert!(!outcome.results.is_empty(), "expected at least one result");
 }
 
@@ -1319,7 +1371,7 @@ fn search_pipeline_text_only_returns_name_matches() {
     )
     .unwrap();
 
-    let results = search_pipeline(&conn, "auth", None, 10, 0, None, &[]).unwrap();
+    let (results, _stages) = search_pipeline(&conn, "auth", None, 10, 0, None, &[], false).unwrap();
     assert!(
         !results.is_empty(),
         "text-only pipeline should find name matches"
@@ -1353,7 +1405,8 @@ fn search_pipeline_with_embedding_returns_semantic() {
     )
     .unwrap();
 
-    let results = search_pipeline(&conn, "button", Some(&emb), 10, 0, None, &[]).unwrap();
+    let (results, _stages) =
+        search_pipeline(&conn, "button", Some(&emb), 10, 0, None, &[], false).unwrap();
     assert!(!results.is_empty());
     assert_eq!(results[0].match_source, storage::MatchSource::Semantic);
 }
@@ -1377,7 +1430,7 @@ fn search_pipeline_caps_per_file() {
         .collect();
     storage::replace_file_chunks_only(&conn, "src/big.ts", &chunks, "h1", "", &[], None).unwrap();
 
-    let results = search_pipeline(&conn, "fn", None, 10, 0, None, &[]).unwrap();
+    let (results, _stages) = search_pipeline(&conn, "fn", None, 10, 0, None, &[], false).unwrap();
     let file_count = results
         .iter()
         .filter(|r| r.chunk.file_path == "src/big.ts")
@@ -1441,6 +1494,7 @@ fn text_only_search_with_offset_returns_results() {
         10,
         None,
         &[],
+        false,
     )
     .unwrap();
     assert!(
@@ -1478,7 +1532,17 @@ fn search_chunk_only_index_with_embedder_falls_back_to_text() {
     assert_eq!(stats.embedded_chunks, 0, "no embeddings should exist");
 
     let conn = Arc::new(Mutex::new(conn));
-    let outcome = search(&conn, &MockEmbedder::default(), "button", 10, 0, None, &[]).unwrap();
+    let outcome = search(
+        &conn,
+        &MockEmbedder::default(),
+        "button",
+        10,
+        0,
+        None,
+        &[],
+        false,
+    )
+    .unwrap();
     assert!(
         !outcome.results.is_empty(),
         "should return text/name fallback results even with zero embeddings"
@@ -2132,10 +2196,91 @@ fn search_pipeline_offset_beyond_results_returns_empty() {
     }
 
     // offset=10 exceeds the 2-result set → empty Vec expected.
-    let results = search_pipeline(&conn, "widget", None, 10, 10, None, &[]).unwrap();
+    let (results, _stages) =
+        search_pipeline(&conn, "widget", None, 10, 10, None, &[], false).unwrap();
     assert!(
         results.is_empty(),
         "offset >= results.len() should return empty Vec, got: {results:?}"
+    );
+}
+
+// === TC-6: stage capture (Issue #182 Phase 2) ===
+
+// T-QL-014: capture_stages=false leaves stages as None (NFR-002 zero-cost flag-off).
+#[test]
+fn search_pipeline_capture_stages_false_returns_none() {
+    let (conn, _dir) = from_test_db();
+    storage::replace_file_chunks_only(
+        &conn,
+        "src/auth.ts",
+        &[storage::NewChunk {
+            chunk_type: &storage::ChunkType::Other,
+            name: Some("authHandler"),
+            content: "function authHandler() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        }],
+        "h0",
+        "",
+        &[],
+        None,
+    )
+    .unwrap();
+
+    let (_results, stages) = search_pipeline(&conn, "auth", None, 10, 0, None, &[], false).unwrap();
+    assert!(
+        stages.is_none(),
+        "capture_stages=false must return None, got: {stages:?}"
+    );
+}
+
+// T-QL-015: capture_stages=true populates fts_results / rrf_results / reranked_results
+// on the FTS-only path (no embedding) with source="fts".
+#[test]
+fn search_pipeline_capture_stages_fts_path_populates_stages() {
+    let (conn, _dir) = from_test_db();
+    storage::replace_file_chunks_only(
+        &conn,
+        "src/auth.ts",
+        &[storage::NewChunk {
+            chunk_type: &storage::ChunkType::Other,
+            name: Some("authHandler"),
+            content: "function authHandler() {}",
+            start_line: 1,
+            end_line: 1,
+            parent_index: None,
+        }],
+        "h0",
+        "",
+        &[],
+        None,
+    )
+    .unwrap();
+
+    let (results, stages) = search_pipeline(&conn, "auth", None, 10, 0, None, &[], true).unwrap();
+    assert!(!results.is_empty(), "expected at least 1 result");
+    let s = stages.expect("capture_stages=true must return Some");
+    assert!(
+        s.vec_results.is_empty(),
+        "no embedding => vec_results must be empty, got: {:?}",
+        s.vec_results
+    );
+    assert!(
+        !s.fts_results.is_empty(),
+        "FTS path must populate fts_results"
+    );
+    assert_eq!(
+        s.fts_results[0].source, "fts",
+        "fts stage source must be 'fts'"
+    );
+    assert!(
+        !s.rrf_results.is_empty(),
+        "post-merge rrf_results must include FTS hits"
+    );
+    assert!(
+        !s.reranked_results.is_empty(),
+        "post-rerank reranked_results must be populated"
     );
 }
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -294,6 +294,7 @@ impl Yomu {
             offset,
             self.get_reranker(),
             paths,
+            self.log_query,
         )?;
         if self.log_query {
             let latency_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
@@ -907,14 +908,15 @@ impl Yomu {
         let timestamp = OffsetDateTime::now_utc()
             .format(&Rfc3339)
             .unwrap_or_default();
+        let stages = outcome.stages.clone().unwrap_or_default();
         let record = QueryLogRecord {
             timestamp,
             yomu_version: env!("CARGO_PKG_VERSION").to_owned(),
             original_query: query.to_owned(),
-            fts_results: Vec::new(),
-            vec_results: Vec::new(),
-            rrf_results: Vec::new(),
-            reranked_results: Vec::new(),
+            fts_results: stages.fts_results,
+            vec_results: stages.vec_results,
+            rrf_results: stages.rrf_results,
+            reranked_results: stages.reranked_results,
             final_context_ids: outcome.results.iter().filter_map(|r| r.chunk_id).collect(),
             latency_ms,
         };


### PR DESCRIPTION
## 概要

Issue #182 Phase 2 として、search パイプラインの中間 stage 観測を実装。Phase 1 で導入した `QueryLogRecord` の `fts_results` / `vec_results` / `rrf_results` / `reranked_results` が空 Vec のままだった状態を解消し、各 stage の chunk_id + score + source を JSONL に書き出すようにする。

## 動機

Phase 1 で primitive (schema + writer + XDG path + emit hook) は揃ったが、中間 stage は populate されていなかった。これでは Hit@1 低下時に「どの stage で漏れたか」(fts / vec / merge / rerank) を切り分けられない。Phase 2 で stage capture を入れて、log 観測の本来の価値 (regression 検知 / alias / rerank 効果検証) を有効化する。

## スコープ

### 含む

- `SearchOutcome.stages: Option<SearchStages>` を追加
- `query::search()` / `search_pipeline()` に `capture_stages: bool` param を追加。flag-off で `stages = None` (zero overhead)
- 4 箇所の capture hook (vec_search 後 / fts_search 後 / merge 後 / rerank+cross_encoder 後)
- `Yomu::search` で `self.log_query` を forward
- `emit_query_log` で `outcome.stages` から fts/vec/rrf/reranked を populate
- T-QL-014 (flag-off → `None`) と T-QL-015 (FTS path → 各 stage populate + source="fts") の unit test

### 含まない

- `vec_results` semantic path の独立 unit test (既存 `search_pipeline_with_embedding_returns_semantic` は capture オフ実行)
- query options struct への refactor (`#[allow(clippy::too_many_arguments)]` で抑制。`capture_stages` 追加で 8 引数になったが、options struct 化は別 Issue 候補)
- amici 側 external_log replay subcommand (incident driven、別 Issue 維持)

## 設計判断

| 判断 | 採用 | 却下 | 理由 |
| --- | --- | --- | --- |
| Stage capture API | `SearchOutcome.stages: Option<SearchStages>` | callback closure (FnMut) | 既存 caller への影響最小、return type 拡張 1 ヶ所のみ |
| flag-off の cost | `if let Some(s) = stages.as_mut()` guard | 常に populate して emit 側で破棄 | Phase 1 NFR-002 「1 boolean branch on search hot path」を保つ |
| `rrf_results` の意味 | extend (merge) 後の raw 状態 | 本当の RRF (Reciprocal Rank Fusion) | 現状の pipeline は単純 merge。schema 名は forward-compat (将来 RRF 実装時に意味を一致させる) のため Phase 1 命名維持 |
| 引数 8 化の対応 | `#[allow(clippy::too_many_arguments)]` 2 箇所 | options struct への refactor | Phase 2 scope を絞る |

## テスト

- [x] `cargo test --lib` (495 pass / 0 fail / 4 ignored)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)

新規 test:
- T-QL-014: `capture_stages=false` で `stages = None`
- T-QL-015: `capture_stages=true` で FTS-only path から `fts_results` / `rrf_results` / `reranked_results` が populate、`source` field が `"fts"` であること

## 関連

- Issue #182
- 先行 PR #193 (Phase 1)
- 設計成果物: `.claude/workspace/planning/2026-05-19-query-log-primitive/` (Phase 1 から継続。Phase 2 は Phase 1 spec.md FR-004 の 4 field を populate する範囲拡張)
