### PR TITLE
success envelope に degraded / notes を追加 (Phase 2.2b)

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -91,6 +91,54 @@ pub(crate) fn parse_impact_target(target: &str) -> (&str, Option<&str>) {
     (target, None)
 }
 
+/// Routes with no current degraded condition (status, impact) per FR-006:
+/// the constants are emitted so the envelope shape stays uniform across all
+/// six JSON success routes.
+fn never_degraded() -> (bool, Vec<String>) {
+    (false, Vec::new())
+}
+
+/// degraded signal for chunking-mutation routes (index, rebuild) per FR-002 / FR-003.
+/// Single source of truth for the note wording so production and tests stay in sync.
+pub(super) fn degraded_for_chunk_errors(files_errored: u32) -> (bool, Vec<String>) {
+    if files_errored > 0 {
+        (
+            true,
+            vec![format!("failed to chunk {} file(s)", files_errored)],
+        )
+    } else {
+        (false, Vec::new())
+    }
+}
+
+/// degraded signal for dry-run preview per FR-004.
+pub(super) fn degraded_for_dry_run_errors(files_errored: u32) -> (bool, Vec<String>) {
+    if files_errored > 0 {
+        (
+            true,
+            vec![format!("check failed for {} file(s)", files_errored)],
+        )
+    } else {
+        (false, Vec::new())
+    }
+}
+
+/// degraded signal for embed when fewer chunks landed than requested per FR-005.
+pub(super) fn degraded_for_embed_skips(pending: u32, chunks_embedded: u32) -> (bool, Vec<String>) {
+    let skipped = pending.saturating_sub(chunks_embedded);
+    if skipped > 0 {
+        (
+            true,
+            vec![format!(
+                "embedded {} of {} chunks ({} skipped)",
+                chunks_embedded, pending, skipped
+            )],
+        )
+    } else {
+        (false, Vec::new())
+    }
+}
+
 /// Runtime options for [`Yomu::new`] / [`Yomu::with_root`].
 ///
 /// Each field is OR-merged with the corresponding env var, so either source
