### PR TITLE
ErrorPayload に next_step / candidates / retryable を追加 (Phase 2.2a)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -50,14 +50,38 @@ struct ErrorEnvelope<'a> {
 struct ErrorPayload<'a> {
     code: ErrorCode,
     message: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    next_step: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    candidates: Vec<String>,
+    retryable: bool,
 }
 
 /// Serializes the JSON error envelope as a single line, suitable for
-/// `eprintln!`. Never returns an `Err` because the payload only carries
-/// owned/borrowed primitives.
+/// `eprintln!`. Convenience wrapper for legacy call sites without ADR-0060
+/// fields; new sites should call [`render_json_error_with`].
 pub fn render_json_error(code: ErrorCode, message: &str) -> String {
+    render_json_error_with(code, message, None, &[], false)
+}
+
+/// Renders the JSON error envelope with ADR-0060 agent-friendly fields.
+/// `next_step` is omitted when `None`, `candidates` is omitted when empty,
+/// `retryable` is always present.
+pub fn render_json_error_with(
+    code: ErrorCode,
+    message: &str,
+    next_step: Option<String>,
+    candidates: &[String],
+    retryable: bool,
+) -> String {
     serde_json::to_string(&ErrorEnvelope {
-        error: ErrorPayload { code, message },
+        error: ErrorPayload {
+            code,
+            message,
+            next_step,
+            candidates: candidates.to_vec(),
+            retryable,
+        },
     })
     .expect("ErrorEnvelope is always serializable")
 }
@@ -78,12 +102,13 @@ mod tests {
     }
 
     // T-EC002: JSON envelope serializes the variant in SCREAMING_SNAKE_CASE.
+    // Issue #192 Phase 2.2a: envelope now always includes `retryable` (FR-005).
     #[test]
     fn json_envelope_uses_screaming_snake_case() {
         let json = render_json_error(ErrorCode::UsageError, "bad arg");
         assert_eq!(
             json,
-            r#"{"error":{"code":"USAGE_ERROR","message":"bad arg"}}"#
+            r#"{"error":{"code":"USAGE_ERROR","message":"bad arg","retryable":false}}"#
         );
     }
 
