### PR TITLE
EmptyTarget エラーに index 済みファイル候補を載せる (#197)

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -48,6 +48,10 @@ pub const MAX_SEARCH_OFFSET: u32 = 500;
 pub const MAX_IMPACT_DEPTH: u32 = 10;
 const BRIEF_MAX_INFERRED_SEEDS: u32 = 5;
 
+/// Upper bound for the EmptyTarget `candidates` retry list emitted to agents.
+/// A short, scannable list is the actionable shape per ADR-0060.
+pub const MAX_EMPTY_TARGET_CANDIDATES: usize = 10;
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum IndexState {
     Empty,
@@ -197,7 +201,7 @@ pub enum InvalidInputKind {
     #[error("query or --from is required")]
     QueryOrFromRequired,
     #[error("target must not be empty")]
-    EmptyTarget,
+    EmptyTarget { candidates: Vec<String> },
     #[error("index is empty — run `yomu index` first, or use `yomu search` which auto-indexes")]
     EmptyIndex,
     #[error("task must not be empty")]
@@ -238,7 +242,9 @@ impl InvalidInputKind {
             Self::QueryOrFromRequired => {
                 "run `yomu search \"<query>\"` or `yomu search --from <file>`".to_owned()
             }
-            Self::EmptyTarget => "provide a target path, e.g. `yomu impact src/foo.rs`".to_owned(),
+            Self::EmptyTarget { .. } => {
+                "provide a target path, e.g. `yomu impact src/foo.rs`".to_owned()
+            }
             Self::EmptyIndex => {
                 "run `yomu index` first, or use `yomu search` which auto-indexes".to_owned()
             }
@@ -285,11 +291,15 @@ impl YomuError {
         }
     }
 
-    /// ADR-0060 candidates: always empty in this PR (FR-V02). Dynamic
-    /// provisioning (e.g. listing index files for `EmptyTarget`) is deferred
-    /// to a follow-up PR; the field is wired so envelope shape stays stable.
+    /// ADR-0060 candidates: file paths the agent can try next. Currently
+    /// only `EmptyTarget` carries them (lexicographically-first
+    /// `MAX_EMPTY_TARGET_CANDIDATES` indexed paths); all other variants
+    /// return an empty vector (FR-001 / BR-004 / #197).
     pub fn candidates(&self) -> Vec<String> {
-        Vec::new()
+        match self {
+            Self::InvalidInput(InvalidInputKind::EmptyTarget { candidates }) => candidates.clone(),
+            _ => Vec::new(),
+        }
     }
 
     /// ADR-0060 retryable: `true` only when immediate retry can recover
@@ -587,6 +597,22 @@ impl Yomu {
         Ok(text)
     }
 
+    /// Lexicographically-first `max` indexed file paths. Used to populate
+    /// `EmptyTarget.candidates` when impact is invoked with an empty target
+    /// (#197). Storage failures degrade to an empty vector so the primary
+    /// `UsageError` code is preserved (FR-004 / BR-002). Ordering is
+    /// alphabetical (not ranked) to keep results deterministic across runs.
+    fn first_indexed_paths(&self, max: usize) -> Vec<String> {
+        self.with_db(storage::get_all_file_paths)
+            .map(|set| {
+                let mut v: Vec<String> = set.into_iter().collect();
+                v.sort();
+                v.truncate(max);
+                v
+            })
+            .unwrap_or_default()
+    }
+
     pub fn impact(
         &self,
         target: &str,
@@ -596,7 +622,10 @@ impl Yomu {
         semantic: bool,
     ) -> Result<String, YomuError> {
         if target.is_empty() {
-            return Err(YomuError::InvalidInput(InvalidInputKind::EmptyTarget));
+            let candidates = self.first_indexed_paths(MAX_EMPTY_TARGET_CANDIDATES);
+            return Err(YomuError::InvalidInput(InvalidInputKind::EmptyTarget {
+                candidates,
+            }));
         }
 
         let stats = self.with_db(storage::get_stats)?;

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -2815,7 +2815,7 @@ fn invalid_input_kind_has_eight_variants_with_exhaustive_match() {
             actual: 1500,
         },
         InvalidInputKind::QueryOrFromRequired,
-        InvalidInputKind::EmptyTarget,
+        InvalidInputKind::EmptyTarget { candidates: vec![] },
         InvalidInputKind::EmptyIndex,
         InvalidInputKind::EmptyTask,
         InvalidInputKind::SeedSymbolUnimplemented,
@@ -2827,7 +2827,7 @@ fn invalid_input_kind_has_eight_variants_with_exhaustive_match() {
             InvalidInputKind::EmptyQuery => seen |= 1 << 1,
             InvalidInputKind::QueryTooLong { .. } => seen |= 1 << 2,
             InvalidInputKind::QueryOrFromRequired => seen |= 1 << 3,
-            InvalidInputKind::EmptyTarget => seen |= 1 << 4,
+            InvalidInputKind::EmptyTarget { .. } => seen |= 1 << 4,
             InvalidInputKind::EmptyIndex => seen |= 1 << 5,
             InvalidInputKind::EmptyTask => seen |= 1 << 6,
             InvalidInputKind::SeedSymbolUnimplemented => seen |= 1 << 7,
@@ -2997,14 +2997,10 @@ fn retryable_for_invalid_input_is_false() {
     assert!(!e.retryable(), "InvalidInput errors are not retryable");
 }
 
-// T-017: candidates() returns empty Vec for every variant in this PR.
-// FR-V02. Dynamic provisioning is deferred to a follow-up PR; the field
-// is wired but always empty so the envelope shape stays stable at v0.17.0.
-#[test]
-fn candidates_returns_empty_vec_for_invalid_input() {
-    let e = YomuError::InvalidInput(InvalidInputKind::EmptyTarget);
-    assert_eq!(e.candidates(), Vec::<String>::new());
-}
+// T-017 (Issue #192 Phase 2.2a): superseded by T-005 (Issue #197).
+// The original assertion "EmptyTarget returns empty candidates" inverts FR-001
+// of #197 (EmptyTarget now carries candidates). T-005 below covers the
+// remaining contract: non-EmptyTarget variants return Vec::new().
 
 // Phase 2.2b — degraded / notes coverage on 6 routes (issue #192).
 // Spec: .claude/workspace/planning/2026-05-20-192-phase-2-2b-degraded-notes/spec.md
@@ -3293,4 +3289,142 @@ fn format_embed_result_full_completion_is_not_degraded() {
         notes_arr.is_empty(),
         "notes must be empty when fully embedded: {json}"
     );
+}
+
+// --- Issue #197: EmptyTarget candidates dynamic supply ---
+//
+// Spec: .claude/workspace/planning/2026-05-20-197-empty-target-candidates/spec.md
+//
+// FR-001..FR-005 cover the `EmptyTarget` cause carrying an index-sourced
+// `Vec<String>` of file paths. T-001 to T-003 exercise the unit boundary;
+// T-005 fixes the negative half (other variants return empty Vec). T-004 is
+// the integration counterpart and lives in `tests/cli_integration.rs`.
+
+/// Unwraps an `EmptyTarget` cause and returns its `candidates` vector.
+/// Panics for every other variant — used in T-001 / T-002 / T-003 to keep
+/// each test's body assertion-focused. T-005 covers the negative dispatch.
+fn unwrap_empty_target_candidates(err: YomuError) -> Vec<String> {
+    match err {
+        YomuError::InvalidInput(InvalidInputKind::EmptyTarget { candidates }) => candidates,
+        other => panic!("expected EmptyTarget with candidates, got: {other:?}"),
+    }
+}
+
+/// Inserts a placeholder chunk row at each given `file_path`. The only column
+/// `get_all_file_paths` reads is `file_path`, so the chunk body is arbitrary;
+/// using `insert_chunk_row` (vs. `insert_chunk`) skips vector embedding writes
+/// and keeps the helper minimal.
+fn seed_chunks_at_paths(conn: &storage::Db, paths: &[&str]) {
+    for path in paths {
+        storage::insert_chunk_row(
+            conn,
+            path,
+            &storage::NewChunk {
+                chunk_type: &storage::ChunkType::Other,
+                name: None,
+                content: "x",
+                start_line: 1,
+                end_line: 1,
+                parent_index: None,
+            },
+            "hash",
+            None,
+        )
+        .unwrap();
+    }
+}
+
+// T-001: impact_empty_target_returns_candidates_with_indexed_paths
+// FR-001. With 3 indexed paths in already-sorted insertion order, the
+// EmptyTarget cause carries those 3 paths verbatim.
+#[test]
+fn impact_empty_target_returns_candidates_with_indexed_paths() {
+    let (y, _dir) = test_yomu();
+    {
+        let conn = y.conn.lock().unwrap();
+        seed_chunks_at_paths(&conn, &["a.rs", "b.rs", "c.rs"]);
+    }
+    let candidates =
+        unwrap_empty_target_candidates(y.impact("", None, 0, false, false).unwrap_err());
+    assert_eq!(
+        candidates,
+        vec!["a.rs".to_owned(), "b.rs".to_owned(), "c.rs".to_owned()],
+        "FR-001: candidates must contain the 3 indexed paths"
+    );
+}
+
+// T-002: impact_empty_target_sorts_candidates_alphabetically
+// FR-002. Paths inserted in non-sorted order ("c", "a", "b") must emerge
+// alphabetically. Distinct from T-001 because the input order differs from
+// the asserted output — this is the test that actually discriminates sorting
+// from insertion-order accidental ordering.
+#[test]
+fn impact_empty_target_sorts_candidates_alphabetically() {
+    let (y, _dir) = test_yomu();
+    {
+        let conn = y.conn.lock().unwrap();
+        seed_chunks_at_paths(&conn, &["c.rs", "a.rs", "b.rs"]);
+    }
+    let candidates =
+        unwrap_empty_target_candidates(y.impact("", None, 0, false, false).unwrap_err());
+    assert_eq!(
+        candidates,
+        vec!["a.rs".to_owned(), "b.rs".to_owned(), "c.rs".to_owned()],
+        "FR-002: candidates must be sorted lexicographically regardless of insertion order"
+    );
+}
+
+// T-003: impact_empty_target_caps_candidates_at_ten
+// FR-003. With 15 paths "file00.rs" .. "file14.rs", the candidate list is
+// truncated to the lexicographically-first 10 entries.
+#[test]
+fn impact_empty_target_caps_candidates_at_ten() {
+    let (y, _dir) = test_yomu();
+    let paths: Vec<String> = (0..15).map(|i| format!("file{i:02}.rs")).collect();
+    let path_refs: Vec<&str> = paths.iter().map(String::as_str).collect();
+    {
+        let conn = y.conn.lock().unwrap();
+        seed_chunks_at_paths(&conn, &path_refs);
+    }
+    let candidates =
+        unwrap_empty_target_candidates(y.impact("", None, 0, false, false).unwrap_err());
+    let expected: Vec<String> = (0..super::MAX_EMPTY_TARGET_CANDIDATES)
+        .map(|i| format!("file{i:02}.rs"))
+        .collect();
+    assert_eq!(
+        candidates,
+        expected,
+        "FR-003: candidates must be the lexicographically-first MAX_EMPTY_TARGET_CANDIDATES paths (capped at {})",
+        super::MAX_EMPTY_TARGET_CANDIDATES
+    );
+}
+
+// T-005: candidates_returns_empty_for_non_empty_target_variants
+// FR-001 (negative). YomuError::candidates() returns Vec::new() for every
+// InvalidInputKind variant except EmptyTarget. This guards the dispatch
+// branch from regressing into a catch-all that leaks data through other
+// variants.
+#[test]
+fn candidates_returns_empty_for_non_empty_target_variants() {
+    let cases: Vec<YomuError> = vec![
+        YomuError::InvalidInput(InvalidInputKind::PathTraversal {
+            path: "x".to_owned(),
+        }),
+        YomuError::InvalidInput(InvalidInputKind::EmptyQuery),
+        YomuError::InvalidInput(InvalidInputKind::QueryTooLong {
+            max: 1000,
+            actual: 1500,
+        }),
+        YomuError::InvalidInput(InvalidInputKind::QueryOrFromRequired),
+        YomuError::InvalidInput(InvalidInputKind::EmptyIndex),
+        YomuError::InvalidInput(InvalidInputKind::EmptyTask),
+        YomuError::InvalidInput(InvalidInputKind::SeedSymbolUnimplemented),
+    ];
+    for e in &cases {
+        assert_eq!(
+            e.candidates(),
+            Vec::<String>::new(),
+            "FR-001 negative: non-EmptyTarget variant {e:?} must return Vec::new()"
+        );
+    }
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1286,3 +1286,49 @@ fn degraded_and_notes_present_in_all_six_json_routes() {
         );
     }
 }
+
+// --- Issue #197: EmptyTarget candidates dynamic supply ---
+//
+// Spec: .claude/workspace/planning/2026-05-20-197-empty-target-candidates/spec.md
+
+// T-004: impact_empty_target_json_envelope_includes_candidates_array
+// FR-001, FR-005, NFR-003. Against a workspace with at least one indexed
+// file, `yomu impact "" --json` must:
+//   - exit non-zero with USAGE_ERROR (FR-001 routing via InvalidInput)
+//   - emit `error.candidates` as a non-empty array of strings (FR-005 + NFR-003:
+//     key present iff candidate list is non-empty)
+#[test]
+fn impact_empty_target_json_envelope_includes_candidates_array() {
+    let dir = setup_project();
+    let output = yomu_cmd()
+        .args(["--json", "impact", ""])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "empty target must exit non-zero, stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let parsed: serde_json::Value = serde_json::from_str(stderr.trim())
+        .unwrap_or_else(|e| panic!("expected JSON envelope on stderr: {e}: {stderr}"));
+    assert_eq!(
+        parsed["error"]["code"], "USAGE_ERROR",
+        "FR-001: empty target routes through InvalidInput → USAGE_ERROR: {stderr}"
+    );
+    let candidates = parsed["error"]["candidates"]
+        .as_array()
+        .unwrap_or_else(|| panic!("FR-005: error.candidates must be an array: {stderr}"));
+    assert!(
+        !candidates.is_empty(),
+        "FR-005 / NFR-003: candidates array must be non-empty when index has files: {stderr}"
+    );
+    for v in candidates {
+        assert!(
+            v.is_string(),
+            "FR-005: every candidates entry must be a string, got: {v:?} in {stderr}"
+        );
+    }
+}


### PR DESCRIPTION
## 目的

`yomu --json impact ""` (target 空指定) でエラーを受けた AI agent が、同じ envelope の `error.candidates` から index 済みファイルを直接見て次試行の target を選べるようにする。これまでは別途 `yomu status` を呼ぶ必要があった (1 round trip 増)。Phase 2.2a (#196) で `candidates` を wire-up 済み、本 PR で value を供給して closing。

## 変更点

- `InvalidInputKind::EmptyTarget` を unit → struct variant `{ candidates: Vec<String> }` に変更 (Approach A)。
- `impact` route で target 空指定時、`storage::get_all_file_paths` 経由で取得した path を alphabetical sort + `take(MAX_EMPTY_TARGET_CANDIDATES)` (= 10) で candidates 構築。
- `Yomu::first_indexed_paths(max)` helper を追加 (storage failure 時は `.unwrap_or_default()` で空 Vec に degrade、primary `UsageError` 保持)。
- `YomuError::candidates()` で `EmptyTarget { candidates }` variant を match して clone 返却、他 variant は `Vec::new()`。
- 既存の `EmptyTarget` construction 箇所 (test) を struct shape に更新。
- test helper `unwrap_empty_target_candidates` 追加 (T-001/T-002/T-003 の match 重複を集約)。

## スコープ

- **対象**: `EmptyTarget` 1 variant のみ。candidates は agent が試行する file path 候補 (top 10 alphabetical)。
- **対象外**: 他 `InvalidInputKind` variant への candidates 拡張 (各 variant ごとに data/command の性質が違うため別 issue で評価)、`EmptyIndex` の command suggestion (data ではないため別 channel が筋)、success path での candidates (別 issue)、ranking を import count / recently-modified 等に変える改善 (alphabetical で十分、計測してから別途)。

## 設計判断

- **struct variant 化 (Approach A)**: Phase 2.2a の enum 化方針と一貫。type-safe で構築漏れを compile-time に検出。Approach B (builder on YomuError) は変えない variant に対しても candidates の opt-in を要求し silent regression リスク、Approach C (別 wrapper type) は ad-hoc で除外 (critic-design で confirm)。
- **`storage::get_all_file_paths` を採用**: 当初案の `get_files_by_import_count` は (a) signature が `(conn) -> Result<Vec<String>>` (引数 1)、(b) `WHERE v.chunk_id IS NULL` で un-embedded only を返すため embed 完了後は空 → 用途不一致。critic-design BLOCKER に対応して採用関数を変更。
- **alphabetical sort**: ranking 順位より N 個の候補集合自体が agent への質的価値。deterministic で test 容易。
- **`.unwrap_or_default()` で degrade**: DB fetch fail 時に `Storage` エラーで primary `UsageError` を mask しないように (critic-design MINOR)。
- **`MAX_EMPTY_TARGET_CANDIDATES = 10`**: agent が scan できる短いリスト (ADR-0060 補強パターン)。env 化は YAGNI。
- **scope 縮小に reject**: 「将来 EmptyIndex も candidates が必要になる」案 (critic-design MAJOR) は data vs command の性質差で却下。EmptyIndex は `next_step` の command 提案で対応済み。

## 動作確認

1. `cargo test --lib` → 527 passed (524 → 527、新規 unit 3 + T-005 既存 pass)
2. `cargo test --test cli_integration` → 46 passed (45 → 46、T-004 1 個追加)
3. `cargo clippy --all-targets` → warning-free
4. `cargo run -- impact "" --json` を fixture workspace で実行 → envelope に `"candidates":["...","..."]` が出ることを観測 (手動)

## 関連

- Closes #197 (Phase 2.2a follow-up)
- Parent: #192 (agent-friendly CLI envelope)
- Source: #196 (Phase 2.2a で wire-up 完了)
- ADR: ADR-0060 (補強パターン next_step + candidates)