@@ -479,7 +527,8 @@ impl Yomu {
         let stats = self.with_db(storage::get_stats)?;
 
         if json {
-            return Ok(format_index_json(&chunk_result, &stats));
+            let (degraded, notes) = degraded_for_chunk_errors(chunk_result.files_errored);
+            return Ok(format_index_json(&chunk_result, &stats, degraded, notes));
         }
 
         let mut text = format!(
@@ -499,7 +548,8 @@ impl Yomu {
         let preview = indexer::dry_run_index(&self.conn, &self.root, force)?;
 
         if json {
-            return Ok(format_dry_run_json(&preview));
+            let (degraded, notes) = degraded_for_dry_run_errors(preview.files_errored);
+            return Ok(format_dry_run_json(&preview, degraded, notes));
         }
 
         let mut text = format!(
@@ -523,7 +573,8 @@ impl Yomu {
         let stats = self.with_db(storage::get_stats)?;
 
         if json {
-            return Ok(format_rebuild_json(&chunk_result, &stats));
+            let (degraded, notes) = degraded_for_chunk_errors(chunk_result.files_errored);
+            return Ok(format_rebuild_json(&chunk_result, &stats, degraded, notes));
         }
 
         let mut text = format!(
@@ -585,6 +636,7 @@ impl Yomu {
         };
 
         if json {
+            let (degraded, notes) = never_degraded();
             return Ok(format_impact_json(
                 target,
                 file_in_index,
@@ -592,6 +644,8 @@ impl Yomu {
                 &direct_refs,
                 &symbol_refs,
                 &semantic_related,
+                degraded,
+                notes,
             ));
         }
 
@@ -623,7 +677,8 @@ impl Yomu {
         })?;
 
         if json {
-            return Ok(format_status_json(&stats, ref_count));
+            let (degraded, notes) = never_degraded();
+            return Ok(format_status_json(&stats, ref_count, degraded, notes));
         }
 
         Ok(format!(
@@ -676,8 +731,16 @@ impl Yomu {
         )?;
 
         match result {
-            Some(r) => Ok(format_embed_result(&r, json)),
-            None => Ok(format_embed_result(&indexer::EmbedResult::default(), json)),
+            Some(r) => {
+                let (degraded, notes) = degraded_for_embed_skips(pending, r.chunks_embedded);
+                Ok(format_embed_result(&r, json, degraded, notes))
+            }
+            None => Ok(format_embed_result(
+                &indexer::EmbedResult::default(),
+                json,
+                false,
+                Vec::new(),
+            )),
         }
     }
 

--- a/src/tools/format.rs
+++ b/src/tools/format.rs
@@ -1,3 +1,9 @@
+//! JSON envelope formatters for success-path routes.
+//!
+//! `degraded` and `notes` fields are always serialized (no `skip_serializing_if`)
+//! so consumers can read `obj.degraded` without an existence guard
+//! (OUTCOME.md Behavior #4, spec FR-001 / BR-002).
+
 use std::collections::{HashMap, HashSet};
 
 use serde::Serialize;
@@ -302,12 +308,16 @@ struct JsonMutationResult {
     files_errored: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     coverage: Option<String>,
+    degraded: bool,
+    notes: Vec<String>,
 }
 
 fn format_mutation_json(
     result: &indexer::IndexResult,
     stats: &storage::IndexStatus,
     include_skipped: bool,
+    degraded: bool,
+    notes: Vec<String>,
 ) -> String {
     let resp = JsonMutationResult {
         files_processed: result.files_processed,
@@ -319,6 +329,8 @@ fn format_mutation_json(
         },
         files_errored: result.files_errored,
         coverage: coverage_if_partial(stats),
+        degraded,
+        notes,
     };
     serde_json::to_string(&resp).unwrap()
 }
@@ -326,15 +338,19 @@ fn format_mutation_json(
 pub(super) fn format_index_json(
     result: &indexer::IndexResult,
     stats: &storage::IndexStatus,
+    degraded: bool,
+    notes: Vec<String>,
 ) -> String {
-    format_mutation_json(result, stats, true)
+    format_mutation_json(result, stats, true, degraded, notes)
 }
 
 pub(super) fn format_rebuild_json(
     result: &indexer::IndexResult,
     stats: &storage::IndexStatus,
+    degraded: bool,
+    notes: Vec<String>,
 ) -> String {
-    format_mutation_json(result, stats, false)
+    format_mutation_json(result, stats, false, degraded, notes)
 }
 
 #[derive(Serialize)]
@@ -344,15 +360,23 @@ struct JsonDryRunResult {
     total_files: u32,
     files_errored: u32,
     orphans_to_remove: u32,
+    degraded: bool,
+    notes: Vec<String>,
 }
 
-pub(super) fn format_dry_run_json(result: &indexer::DryRunResult) -> String {
+pub(super) fn format_dry_run_json(
+    result: &indexer::DryRunResult,
+    degraded: bool,
+    notes: Vec<String>,
+) -> String {
     let resp = JsonDryRunResult {
         files_to_process: result.files_to_process,
         files_to_skip: result.files_to_skip,
         total_files: result.total_files,
         files_errored: result.files_errored,
         orphans_to_remove: result.orphans_to_remove,
+        degraded,
+        notes,
     };
     serde_json::to_string(&resp).unwrap()
 }
@@ -366,17 +390,28 @@ struct JsonStatus {
     embed_percentage: u32,
     references: u32,
     last_indexed: Option<String>,
+    degraded: bool,
+    notes: Vec<String>,
 }
 
 #[derive(Serialize)]
 struct JsonEmbedResult {
     embedded: u32,
+    degraded: bool,
+    notes: Vec<String>,
 }
 
-pub(super) fn format_embed_result(result: &indexer::EmbedResult, json: bool) -> String {
+pub(super) fn format_embed_result(
+    result: &indexer::EmbedResult,
+    json: bool,
+    degraded: bool,
+    notes: Vec<String>,
+) -> String {
     if json {
         let resp = JsonEmbedResult {
             embedded: result.chunks_embedded,
+            degraded,
+            notes,
         };
         return serde_json::to_string(&resp).unwrap();
     }
@@ -389,7 +424,12 @@ pub(super) fn format_embed_result(result: &indexer::EmbedResult, json: bool) -> 
     )
 }
 
-pub(super) fn format_status_json(stats: &storage::IndexStatus, ref_count: u32) -> String {
+pub(super) fn format_status_json(
+    stats: &storage::IndexStatus,
+    ref_count: u32,
+    degraded: bool,
+    notes: Vec<String>,
+) -> String {
     let resp = JsonStatus {
         files: stats.total_files,
         chunks: stats.total_chunks,
@@ -398,6 +438,8 @@ pub(super) fn format_status_json(stats: &storage::IndexStatus, ref_count: u32) -
         embed_percentage: stats.embed_percentage(),
         references: ref_count,
         last_indexed: stats.last_indexed_at.clone(),
+        degraded,
+        notes,
     };
     serde_json::to_string(&resp).unwrap()
 }
@@ -432,8 +474,12 @@ struct JsonImpactResult<'a> {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     semantic_related: Vec<JsonSemanticRelated<'a>>,
     total: usize,
+    degraded: bool,
+    notes: Vec<String>,
 }
 
+// 8 args per Spec NFR-002: envelope shape stability over arg-count cap.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn format_impact_json(
     target: &str,
     file_in_index: bool,
@@ -441,6 +487,8 @@ pub(super) fn format_impact_json(
     direct_refs: &HashMap<String, Vec<storage::DirectReference>>,
     symbol_refs: &[String],
     semantic_related: &[storage::SearchResult],
+    degraded: bool,
+    notes: Vec<String>,
 ) -> String {
     let deps: Vec<JsonDependent> = dependents
         .iter()
@@ -478,6 +526,8 @@ pub(super) fn format_impact_json(
         symbol_refs,
         semantic_related: sem,
         total: dependents.len(),
+        degraded,
+        notes,
     };
     serde_json::to_string(&resp).unwrap()
 }

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -3005,3 +3005,292 @@ fn candidates_returns_empty_vec_for_invalid_input() {
     let e = YomuError::InvalidInput(InvalidInputKind::EmptyTarget);
     assert_eq!(e.candidates(), Vec::<String>::new());
 }
+
+// Phase 2.2b — degraded / notes coverage on 6 routes (issue #192).
+// Spec: .claude/workspace/planning/2026-05-20-192-phase-2-2b-degraded-notes/spec.md
+
+fn make_index_result(files_errored: u32) -> indexer::IndexResult {
+    indexer::IndexResult {
+        files_processed: 3,
+        chunks_created: 10,
+        files_skipped: 0,
+        files_errored,
+    }
+}
+
+fn make_index_status() -> storage::IndexStatus {
+    storage::IndexStatus {
+        total_files: 3,
+        total_chunks: 10,
+        embeddable_chunks: 10,
+        embedded_chunks: 10,
+        last_indexed_at: Some("2026-05-20".to_owned()),
+    }
+}
+
+fn make_partial_index_status() -> storage::IndexStatus {
+    // embedded < embeddable → triggers JsonMutationResult.coverage Some(...).
+    // Used by T-009 to assert notes never duplicates the coverage wording.
+    storage::IndexStatus {
+        total_files: 3,
+        total_chunks: 10,
+        embeddable_chunks: 10,
+        embedded_chunks: 4,
+        last_indexed_at: Some("2026-05-20".to_owned()),
+    }
+}
+
+fn make_dry_run_result(files_errored: u32) -> indexer::DryRunResult {
+    indexer::DryRunResult {
+        total_files: 10,
+        files_to_process: 5,
+        files_to_skip: 4,
+        files_errored,
+        orphans_to_remove: 0,
+    }
+}
+
+fn make_embed_result(chunks_embedded: u32, files_completed: u32) -> indexer::EmbedResult {
+    indexer::EmbedResult {
+        chunks_embedded,
+        files_completed,
+    }
+}
+
+// T-001: format_index_json with files_errored=2 marks degraded and explains why.
+// FR-002.
+#[test]
+fn format_index_json_with_errored_files_is_degraded() {
+    let result = make_index_result(2);
+    let stats = make_index_status();
+    let (degraded, notes) = super::degraded_for_chunk_errors(result.files_errored);
+
+    let json = format_index_json(&result, &stats, degraded, notes);
+    let parsed = parse_json(&json);
+
+    assert_eq!(
+        parsed["degraded"], true,
+        "files_errored=2 should set degraded=true: {json}"
+    );
+    let notes_arr = parsed["notes"]
+        .as_array()
+        .unwrap_or_else(|| panic!("notes must be an array: {json}"));
+    assert!(
+        notes_arr
+            .iter()
+            .any(|n| n.as_str() == Some("failed to chunk 2 file(s)")),
+        "notes must contain failure description, got: {json}"
+    );
+}
+
+// T-002: format_index_json with no errors emits degraded=false and empty notes.
+// FR-002 (false branch) + FR-001 (key always present).
+#[test]
+fn format_index_json_with_no_errors_is_not_degraded() {
+    let result = make_index_result(0);
+    let stats = make_index_status();
+    let (degraded, notes) = super::degraded_for_chunk_errors(result.files_errored);
+
+    let json = format_index_json(&result, &stats, degraded, notes);
+    let parsed = parse_json(&json);
+
+    assert_eq!(
+        parsed["degraded"], false,
+        "files_errored=0 should set degraded=false: {json}"
+    );
+    let notes_arr = parsed["notes"]
+        .as_array()
+        .unwrap_or_else(|| panic!("notes must be an array: {json}"));
+    assert!(
+        notes_arr.is_empty(),
+        "notes must be empty when not degraded, got: {json}"
+    );
+}
+
+// T-003: format_rebuild_json with files_errored=1 marks degraded.
+// FR-003.
+#[test]
+fn format_rebuild_json_with_errored_files_is_degraded() {
+    let result = indexer::IndexResult {
+        files_processed: 2,
+        chunks_created: 8,
+        files_skipped: 0,
+        files_errored: 1,
+    };
+    let stats = make_index_status();
+    let (degraded, notes) = super::degraded_for_chunk_errors(result.files_errored);
+
+    let json = format_rebuild_json(&result, &stats, degraded, notes);
+    let parsed = parse_json(&json);
+
+    assert_eq!(
+        parsed["degraded"], true,
+        "rebuild with files_errored=1 should set degraded=true: {json}"
+    );
+    let notes_arr = parsed["notes"]
+        .as_array()
+        .unwrap_or_else(|| panic!("notes must be an array: {json}"));
+    assert!(
+        notes_arr
+            .iter()
+            .any(|n| n.as_str() == Some("failed to chunk 1 file(s)")),
+        "rebuild notes must contain failure description, got: {json}"
+    );
+}
+
+// T-004: format_dry_run_json with files_errored=1 marks degraded with check wording.
+// FR-004.
+#[test]
+fn format_dry_run_json_with_errored_files_is_degraded() {
+    let result = make_dry_run_result(1);
+    let (degraded, notes) = super::degraded_for_dry_run_errors(result.files_errored);
+
+    let json = format_dry_run_json(&result, degraded, notes);
+    let parsed = parse_json(&json);
+
+    assert_eq!(
+        parsed["degraded"], true,
+        "dry_run with files_errored=1 should set degraded=true: {json}"
+    );
+    let notes_arr = parsed["notes"]
+        .as_array()
+        .unwrap_or_else(|| panic!("notes must be an array: {json}"));
+    assert!(
+        notes_arr
+            .iter()
+            .any(|n| n.as_str() == Some("check failed for 1 file(s)")),
+        "dry_run notes must contain check-failure description, got: {json}"
+    );
+}
+
+// T-005: format_embed_result with pending > chunks_embedded marks degraded
+// and reports both counts plus the skip count.
+// FR-005.
+#[test]
+fn format_embed_result_pending_exceeds_embedded_is_degraded() {
+    let pending = 5;
+    let result = make_embed_result(3, 2);
+    let (degraded, notes) = super::degraded_for_embed_skips(pending, result.chunks_embedded);
+
+    let json = format_embed_result(&result, true, degraded, notes);
+    let parsed = parse_json(&json);
+
+    assert_eq!(
+        parsed["degraded"], true,
+        "pending=5 > embedded=3 should set degraded=true: {json}"
+    );
+    let notes_arr = parsed["notes"]
+        .as_array()
+        .unwrap_or_else(|| panic!("notes must be an array: {json}"));
+    assert!(
+        notes_arr
+            .iter()
+            .any(|n| n.as_str() == Some("embedded 3 of 5 chunks (2 skipped)")),
+        "embed notes must contain count breakdown, got: {json}"
+    );
+}
+
+// T-006: format_status_json with (false, vec![]) emits constant non-degraded envelope.
+// FR-006 (status is never degraded by this route's design).
+#[test]
+fn format_status_json_is_never_degraded() {
+    let stats = make_index_status();
+    let ref_count = 7;
+
+    let json = format_status_json(&stats, ref_count, false, vec![]);
+    let parsed = parse_json(&json);
+
+    assert_eq!(
+        parsed["degraded"], false,
+        "status must emit degraded=false: {json}"
+    );
+    let notes_arr = parsed["notes"]
+        .as_array()
+        .unwrap_or_else(|| panic!("notes must be an array: {json}"));
+    assert!(notes_arr.is_empty(), "status notes must be empty: {json}");
+}
+
+// T-007: format_impact_json with (false, vec![]) emits constant non-degraded envelope.
+// FR-006 (impact is never degraded by this route's design).
+#[test]
+fn format_impact_json_is_never_degraded() {
+    let dependents: Vec<storage::Dependent> = vec![];
+    let direct_refs: HashMap<String, Vec<storage::DirectReference>> = HashMap::new();
+    let symbol_refs: Vec<String> = vec![];
+    let semantic_related: Vec<storage::SearchResult> = vec![];
+
+    let json = format_impact_json(
+        "src/Button.tsx",
+        true,
+        &dependents,
+        &direct_refs,
+        &symbol_refs,
+        &semantic_related,
+        false,
+        vec![],
+    );
+    let parsed = parse_json(&json);
+
+    assert_eq!(
+        parsed["degraded"], false,
+        "impact must emit degraded=false: {json}"
+    );
+    let notes_arr = parsed["notes"]
+        .as_array()
+        .unwrap_or_else(|| panic!("notes must be an array: {json}"));
+    assert!(notes_arr.is_empty(), "impact notes must be empty: {json}");
+}
+
+// T-009: format_index_json notes never duplicate the coverage wording.
+// FR-007 (negative assertion); paired with AS-002 (coverage field unchanged).
+#[test]
+fn format_index_json_notes_does_not_mention_coverage() {
+    // files_errored=1 forces degraded=true so notes is non-empty.
+    // partial embedding means JsonMutationResult.coverage is Some(...),
+    // so the JSON does contain the word "coverage" — but only in that field,
+    // never in the notes array.
+    let result = make_index_result(1);
+    let stats = make_partial_index_status();
+    let (degraded, notes) = super::degraded_for_chunk_errors(result.files_errored);
+
+    let json = format_index_json(&result, &stats, degraded, notes);
+    let parsed = parse_json(&json);
+
+    let notes_arr = parsed["notes"]
+        .as_array()
+        .unwrap_or_else(|| panic!("notes must be an array: {json}"));
+    assert!(
+        !notes_arr.is_empty(),
+        "precondition: notes non-empty: {json}"
+    );
+    assert!(
+        !notes_arr
+            .iter()
+            .any(|n| n.as_str().is_some_and(|s| s.contains("coverage"))),
+        "notes must not mention coverage (FR-007), got: {json}"
+    );
+}
+
+// T-010: format_embed_result with pending == chunks_embedded is not degraded.
+// FR-005 (boundary at equality) + BR-001 (coverage partiality is not a degradation).
+#[test]
+fn format_embed_result_full_completion_is_not_degraded() {
+    let pending = 5;
+    let result = make_embed_result(5, 5);
+    let (degraded, notes) = super::degraded_for_embed_skips(pending, result.chunks_embedded);
+
+    let json = format_embed_result(&result, true, degraded, notes);
+    let parsed = parse_json(&json);
+
+    assert_eq!(
+        parsed["degraded"], false,
+        "pending==embedded should set degraded=false: {json}"
+    );
+    let notes_arr = parsed["notes"]
+        .as_array()
+        .unwrap_or_else(|| panic!("notes must be an array: {json}"));
+    assert!(
+        notes_arr.is_empty(),
+        "notes must be empty when fully embedded: {json}"
+    );
+}

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1214,3 +1214,75 @@ fn after_help_examples_present_for_all_commands() {
         );
     }
 }
+
+// T-008: degraded_and_notes_present_in_all_six_json_routes [Issue #192 Phase 2.2b]
+// FR-001: every JSON success envelope on index, rebuild, dry_run, embed, status,
+// and impact carries both `degraded` (boolean) and `notes` (array).
+//
+// Setup: indexed project with a single .tsx file plus an importer so impact has
+// a target. `yomu embed` runs against an indexed-but-empty-pending state (no
+// embedder configured; pending=0 → embed_with_spinners short-circuits) so the
+// JSON envelope is produced without requiring a model.
+#[test]
+fn degraded_and_notes_present_in_all_six_json_routes() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(
+        src.join("Button.tsx"),
+        "export function Button() { return <button>Click</button>; }\n",
+    )
+    .unwrap();
+    fs::write(
+        src.join("App.tsx"),
+        "import { Button } from './Button';\nexport function App() { return <Button/>; }\n",
+    )
+    .unwrap();
+    Command::new("git")
+        .args(["init"])
+        .current_dir(dir.path())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .unwrap();
+
+    // Routes that produce JSON without external state.
+    // `embed` runs without GEMINI_API_KEY / YOMU_EMBED so it neither tries the
+    // network nor a downloaded model — pending=0 because the index does not
+    // exist yet at first call, so embed short-circuits to a default result.
+    // Order matters: embed runs before index so its pending count is 0.
+    let routes: &[(&str, &[&str])] = &[
+        ("index --dry-run", &["--json", "index", "--dry-run"]),
+        ("embed (pending=0)", &["--json", "embed"]),
+        ("index", &["--json", "index"]),
+        ("status", &["--json", "status"]),
+        ("rebuild", &["--json", "rebuild"]),
+        ("impact", &["--json", "impact", "src/Button.tsx"]),
+    ];
+
+    for (label, args) in routes {
+        let output = yomu_cmd()
+            .args(*args)
+            .current_dir(dir.path())
+            .env_remove("YOMU_EMBED")
+            .env_remove("GEMINI_API_KEY")
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "{label} should succeed, stderr: {stderr}, stdout: {stdout}"
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&stdout)
+            .unwrap_or_else(|e| panic!("{label} should emit JSON: {e}\n{stdout}"));
+        assert!(
+            parsed["degraded"].is_boolean(),
+            "{label} must include `degraded` as boolean: {stdout}"
+        );
+        assert!(
+            parsed["notes"].is_array(),
+            "{label} must include `notes` as array: {stdout}"
+        );
+    }
+}


### PR DESCRIPTION
## 目的

`yomu` の success-path JSON envelope (6 経路: index / rebuild / dry_run / embed / status / impact) に AI agent 向けの `degraded: bool` と `notes: string[]` を追加する。Phase 2.2a (#196) で error envelope は揃っており、success envelope を後回しにすると shape 変更が 2 段階になるため 1 PR で揃える。本 PR は #192 の Phase 2.2b。

## 変更点

- `src/tools/format.rs` の 5 つの Json* struct (JsonMutationResult / JsonDryRunResult / JsonStatus / JsonEmbedResult / JsonImpactResult) に `degraded: bool` / `notes: Vec<String>` を追加。`skip_serializing_if` なし (常時出力)。
- `src/tools.rs` に 4 つの helper を追加: `never_degraded()` (status/impact 用)、`degraded_for_chunk_errors` (index/rebuild)、`degraded_for_dry_run_errors` (dry_run)、`degraded_for_embed_skips` (embed)。note wording の単一情報源化。
- 6 経路の call site で helper 経由で `(degraded, notes)` を流す。意味のある degraded 条件は 4 経路のみ:
  - index / rebuild: `files_errored > 0` → `"failed to chunk N file(s)"`
  - dry_run: `files_errored > 0` → `"check failed for N file(s)"`
  - embed: `chunks_embedded < pending` → `"embedded X of Y chunks (Z skipped)"`
- status / impact は `never_degraded()` で常時 `(false, [])` (現状 runtime fault 経路なし、shape 統一のため出力)。
- format.rs に module-level doc comment 追加 (`degraded`/`notes` always-emit の理由と spec citation)。

## スコープ

- **対象外**: `coverage` field の deprecate / 統合 (別 issue)、status/impact に意味のある degraded を後付けする探索 (別 issue)、recall / sae 等への共通 envelope 抽出 (別 ADR / 別 PR)。
- error envelope (next_step / candidates / retryable) は #196 で完了。

## 設計判断

- **shape 統一を優先**: status / impact に意味のある degraded 条件は現状ない (state の steady-state 部分性 / 構造的に別 field で表現) が、OUTCOME.md Behavior #4 (consumer が後処理なしに JSON を読む) を outcome として優先し、6 経路で常に同じキー集合を出す。spec FR-V01 / BR-001 で semantic を lock。
- **Approach A (per-route inline)** を採用: 既存 `JsonResponse` (format.rs:260) の pattern と一致。Approach B (envelope wrapper, `Enveloped<T>`) は YAGNI + serde flatten のキー衝突リスクで除外、Approach C (trait + builder) は over-engineered で除外 (critic-design + advisor で確認)。
- **note wording の単一情報源化**: production helper を `pub(super)` で tools.rs に置き、production の 4 call site と test helper の両方から呼ぶ。wording 変更時に test も lockstep で fail する。
- **`format_impact_json` 8 引数**: spec NFR-002 で 8 args ceiling を許容 (envelope shape stability over arg-count cap)。`#[allow(clippy::too_many_arguments)]` に inline rationale comment 付与。

## 破壊的変更

success JSON envelope shape を拡張:

- 6 経路全てに `degraded` (boolean) と `notes` (array) キーが常に追加される (additive)。
- 既存キーの wording / 型は変更なし。
- 旧 shape に strict match している consumer (未知キーを許容しない実装) は追従が必要。

## 動作確認

1. `cargo test --lib` → 524 passed (515 → 524、新規 unit 9 個追加)
2. `cargo test --test cli_integration` → 45 passed (44 → 45、T-008 で 6 経路の key 存在を整合検証)
3. `cargo clippy --all-targets` → warning-free
4. `cargo run -- index --json` (errored file ありの workspace) で `"degraded":true`, `"notes":["failed to chunk N file(s)"]` を観測 (手動)

## 関連

- Closes #192 の Phase 2.2b 部分 (Phase 2.2a (#196) と Phase 2.3 (#195) は別 PR)
- Parent: #156 (ADR-0060 適用)
- Follow-up: #197 (`candidates` 動的供給)
- ADR-0060: agent-friendly CLI principles (補強パターン「構造化 degradation signal」を 6 経路完成)
