### PR TITLE
7 サブコマンドの --help に Examples を追加 (#192 Phase 2.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,9 +453,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -2085,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "rsqlite-vfs"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
  "thiserror",
@@ -2399,9 +2399,9 @@ dependencies = [
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
+checksum = "cdd578e94101503d97e2b286bbf8db2135035ca24b2ce4cbf3f9e2fb2bbf1eee"
 dependencies = [
  "cc",
  "js-sys",

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,12 @@ struct Cli {
 #[derive(Debug, Subcommand)]
 enum Command {
     /// Semantic code search. Finds components, hooks, types by meaning.
+    #[command(after_help = "\
+Examples:
+  yomu search \"streaming chat hooks\"
+  yomu search --from src/query.rs:rerank
+  yomu search \"auth\" --path src/auth --limit 5
+  yomu --json search \"useAuth\"")]
     Search {
         /// Natural language query (reads from stdin if omitted or "-")
         query: Option<String>,
@@ -57,18 +63,31 @@ enum Command {
         no_embed: bool,
     },
     /// Update chunk index incrementally. No API calls.
+    #[command(after_help = "\
+Examples:
+  yomu index
+  yomu index --dry-run")]
     Index {
         /// Show what would be indexed without writing to the database
         #[arg(long)]
         dry_run: bool,
     },
     /// Rebuild chunk index from scratch. No API calls.
+    #[command(after_help = "\
+Examples:
+  yomu rebuild
+  yomu rebuild --dry-run")]
     Rebuild {
         /// Show what would be rebuilt without writing to the database
         #[arg(long)]
         dry_run: bool,
     },
     /// Analyze impact of changes to a file or symbol.
+    #[command(after_help = "\
+Examples:
+  yomu impact src/hooks/useAuth.ts
+  yomu impact src/hooks/useAuth.ts --symbol useAuth --depth 2
+  yomu impact src/hooks/useAuth.ts --semantic")]
     Impact {
         /// File path relative to project root (e.g. "src/hooks/useAuth.ts")
         target: String,
@@ -83,10 +102,23 @@ enum Command {
         semantic: bool,
     },
     /// Show index statistics.
+    #[command(after_help = "\
+Examples:
+  yomu status
+  yomu --json status")]
     Status,
     /// Embed pending chunks for semantic search.
+    #[command(after_help = "\
+Examples:
+  yomu embed
+  yomu --json embed")]
     Embed,
     /// Bundle forward-closure code for an agent (recall-complete brief).
+    #[command(after_help = "\
+Examples:
+  yomu brief \"add OAuth login\" --seed-file src/auth.rs
+  yomu brief \"fix rerank scoring\" --seed-symbol rerank --depth 2
+  yomu --json brief \"refactor query layer\" --seed-file src/query.rs --max-chunks 40")]
     Brief {
         /// Free-form task description (must not be empty)
         task: String,

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1160,3 +1160,30 @@ fn search_no_query_json_emits_usage_error_envelope() {
         "expected error.message string: {stderr}"
     );
 }
+
+// T-700: after_help_examples_present_for_all_commands [Issue #192 Phase 2.3]
+#[test]
+fn after_help_examples_present_for_all_commands() {
+    for cmd in [
+        "search", "index", "rebuild", "impact", "status", "embed", "brief",
+    ] {
+        let output = yomu_cmd().args([cmd, "--help"]).output().unwrap();
+        assert!(
+            output.status.success(),
+            "{cmd} --help failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let (_, after_examples) = stdout
+            .split_once("Examples:")
+            .unwrap_or_else(|| panic!("{cmd} --help should contain 'Examples:', got: {stdout}"));
+        let example_count = after_examples
+            .lines()
+            .filter(|l| l.trim_start().starts_with("yomu "))
+            .count();
+        assert!(
+            example_count >= 1,
+            "{cmd} --help should have at least 1 example line starting with 'yomu ', got: {stdout}"
+        );
+    }
+}


### PR DESCRIPTION
## What & Why

ADR-0060 採択の agent-friendly CLI 原則のうち「自己発見」を強化するため、7 サブコマンド (search / index / rebuild / impact / status / embed / brief) の `--help` に `Examples` セクションを付与。AI エージェントが `yomu <cmd> --help` 1 回で典型的な呼び出しパターンを把握できる状態にする。

Issue #192 の Phase 2.3 のみを扱う。Phase 2.2 (ErrorPayload 拡張 + degraded/notes 6 経路展開) は別 PR。

## Changes

- `src/main.rs`: 7 Subcommand variant に `#[command(after_help = ...)]` を付与。既存 `Model` subcommand と同じ書式で統一
- `tests/cli_integration.rs`: T-700 を追加。7 コマンドそれぞれの `--help` が `Examples:` マーカー以降に最低 1 行の `yomu ` 呼び出しを含むことを検証
- `Cargo.lock`: ビルド時の incidental dep bumps (crypto-common / rsqlite-vfs / sqlite-wasm-rs)

## Scope

### 含まない

- Phase 2.2 (ErrorPayload 拡張 / degraded/notes 6 経路展開) — 別 PR
- `Model` subcommand への変更 — 既に Examples 付与済み

## Design Decisions

- 既存 `Model` 形式を踏襲 (`after_help = "\nExamples:\n  yomu ..."`)。新形式導入は揺らぎ要因なので consistency 優先
- macro による DRY 化は見送り。現状 7 ブロックだが各コマンドの Examples は独立進化する性質。call sites が 8 を超えた時点で再検討

## How to Test

1. `cargo test --test cli_integration after_help_examples_present_for_all_commands` → passed
2. `cargo run -- search --help` → 末尾に `Examples:` セクション表示
3. `cargo run -- brief --help` → `yomu brief "..." --seed-file ...` 等の実例表示
4. `cargo test --test cli_integration` → 43 passed (regression なし)

## Related

- Issue: #192 (Phase 2.3)
- ADR-0060: agent-friendly CLI design principles
- 親 Issue: #156 (close 済み)
- 次 PR: Phase 2.2a (ErrorPayload 拡張)