@@ -92,5 +117,65 @@ mod tests {
     fn json_envelope_unknown_serializes_to_unknown_label() {
         let json = render_json_error(ErrorCode::Unknown, "x");
         assert!(json.contains(r#""code":"UNKNOWN""#), "got: {json}");
+    }
+
+    // --- Issue #192 Phase 2.2a: render_json_error_with serialization ---
+    //
+    // Spec: .claude/workspace/planning/2026-05-20-192-phase-2-2a-error-payload/spec.md
+    // T-018 ~ T-020 validate the extended envelope shape (next_step /
+    // candidates / retryable) follows the omit-when-empty contract
+    // (FR-002 ~ FR-005).
+
+    // T-018: render_json_error_with serializes the full envelope when
+    // next_step is Some, candidates is empty, and retryable is false.
+    // FR-002, FR-005. Candidates key is omitted on empty (FR-004).
+    #[test]
+    fn render_json_error_with_emits_next_step_and_retryable_without_candidates() {
+        let json = render_json_error_with(
+            ErrorCode::UsageError,
+            "msg",
+            Some("step".to_owned()),
+            &[],
+            false,
+        );
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json).unwrap_or_else(|e| panic!("invalid JSON: {e}: {json}"));
+        assert_eq!(parsed["error"]["code"], "USAGE_ERROR", "json: {json}");
+        assert_eq!(parsed["error"]["message"], "msg", "json: {json}");
+        assert_eq!(parsed["error"]["next_step"], "step", "json: {json}");
+        assert_eq!(parsed["error"]["retryable"], false, "json: {json}");
+        assert!(
+            parsed["error"].get("candidates").is_none(),
+            "candidates key must be omitted when empty: {json}"
+        );
+    }
+
+    // T-019: render_json_error_with omits next_step entirely when None.
+    // FR-003. retryable remains always-present per FR-005.
+    #[test]
+    fn render_json_error_with_omits_next_step_when_none() {
+        let json = render_json_error_with(ErrorCode::UsageError, "msg", None, &[], false);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json).unwrap_or_else(|e| panic!("invalid JSON: {e}: {json}"));
+        assert!(
+            parsed["error"].get("next_step").is_none(),
+            "next_step key must be omitted when None: {json}"
+        );
+        assert_eq!(parsed["error"]["retryable"], false, "json: {json}");
+    }
+
+    // T-020: render_json_error_with serializes candidates when the slice is
+    // non-empty. FR-004.
+    #[test]
+    fn render_json_error_with_includes_candidates_when_non_empty() {
+        let json =
+            render_json_error_with(ErrorCode::UsageError, "msg", None, &["a".to_owned()], false);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json).unwrap_or_else(|e| panic!("invalid JSON: {e}: {json}"));
+        assert_eq!(
+            parsed["error"]["candidates"],
+            serde_json::json!(["a"]),
+            "json: {json}"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,8 @@ use yomu::brief;
 use yomu::error::{self, ErrorCode};
 use yomu::io::write_output;
 use yomu::tools::{
-    MAX_IMPACT_DEPTH, MAX_SEARCH_LIMIT, MAX_SEARCH_OFFSET, Yomu, YomuError, YomuOptions,
+    InvalidInputKind, MAX_IMPACT_DEPTH, MAX_SEARCH_LIMIT, MAX_SEARCH_OFFSET, Yomu, YomuError,
+    YomuOptions,
 };
 
 #[derive(Parser)]
@@ -162,17 +163,29 @@ enum ModelCommand {
 }
 
 #[derive(Debug)]
+enum NoQueryReason {
+    /// stdin is a terminal and no query argument was provided.
+    Terminal,
+    /// stdin was piped but contained no query content.
+    EmptyStdin,
+}
+
+#[derive(Debug)]
 enum QueryError {
-    /// No query available (terminal, empty stdin) — expected with --from
-    NoQuery(String),
-    /// I/O failure reading stdin — must propagate
+    /// No query available — expected with --from, an error otherwise.
+    NoQuery(NoQueryReason),
+    /// I/O failure reading stdin — must propagate.
     Io(String),
 }
 
 impl fmt::Display for QueryError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::NoQuery(msg) | Self::Io(msg) => f.write_str(msg),
+            Self::NoQuery(NoQueryReason::Terminal) => {
+                f.write_str("query required: pass as argument or pipe via stdin")
+            }
+            Self::NoQuery(NoQueryReason::EmptyStdin) => f.write_str("empty query from stdin"),
+            Self::Io(msg) => f.write_str(msg),
         }
     }
 }
@@ -263,8 +276,12 @@ fn main() -> ExitCode {
             } else {
                 let query = match resolve_query(query) {
                     Ok(q) => q,
-                    Err(e @ QueryError::NoQuery(_)) => {
-                        return emit_error_code(&e.to_string(), ErrorCode::UsageError, json);
+                    Err(QueryError::NoQuery(reason)) => {
+                        let kind = match reason {
+                            NoQueryReason::Terminal => InvalidInputKind::QueryOrFromRequired,
+                            NoQueryReason::EmptyStdin => InvalidInputKind::EmptyQuery,
+                        };
+                        return emit_error(&YomuError::InvalidInput(kind), json);
                     }
                     Err(e @ QueryError::Io(_)) => {
                         return emit_error_code(&e.to_string(), ErrorCode::IoError, json);
@@ -323,7 +340,23 @@ fn main() -> ExitCode {
 }
 
 fn emit_error(err: &YomuError, json: bool) -> ExitCode {
-    emit_error_code(&err.to_string(), err.error_code(), json)
+    let code = err.error_code();
+    let message = err.to_string();
+    if json {
+        eprintln!(
+            "{}",
+            error::render_json_error_with(
+                code,
+                &message,
+                err.next_step(),
+                &err.candidates(),
+                err.retryable(),
+            )
+        );
+    } else {
+        exit_error(&message);
+    }
+    ExitCode::from(code.exit_code())
 }
 
 fn emit_error_code(message: &str, code: ErrorCode, json: bool) -> ExitCode {
@@ -399,9 +432,7 @@ fn resolve_query_with(
         Some(q) if q != "-" => Ok(q),
         _ => {
             if stdin_is_terminal {
-                return Err(QueryError::NoQuery(
-                    "query required: pass as argument or pipe via stdin".into(),
-                ));
+                return Err(QueryError::NoQuery(NoQueryReason::Terminal));
             }
             let mut buf = String::new();
             stdin
@@ -409,7 +440,7 @@ fn resolve_query_with(
                 .map_err(|e| QueryError::Io(format!("failed to read from stdin: {e}")))?;
             let trimmed = buf.trim();
             if trimmed.is_empty() {
-                return Err(QueryError::NoQuery("empty query from stdin".into()));
+                return Err(QueryError::NoQuery(NoQueryReason::EmptyStdin));
             }
             Ok(trimmed.to_owned())
         }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -70,9 +70,9 @@ fn determine_index_state(stats: &storage::IndexStatus) -> IndexState {
 
 fn validate_path(path: &str) -> Result<(), YomuError> {
     if path.contains("..") || Path::new(path).is_absolute() {
-        return Err(YomuError::InvalidInput(format!(
-            "'{path}' must be a relative path and must not contain '..'"
-        )));
+        return Err(YomuError::InvalidInput(InvalidInputKind::PathTraversal {
+            path: path.to_owned(),
+        }));
     }
     Ok(())
 }
@@ -138,13 +138,34 @@ impl Default for YomuConfig {
 }
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum InvalidInputKind {
+    #[error("'{path}' must be a relative path and must not contain '..'")]
+    PathTraversal { path: String },
+    #[error("query must not be empty")]
+    EmptyQuery,
+    #[error("query exceeds max length ({actual} > {max})")]
+    QueryTooLong { max: usize, actual: usize },
+    #[error("query or --from is required")]
+    QueryOrFromRequired,
+    #[error("target must not be empty")]
+    EmptyTarget,
+    #[error("index is empty — run `yomu index` first, or use `yomu search` which auto-indexes")]
+    EmptyIndex,
+    #[error("task must not be empty")]
+    EmptyTask,
+    #[error("--seed-symbol is not yet implemented; use --seed-file")]
+    SeedSymbolUnimplemented,
+}
+
+#[derive(Debug, thiserror::Error)]
 pub enum YomuError {
     #[error("storage error: {0}")]
     Storage(#[from] storage::StorageError),
     #[error("io error: {0}")]
     Io(#[from] io::Error),
-    #[error("{0}")]
-    InvalidInput(String),
+    #[error(transparent)]
+    InvalidInput(#[from] InvalidInputKind),
     #[error("{0}")]
     Index(#[from] indexer::IndexError),
     #[error("internal error: {0}")]
@@ -153,6 +174,34 @@ pub enum YomuError {
     Query(#[from] QueryError),
     #[error("{0}")]
     EmbedderUnavailable(String),
+}
+
+impl InvalidInputKind {
+    /// Kind-specific recommendation an AI agent can follow without parsing
+    /// the message (FR-002, BR-002). Every variant carries a concrete next
+    /// step; the optional layer lives at [`YomuError::next_step`].
+    pub fn next_step(&self) -> String {
+        match self {
+            Self::PathTraversal { .. } => "use a relative path inside the project root".to_owned(),
+            Self::EmptyQuery => {
+                "run `yomu search \"<query>\"` or pipe a query via stdin".to_owned()
+            }
+            Self::QueryTooLong { max, .. } => format!("shorten query to ≤ {max} characters"),
+            Self::QueryOrFromRequired => {
+                "run `yomu search \"<query>\"` or `yomu search --from <file>`".to_owned()
+            }
+            Self::EmptyTarget => "provide a target path, e.g. `yomu impact src/foo.rs`".to_owned(),
+            Self::EmptyIndex => {
+                "run `yomu index` first, or use `yomu search` which auto-indexes".to_owned()
+            }
+            Self::EmptyTask => {
+                "provide a task description, e.g. `yomu brief \"add OAuth login\"`".to_owned()
+            }
+            Self::SeedSymbolUnimplemented => {
+                "use `--seed-file` instead of `--seed-symbol`".to_owned()
+            }
+        }
+    }
 }
 
 impl YomuError {
@@ -166,6 +215,40 @@ impl YomuError {
             Self::Io(_) => ErrorCode::IoError,
             Self::EmbedderUnavailable(_) => ErrorCode::TempFailure,
         }
+    }
+
+    /// ADR-0060 next_step: kind-specific recommendation for the agent.
+    /// `None` for variants without an actionable agent recommendation
+    /// (`Io`, `Query`).
+    pub fn next_step(&self) -> Option<String> {
+        match self {
+            Self::InvalidInput(kind) => Some(kind.next_step()),
+            Self::Index(_) => Some("run `yomu rebuild` to recreate the index".to_owned()),
+            Self::Storage(_) => {
+                Some("check `.yomu/index.db` permissions and disk space".to_owned())
+            }
+            Self::Io(_) | Self::Query(_) => None,
+            Self::EmbedderUnavailable(_) => Some(
+                "run `yomu model download`, or set `YOMU_EMBED=0` for FTS-only mode".to_owned(),
+            ),
+            Self::Internal(_) => Some(
+                "file a bug report with the reproduction command and `RUST_BACKTRACE=1`".to_owned(),
+            ),
+        }
+    }
+
+    /// ADR-0060 candidates: always empty in this PR (FR-V02). Dynamic
+    /// provisioning (e.g. listing index files for `EmptyTarget`) is deferred
+    /// to a follow-up PR; the field is wired so envelope shape stays stable.
+    pub fn candidates(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    /// ADR-0060 retryable: `true` only when immediate retry can recover
+    /// (`EmbedderUnavailable` after a model download). All other variants
+    /// require a different input or operator action (BR-001).
+    pub fn retryable(&self) -> bool {
+        matches!(self, Self::EmbedderUnavailable(_))
     }
 }
 
@@ -246,12 +329,13 @@ impl Yomu {
     ) -> Result<String, YomuError> {
         if let Some(q) = query {
             if q.is_empty() {
-                return Err(YomuError::InvalidInput("query must not be empty".into()));
+                return Err(YomuError::InvalidInput(InvalidInputKind::EmptyQuery));
             }
             if q.len() > MAX_QUERY_LENGTH {
-                return Err(YomuError::InvalidInput(format!(
-                    "query exceeds maximum length of {MAX_QUERY_LENGTH} characters"
-                )));
+                return Err(YomuError::InvalidInput(InvalidInputKind::QueryTooLong {
+                    max: MAX_QUERY_LENGTH,
+                    actual: q.len(),
+                }));
             }
         }
 
@@ -267,7 +351,7 @@ impl Yomu {
         }
 
         let query =
-            query.ok_or_else(|| YomuError::InvalidInput("query or --from is required".into()))?;
+            query.ok_or_else(|| YomuError::InvalidInput(InvalidInputKind::QueryOrFromRequired))?;
 
         let embedder = self.get_embedder();
         let offset = offset.min(MAX_SEARCH_OFFSET);
@@ -461,15 +545,12 @@ impl Yomu {
         semantic: bool,
     ) -> Result<String, YomuError> {
         if target.is_empty() {
-            return Err(YomuError::InvalidInput("target must not be empty".into()));
+            return Err(YomuError::InvalidInput(InvalidInputKind::EmptyTarget));
         }
 
         let stats = self.with_db(storage::get_stats)?;
         if stats.total_chunks == 0 {
-            return Err(YomuError::InvalidInput(
-                "index is empty — run `yomu index` first, or use `yomu search` which auto-indexes"
-                    .into(),
-            ));
+            return Err(YomuError::InvalidInput(InvalidInputKind::EmptyIndex));
         }
 
         let (file_path, parsed_symbol) = parse_impact_target(target);
@@ -667,7 +748,7 @@ impl Yomu {
 
     pub fn brief(&self, task: &brief::TaskBrief, json: bool) -> Result<String, YomuError> {
         if task.task.trim().is_empty() {
-            return Err(YomuError::InvalidInput("task must not be empty".into()));
+            return Err(YomuError::InvalidInput(InvalidInputKind::EmptyTask));
         }
         if task
             .seeds
@@ -675,7 +756,7 @@ impl Yomu {
             .any(|s| matches!(s.kind, brief::SeedKind::Symbol))
         {
             return Err(YomuError::InvalidInput(
-                "--seed-symbol is not yet implemented; use --seed-file".into(),
+                InvalidInputKind::SeedSymbolUnimplemented,
             ));
         }
 

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -103,7 +103,7 @@ fn search_rejects_long_query() {
         .search(Some(&long_query), 10, 0, &[], false, None)
         .unwrap_err();
     assert!(
-        err.to_string().contains("maximum length"),
+        err.to_string().contains("max length"),
         "expected max length error, got: {}",
         err
     );
@@ -2674,7 +2674,7 @@ fn io_err() -> io::Error {
 // T-EC101: InvalidInput → UsageError (64)
 #[test]
 fn error_code_invalid_input_is_usage_error() {
-    let err = YomuError::InvalidInput("bad".into());
+    let err = YomuError::InvalidInput(InvalidInputKind::EmptyQuery);
     assert_eq!(err.error_code(), ErrorCode::UsageError);
     assert_eq!(err.exit_code(), ExitCode::from(64));
 }
@@ -2794,4 +2794,214 @@ fn yomu_config_default_matches_empty_lookup() {
     assert_eq!(default.embed_disabled, empty.embed_disabled);
     assert_eq!(default.rerank_enabled, empty.rerank_enabled);
     assert_eq!(default.embed_budget, empty.embed_budget);
+}
+
+// --- Issue #192 Phase 2.2a: InvalidInputKind + YomuError methods ---
+//
+// Spec: .claude/workspace/planning/2026-05-20-192-phase-2-2a-error-payload/spec.md
+
+// T-001: 8 InvalidInputKind variants are constructible and exhaustively matched.
+// FR-001: classify each invalid-input case as one of 8 named variants.
+// The `match` has no `_` arm so adding a 9th variant breaks compilation.
+#[test]
+fn invalid_input_kind_has_eight_variants_with_exhaustive_match() {
+    let kinds = [
+        InvalidInputKind::PathTraversal {
+            path: "x".to_owned(),
+        },
+        InvalidInputKind::EmptyQuery,
+        InvalidInputKind::QueryTooLong {
+            max: 1000,
+            actual: 1500,
+        },
+        InvalidInputKind::QueryOrFromRequired,
+        InvalidInputKind::EmptyTarget,
+        InvalidInputKind::EmptyIndex,
+        InvalidInputKind::EmptyTask,
+        InvalidInputKind::SeedSymbolUnimplemented,
+    ];
+    let mut seen = 0_u8;
+    for kind in &kinds {
+        match kind {
+            InvalidInputKind::PathTraversal { .. } => seen |= 1 << 0,
+            InvalidInputKind::EmptyQuery => seen |= 1 << 1,
+            InvalidInputKind::QueryTooLong { .. } => seen |= 1 << 2,
+            InvalidInputKind::QueryOrFromRequired => seen |= 1 << 3,
+            InvalidInputKind::EmptyTarget => seen |= 1 << 4,
+            InvalidInputKind::EmptyIndex => seen |= 1 << 5,
+            InvalidInputKind::EmptyTask => seen |= 1 << 6,
+            InvalidInputKind::SeedSymbolUnimplemented => seen |= 1 << 7,
+        }
+    }
+    assert_eq!(
+        seen, 0xFF,
+        "expected all 8 InvalidInputKind variants to be visited, got bitmask {seen:#010b}"
+    );
+}
+
+// T-002: next_step for EmptyQuery returns the kind-specific guidance string.
+// FR-002, BR-002.
+#[test]
+fn next_step_for_empty_query_returns_search_or_stdin_hint() {
+    let e = YomuError::InvalidInput(InvalidInputKind::EmptyQuery);
+    assert_eq!(
+        e.next_step(),
+        Some("run `yomu search \"<query>\"` or pipe a query via stdin".to_owned())
+    );
+}
+
+// T-003: next_step for QueryTooLong embeds the `max` value verbatim.
+// FR-002. Uses U+2264 (≤) per spec mapping table.
+#[test]
+fn next_step_for_query_too_long_includes_max_characters() {
+    let e = YomuError::InvalidInput(InvalidInputKind::QueryTooLong {
+        max: 1000,
+        actual: 1500,
+    });
+    assert_eq!(
+        e.next_step(),
+        Some("shorten query to ≤ 1000 characters".to_owned())
+    );
+}
+
+// T-004: next_step for EmbedderUnavailable suggests model download + env opt-out.
+// FR-002, AS-002.
+#[test]
+fn next_step_for_embedder_unavailable_recommends_download_or_disable() {
+    let e = YomuError::EmbedderUnavailable("test".into());
+    assert_eq!(
+        e.next_step(),
+        Some("run `yomu model download`, or set `YOMU_EMBED=0` for FTS-only mode".to_owned())
+    );
+}
+
+// T-005: next_step for Index errors recommends `yomu rebuild`.
+// FR-002.
+#[test]
+fn next_step_for_index_error_recommends_rebuild() {
+    let inner = indexer::IndexError::Internal("x".into());
+    let e = YomuError::Index(inner);
+    assert_eq!(
+        e.next_step(),
+        Some("run `yomu rebuild` to recreate the index".to_owned())
+    );
+}
+
+// T-006: next_step for Storage errors recommends a permissions/disk check.
+// FR-002.
+#[test]
+fn next_step_for_storage_error_recommends_permission_check() {
+    let inner = storage::StorageError::LengthMismatch {
+        chunks: 1,
+        embeddings: 0,
+    };
+    let e = YomuError::Storage(inner);
+    assert_eq!(
+        e.next_step(),
+        Some("check `.yomu/index.db` permissions and disk space".to_owned())
+    );
+}
+
+// T-007: next_step for Internal errors recommends a bug report.
+// FR-002.
+#[test]
+fn next_step_for_internal_error_recommends_bug_report() {
+    let e = YomuError::Internal("bug".into());
+    assert_eq!(
+        e.next_step(),
+        Some("file a bug report with the reproduction command and `RUST_BACKTRACE=1`".to_owned())
+    );
+}
+
+// T-008: next_step for Io returns None (no actionable recommendation).
+// FR-V01.
+#[test]
+fn next_step_for_io_error_returns_none() {
+    let e = YomuError::Io(io::Error::other("x"));
+    assert_eq!(e.next_step(), None);
+}
+
+// T-009: next_step for Query returns None until Query subtypes gain hints.
+// FR-V01. Spec references QueryError::NoQuery, but YomuError::Query wraps
+// crate::query::QueryError (Storage / Embed / Internal). Internal is the
+// representative variant for FR-V01 coverage; see Suggestions for spec fix.
+#[test]
+fn next_step_for_query_error_returns_none() {
+    let inner = query::QueryError::Internal("x".into());
+    let e = YomuError::Query(inner);
+    assert_eq!(e.next_step(), None);
+}
+
+// T-010: retryable=true for EmbedderUnavailable (recoverable via model download).
+// FR-006, BR-001, AS-002.
+#[test]
+fn retryable_for_embedder_unavailable_is_true() {
+    let e = YomuError::EmbedderUnavailable("x".into());
+    assert!(e.retryable(), "EmbedderUnavailable must be retryable");
+}
+
+// T-011: retryable=false for Storage (disk/permission errors do not self-heal).
+// FR-006, BR-001.
+#[test]
+fn retryable_for_storage_error_is_false() {
+    let inner = storage::StorageError::LengthMismatch {
+        chunks: 1,
+        embeddings: 0,
+    };
+    let e = YomuError::Storage(inner);
+    assert!(
+        !e.retryable(),
+        "Storage errors are not immediately retryable"
+    );
+}
+
+// T-012: retryable=false for Io.
+// FR-006, BR-001.
+#[test]
+fn retryable_for_io_error_is_false() {
+    let e = YomuError::Io(io::Error::other("x"));
+    assert!(!e.retryable(), "Io errors are not immediately retryable");
+}
+
+// T-013: retryable=false for Index.
+// FR-006, BR-001.
+#[test]
+fn retryable_for_index_error_is_false() {
+    let inner = indexer::IndexError::Internal("x".into());
+    let e = YomuError::Index(inner);
+    assert!(!e.retryable(), "Index errors are not immediately retryable");
+}
+
+// T-014: retryable=false for Internal (logic bugs do not recover on retry).
+// FR-006, BR-001.
+#[test]
+fn retryable_for_internal_error_is_false() {
+    let e = YomuError::Internal("x".into());
+    assert!(!e.retryable(), "Internal errors are not retryable");
+}
+
+// T-015: retryable=false for Query.
+// FR-006, BR-001.
+#[test]
+fn retryable_for_query_error_is_false() {
+    let inner = query::QueryError::Internal("x".into());
+    let e = YomuError::Query(inner);
+    assert!(!e.retryable(), "Query errors are not immediately retryable");
+}
+
+// T-016: retryable=false for InvalidInput (caller must supply different input).
+// FR-006, BR-001.
+#[test]
+fn retryable_for_invalid_input_is_false() {
+    let e = YomuError::InvalidInput(InvalidInputKind::EmptyQuery);
+    assert!(!e.retryable(), "InvalidInput errors are not retryable");
+}
+
+// T-017: candidates() returns empty Vec for every variant in this PR.
+// FR-V02. Dynamic provisioning is deferred to a follow-up PR; the field
+// is wired but always empty so the envelope shape stays stable at v0.17.0.
+#[test]
+fn candidates_returns_empty_vec_for_invalid_input() {
+    let e = YomuError::InvalidInput(InvalidInputKind::EmptyTarget);
+    assert_eq!(e.candidates(), Vec::<String>::new());
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1161,6 +1161,33 @@ fn search_no_query_json_emits_usage_error_envelope() {
     );
 }
 
+// T-022: `yomu --json search` (no query, empty stdin) emits an envelope
+// containing the kind-specific next_step plus retryable: false.
+// Spec: Issue #192 Phase 2.2a — FR-002, FR-005.
+// This is the integration counterpart to T-002 (next_step) and T-016
+// (retryable=false for InvalidInput): the agent reading stderr must see
+// both fields so it can branch without re-parsing the message.
+#[test]
+fn search_no_query_json_envelope_includes_next_step_and_retryable() {
+    let output = yomu_cmd()
+        .args(["--json", "search"])
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    assert!(!output.status.success(), "expected non-zero exit");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let parsed: serde_json::Value = serde_json::from_str(stderr.trim())
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}: {stderr}"));
+    assert!(
+        parsed["error"]["next_step"].is_string(),
+        "expected error.next_step string per FR-002: {stderr}"
+    );
+    assert_eq!(
+        parsed["error"]["retryable"], false,
+        "expected error.retryable=false per FR-005/FR-006 for InvalidInput: {stderr}"
+    );
+}
+
 // T-700: after_help_examples_present_for_all_commands [Issue #192 Phase 2.3]
 #[test]
 fn after_help_examples_present_for_all_commands() {


### PR DESCRIPTION
## 目的

`yomu` の JSON エラー envelope に AI agent 向けの 3 フィールドを追加する。エラー受信時に agent が「次に何をすべきか」を envelope 単独で判断できるようにするのが狙い (ADR-0060)。本 PR は #192 の Phase 2.2a (envelope 拡張部分)。

## 変更点

- `ErrorPayload` 拡張: 常時 `retryable` (boolean)、条件付き `next_step` (string) と `candidates` (array)。`skip_serializing_if` で空時はキー自体を出力しない。
- `InvalidInputKind` enum 化: ad-hoc な `InvalidInput(String)` を `#[non_exhaustive]` な 8 variant に置換し、variant ごとに `next_step()` メッセージを定義。
- `YomuError::{next_step, candidates, retryable}` 追加: envelope 各フィールドへ dispatch。`retryable=true` は `EmbedderUnavailable` のみ (recovery が `yomu model download` で可能なため)。
- `NoQueryReason` enum 追加 (`main.rs`): `resolve_query_with` の "empty" 文字列比較 dispatch を型駆動 match に置換。
- `render_json_error` は thin wrapper として維持し、`render_json_error_with(code, message, next_step, candidates, retryable)` を canonical entry に。

## スコープ

- **対象外**: degraded/notes 経路展開 (Phase 2.2b)、`candidates` の動的供給 (現状は配線のみで常に空)。両方とも別 PR / 別 issue。

## 設計判断

- `candidates` を配線のみ・常時空で確定: v0.17.0 で envelope shape を固める。後付け追加だと consumer 側で再変更が必要になるため、shape breaking を 1 回で済ませる。
- `InvalidInputKind::next_step() -> String` (`Option` ではない): variant ごとに必ず next_step を持つので `Option` 層は `YomuError::next_step` に集約。reviewer-readability の always-Some smell 指摘を反映。
- `QueryError::NoQuery(String)` ではなく `NoQueryReason` enum: 文字列 `msg.contains("empty")` での dispatch は wording 変更で壊れるため型駆動に置換。
- 既存 `render_json_error` 互換維持: `QueryError::Io` / `clap error` 経路は `emit_error_code` → `render_json_error` のまま。内部で `_with(..., None, &[], false)` を呼ぶので、`retryable` は全経路で envelope に出る。

## 破壊的変更

JSON エラー envelope shape を拡張:

- `retryable` (boolean) が常に追加される (既存に無かったキー)。
- `next_step` (string) と `candidates` (array) は条件付き追加 (empty/None 時は省略)。
- `T-EC002` の literal-equality test の期待値を `,"retryable":false}` 込みに更新。
- `InvalidInput(String)` → `InvalidInput(InvalidInputKind)` (8 variant) に置換。message 文字列の wording も一部変更 (例: `"maximum length"` → `"max length ({actual} > {max})"`)。

旧 shape に strict match している consumer は追従が必要。`retryable` は additive だが必ず出るため、未知 key を許容しない consumer では壊れる。

## 動作確認

1. `cargo test --lib` → 515 passed
2. `cargo test --test cli_integration` → 44 passed
3. `cargo clippy --all-targets` → warning-free
4. `cargo run -- search "x"` を embedder 未配置で実行 → JSON envelope に `"retryable":true`, `"next_step":"Run: yomu model download"` が出ることを確認 (手動)

## 関連

- Closes #192 の Phase 2.2a 部分 (Phase 2.2b / 2.3 は別 PR)
- Parent: #156 (ADR-0060 適用)
- 後続 issue: `candidates` の動的供給 (本 PR マージ後に切る)
