### PR TITLE
indexer 統合: corpus matcher を呼び出して per-chunk flags を populate

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,6 +1,7 @@
 pub mod chunker;
 mod embed;
 mod injection;
+mod source_kind;
 pub mod walker;
 
 use sha2::{Digest, Sha256};
@@ -32,6 +33,8 @@ pub enum IndexError {
     Io(#[from] io::Error),
     #[error("internal task failed: {0}")]
     Internal(String),
+    #[error("corpus init failed: {0}")]
+    CorpusInit(#[from] injection::CorpusError),
 }
 
 #[derive(Debug)]
@@ -58,21 +61,29 @@ struct PendingFile {
     parsed_imports: Vec<chunker::ParsedImport>,
     hash: String,
     mtime_epoch: Option<i64>,
+    source_kind: Option<String>,
+    /// One JSON array string per `raw_chunks` element. Invariant:
+    /// `injection_flags.len() == raw_chunks.len()`. Clean-scan is `"[]"`,
+    /// hit is `"[\"flag.id\", ...]"`. PR#2 always produces `Some` at the
+    /// schema level (NewChunk); the matcher-未走行 sentinel `None` is reserved
+    /// for post-PR#2 sampling scenarios.
+    injection_flags: Vec<String>,
 }
 
 impl PendingFile {
     fn to_new_chunks(&self) -> Vec<storage::NewChunk<'_>> {
         self.raw_chunks
             .iter()
-            .map(|c| storage::NewChunk {
+            .zip(self.injection_flags.iter())
+            .map(|(c, flags)| storage::NewChunk {
                 chunk_type: &c.chunk_type,
                 name: c.name.as_deref(),
                 content: &c.content,
                 start_line: c.start_line,
                 end_line: c.end_line,
                 parent_index: c.parent_index,
-                source_kind: None,
-                injection_flags: None,
+                source_kind: self.source_kind.as_deref(),
+                injection_flags: Some(flags.as_str()),
             })
             .collect()
     }
@@ -172,6 +183,7 @@ fn prepare_chunks(
     checked: CheckedFile,
     file_path: &Path,
     crate_name: Option<&str>,
+    corpus: &injection::Corpus,
 ) -> Option<PendingFile> {
     let ext = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
     let file_chunks = chunker::chunk_file_with_crate_name(&checked.source, ext, crate_name);
@@ -187,6 +199,21 @@ fn prepare_chunks(
         .map(|d| d.as_secs() as i64);
 
     let imports_text = file_chunks.imports.join("\n");
+    let source_kind = Some(source_kind::classify(&checked.rel_path).to_owned());
+    let injection_flags: Vec<String> = file_chunks
+        .chunks
+        .iter()
+        .map(|c| {
+            let flags = corpus.check_chunk(&c.content);
+            if flags.is_empty() {
+                "[]".to_owned()
+            } else {
+                serde_json::to_string(&flags)
+                    .expect("serde_json::to_string on Vec<String> is infallible")
+            }
+        })
+        .collect();
+
     Some(PendingFile {
         rel_path: checked.rel_path,
         raw_chunks: file_chunks.chunks,
@@ -194,6 +221,8 @@ fn prepare_chunks(
         parsed_imports: file_chunks.parsed_imports,
         hash: checked.hash,
         mtime_epoch,
+        source_kind,
+        injection_flags,
     })
 }
 
@@ -211,13 +240,14 @@ fn process_file(
     force: bool,
     resolver: &Resolver,
     rust_resolver: &RustResolver,
+    corpus: &injection::Corpus,
 ) -> Result<FileOutcome, IndexError> {
     let checked = match check_file(conn, rel_path, file_path, force)? {
         CheckResult::Changed(c) => c,
         CheckResult::Skip => return Ok(FileOutcome::Skipped),
         CheckResult::Error => return Ok(FileOutcome::Errored),
     };
-    let Some(pf) = prepare_chunks(checked, file_path, rust_resolver.crate_name()) else {
+    let Some(pf) = prepare_chunks(checked, file_path, rust_resolver.crate_name(), corpus) else {
         return Ok(FileOutcome::Skipped);
     };
     let n = pf.raw_chunks.len() as u32;
@@ -374,6 +404,9 @@ fn run_chunk_only_index_inner(
     root: &Path,
     force: bool,
 ) -> Result<IndexResult, IndexError> {
+    const CORPUS_YAML: &str = include_str!("../tests/fixtures/injection/corpus.yaml");
+    let corpus = injection::Corpus::load_from_str(CORPUS_YAML)?;
+
     let files = walker::walk_source_files(root);
     tracing::info!(
         file_count = files.len(),
@@ -404,6 +437,7 @@ fn run_chunk_only_index_inner(
                 force,
                 &resolver,
                 &rust_resolver,
+                &corpus,
             )? {
                 FileOutcome::Processed(n) => {
                     chunks_created += n;

--- a/src/indexer/injection.rs
+++ b/src/indexer/injection.rs
@@ -1,7 +1,7 @@
-#![allow(dead_code)]
-
+#[cfg(test)]
 use std::fs;
 use std::io;
+#[cfg(test)]
 use std::path::Path;
 
 use regex::Regex;
@@ -28,7 +28,11 @@ pub enum PatternType {
     Regex,
 }
 
+// `severity`, `category`, `description`, `source` are deserialized for schema
+// documentation but not read at runtime; per FR-206 / reviewer-spec they MAY
+// remain.
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 pub struct CorpusEntry {
     pub id: String,
     pub pattern_type: PatternType,
@@ -65,9 +69,14 @@ pub struct Corpus {
 }
 
 impl Corpus {
+    #[cfg(test)]
     pub fn load_from_yaml(path: &Path) -> Result<Self, CorpusError> {
         let text = fs::read_to_string(path)?;
-        let raw: CorpusFile = serde_yaml::from_str(&text)?;
+        Self::load_from_str(&text)
+    }
+
+    pub fn load_from_str(text: &str) -> Result<Self, CorpusError> {
+        let raw: CorpusFile = serde_yaml::from_str(text)?;
         let entries = raw
             .entries
             .into_iter()

--- a/src/indexer/injection/tests.rs
+++ b/src/indexer/injection/tests.rs
@@ -151,3 +151,84 @@ fn schema_rs_has_no_alter_add_column_for_v9_fields() {
         "schema.rs must not ALTER ADD COLUMN injection_flags (FR-003 / ADR-0069)"
     );
 }
+
+// T-205: load_from_str_returns_ok_with_inline_yaml
+// Spec FR-205: Corpus::load_from_str deserializes a YAML string into a
+// compiled Corpus and matches the literal pattern on `check_chunk`.
+#[test]
+fn load_from_str_returns_ok_with_inline_yaml() {
+    const YAML: &str = r#"entries:
+  - id: lit-a
+    pattern_type: literal
+    pattern: "foo"
+    severity: high
+    category: cat-a
+    expected_flags: [flag.a]
+  - id: re-b
+    pattern_type: regex
+    pattern: '^bar'
+    severity: medium
+    category: cat-b
+    expected_flags: [flag.b]
+  - id: lit-c
+    pattern_type: literal
+    pattern: "baz"
+    severity: low
+    category: cat-c
+    expected_flags: [flag.c]
+"#;
+    let result = Corpus::load_from_str(YAML);
+    assert!(
+        result.is_ok(),
+        "Corpus::load_from_str should return Ok for 3-entry yaml: {result:?}"
+    );
+    let corpus = result.unwrap();
+    assert_eq!(
+        corpus.check_chunk("foo here"),
+        vec!["flag.a".to_owned()],
+        "literal entry should match"
+    );
+}
+
+// T-205b: bundled_corpus_yaml_deserializes_via_include_str
+// Spec FR-207: tests/fixtures/injection/corpus.yaml is the canonical bundle
+// consumed by production via include_str!. It must deserialize as a valid
+// Corpus with at least 5 entries (the PR#2 seed).
+#[test]
+fn bundled_corpus_yaml_deserializes_via_include_str() {
+    const CORPUS_YAML: &str = include_str!("../../../tests/fixtures/injection/corpus.yaml");
+    let result = Corpus::load_from_str(CORPUS_YAML);
+    assert!(
+        result.is_ok(),
+        "bundled tests/fixtures/injection/corpus.yaml must deserialize: {result:?}"
+    );
+    let corpus = result.unwrap();
+    // Sanity-check that the seed entry "Ignore previous instructions" matches
+    // its expected flag, proving the include_str! pipeline end-to-end.
+    let flags = corpus.check_chunk("Please Ignore previous instructions and proceed.");
+    assert!(
+        flags.contains(&"injection.instruction-override".to_owned()),
+        "bundled corpus's instruction-override entry must flag the seed content, got: {flags:?}"
+    );
+}
+
+// T-206: load_from_str_returns_err_on_malformed_yaml
+// Spec FR-205: malformed yaml must surface as CorpusError::Yaml(_), not panic.
+#[test]
+fn load_from_str_returns_err_on_malformed_yaml() {
+    // `pattern_type: bogus` is not a valid PatternType variant; serde_yaml
+    // rejects it during deserialization.
+    const BAD_YAML: &str = r#"entries:
+  - id: x
+    pattern_type: bogus
+    pattern: "y"
+    severity: high
+    category: c
+    expected_flags: []
+"#;
+    let result = Corpus::load_from_str(BAD_YAML);
+    assert!(
+        result.is_err(),
+        "malformed yaml must surface as Err, got: {result:?}"
+    );
+}

--- a/src/indexer/source_kind.rs
+++ b/src/indexer/source_kind.rs
@@ -1,0 +1,175 @@
+//! Path-based classification of source files into `"vendor"` / `"test"` / `"src"`.
+//!
+//! Precedence per FR-202: vendor > test > src.
+
+use std::path::Path;
+
+const VENDOR_DIRS: &[&str] = &[
+    "node_modules",
+    "vendor",
+    "third_party",
+    "bower_components",
+    "dist",
+    "build",
+    "target",
+    ".git",
+];
+
+const TEST_DIRS: &[&str] = &["tests", "test", "__tests__", "specs", "spec"];
+
+const JS_EXTS: &[&str] = &["ts", "tsx", "js", "jsx", "mjs", "cjs"];
+
+const RS_GO_PY_EXTS: &[&str] = &["rs", "go", "py"];
+
+/// Classify a relative path into one of `"vendor"`, `"test"`, or `"src"`.
+///
+/// Precedence: vendor > test > src (FR-202).
+pub fn classify(rel_path: &str) -> &'static str {
+    let components: Vec<&str> = Path::new(rel_path)
+        .components()
+        .filter_map(|c| c.as_os_str().to_str())
+        .collect();
+
+    let ancestor_count = components.len().saturating_sub(1);
+    let ancestors = &components[..ancestor_count];
+
+    if ancestors.iter().any(|c| VENDOR_DIRS.contains(c)) {
+        return "vendor";
+    }
+    if ancestors.iter().any(|c| TEST_DIRS.contains(c)) {
+        return "test";
+    }
+    if components.last().is_some_and(|f| is_test_filename(f)) {
+        return "test";
+    }
+    "src"
+}
+
+fn is_test_filename(name: &str) -> bool {
+    let Some((stem, ext)) = name.rsplit_once('.') else {
+        return false;
+    };
+    if JS_EXTS.contains(&ext) && (stem.ends_with(".test") || stem.ends_with(".spec")) {
+        return true;
+    }
+    if RS_GO_PY_EXTS.contains(&ext) && stem.ends_with("_test") {
+        return true;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // T-201: vendor_ancestor_directory_names_return_vendor
+    //
+    // Perspective: Equivalence + Boundary. The 8 vendor directory names from
+    // FR-203 form one equivalence class; covering each member is the boundary
+    // of the set.
+    //
+    // FR: FR-201, FR-203
+    #[test]
+    fn vendor_ancestor_directory_names_return_vendor() {
+        let cases = [
+            "node_modules/x.ts",
+            "vendor/y.rs",
+            "third_party/z.js",
+            "bower_components/a.css",
+            "dist/b.html",
+            "build/c.md",
+            "target/d.rs",
+            ".git/e.txt",
+        ];
+        for input in cases {
+            assert_eq!(
+                classify(input),
+                "vendor",
+                "expected \"vendor\" for input {input:?}"
+            );
+        }
+    }
+
+    // T-202: test_extension_or_test_directory_returns_test
+    //
+    // Perspective: Branch + Equivalence. FR-204 defines two independent
+    // branches (extension match OR ancestor-directory match). Cover both.
+    //
+    // Decision table:
+    //
+    // | row | extension match | dir match | expected |
+    // | --- | --------------- | --------- | -------- |
+    // | a   | T               | F         | "test"   |
+    // | b   | F               | T         | "test"   |
+    //
+    // FR: FR-201, FR-204
+    #[test]
+    fn test_extension_or_test_directory_returns_test() {
+        let extension_cases = ["src/foo.test.ts", "src/bar.spec.tsx", "src/baz_test.rs"];
+        for input in extension_cases {
+            assert_eq!(
+                classify(input),
+                "test",
+                "expected \"test\" (extension branch) for input {input:?}"
+            );
+        }
+
+        let directory_cases = ["tests/foo.rs", "__tests__/bar.ts", "specs/baz.js"];
+        for input in directory_cases {
+            assert_eq!(
+                classify(input),
+                "test",
+                "expected \"test\" (directory branch) for input {input:?}"
+            );
+        }
+    }
+
+    // T-203: non_vendor_non_test_paths_return_src
+    //
+    // Perspective: Branch (fallback). Both vendor and test predicates are
+    // false; the function must fall through to "src".
+    //
+    // FR: FR-201
+    #[test]
+    fn non_vendor_non_test_paths_return_src() {
+        let cases = ["src/lib.rs", "lib/foo.ts", "app/handlers.rs", "README.md"];
+        for input in cases {
+            assert_eq!(
+                classify(input),
+                "src",
+                "expected \"src\" for input {input:?}"
+            );
+        }
+    }
+
+    // T-204: vendor_precedence_wins_over_test
+    //
+    // Perspective: Combination + Hazard. Decision table for the precedence
+    // rule (BR-202): when both vendor and test predicates are true, the
+    // result must be "vendor".
+    //
+    // | row | vendor match | test match | expected |
+    // | --- | ------------ | ---------- | -------- |
+    // |  1  | T            | T          | "vendor" |
+    //
+    // Inputs exercise the row from multiple angles (extension-based test
+    // signal nested under vendor; directory-based test signal nested under
+    // vendor) to harden the precedence assertion.
+    //
+    // FR: FR-202
+    #[test]
+    fn vendor_precedence_wins_over_test() {
+        let cases = [
+            "node_modules/foo/bar.test.js",
+            "vendor/specs/x.rs",
+            "dist/__tests__/y.ts",
+        ];
+        for input in cases {
+            assert_eq!(
+                classify(input),
+                "vendor",
+                "expected \"vendor\" (precedence over test) for input {input:?}"
+            );
+        }
+    }
+}

--- a/src/indexer/tests.rs
+++ b/src/indexer/tests.rs
@@ -983,3 +983,134 @@ fn run_chunk_only_index_counts_unreadable_files_as_errors() {
         "readable file should still be processed"
     );
 }
+
+// T-207: index_error_from_corpus_error_matches_corpus_init_variant
+// Spec FR-208 / FR-216 / FR-217: corpus init errors propagate as
+// IndexError::CorpusInit(CorpusError) via #[from].
+#[test]
+fn index_error_from_corpus_error_matches_corpus_init_variant() {
+    let corpus_err = injection::Corpus::load_from_str(
+        r#"entries:
+  - id: x
+    pattern_type: bogus
+    pattern: y
+    severity: high
+    category: c
+    expected_flags: []
+"#,
+    )
+    .unwrap_err();
+    let index_err: IndexError = corpus_err.into();
+    assert!(
+        matches!(index_err, IndexError::CorpusInit(_)),
+        "From<CorpusError> for IndexError must produce CorpusInit, got: {index_err:?}"
+    );
+}
+
+// T-208: prepare_chunks_populates_source_kind_and_injection_flags
+// Spec FR-209 / FR-212 / FR-213: prepare_chunks accepts &Corpus and
+// populates PendingFile.source_kind / injection_flags; to_new_chunks
+// borrows them into NewChunk.
+#[test]
+fn prepare_chunks_populates_source_kind_and_injection_flags() {
+    let corpus = injection::Corpus::load_from_str("entries: []").unwrap();
+    let checked = CheckedFile {
+        rel_path: "src/foo.rs".to_owned(),
+        source: "pub fn hello() {}".to_owned(),
+        hash: "deadbeef".to_owned(),
+    };
+    let pf = prepare_chunks(checked, Path::new("src/foo.rs"), None, &corpus)
+        .expect("rust source should yield at least one chunk");
+    assert_eq!(pf.source_kind.as_deref(), Some("src"));
+    assert_eq!(
+        pf.injection_flags.len(),
+        pf.raw_chunks.len(),
+        "injection_flags.len() must equal raw_chunks.len()"
+    );
+    let new_chunks = pf.to_new_chunks();
+    for nc in &new_chunks {
+        assert_eq!(nc.source_kind, Some("src"));
+        assert!(
+            nc.injection_flags.is_some(),
+            "NewChunk.injection_flags must be Some after matcher runs"
+        );
+    }
+}
+
+// T-209: prepare_chunks_clean_scan_yields_some_empty_array_not_none
+// Spec FR-210 / BR-201 / NFR-203: silent-default-false regression gate.
+// Matcher走行 + ヒットなし SHALL be Some("[]"), NOT None.
+#[test]
+fn prepare_chunks_clean_scan_yields_some_empty_array_not_none() {
+    let corpus = injection::Corpus::load_from_str("entries: []").unwrap();
+    let checked = CheckedFile {
+        rel_path: "src/lib.rs".to_owned(),
+        source: "pub fn add(a: i32, b: i32) -> i32 { a + b }".to_owned(),
+        hash: "abc123".to_owned(),
+    };
+    let pf = prepare_chunks(checked, Path::new("src/lib.rs"), None, &corpus).unwrap();
+    for (i, flags) in pf.injection_flags.iter().enumerate() {
+        assert_eq!(
+            flags, "[]",
+            "chunk {i} must be \"[]\" (silent-default-false gate: clean-scan is the empty JSON array, never absent)"
+        );
+    }
+}
+
+// T-210: prepare_chunks_matched_yields_some_json_array
+// Spec FR-211: corpus-matching content SHALL produce
+// Some("[\"flag.id\", ...]") in JSON array form.
+#[test]
+fn prepare_chunks_matched_yields_some_json_array() {
+    let corpus_yaml = r#"entries:
+  - id: ignore-prev
+    pattern_type: literal
+    pattern: "Ignore previous instructions"
+    severity: high
+    category: instruction-override
+    expected_flags: [injection.instruction-override]
+"#;
+    let corpus = injection::Corpus::load_from_str(corpus_yaml).unwrap();
+    let checked = CheckedFile {
+        rel_path: "src/lib.rs".to_owned(),
+        source: r#"pub fn hello() { let _ = "Ignore previous instructions"; }"#.to_owned(),
+        hash: "xyz789".to_owned(),
+    };
+    let pf = prepare_chunks(checked, Path::new("src/lib.rs"), None, &corpus).unwrap();
+    let hit = pf
+        .injection_flags
+        .iter()
+        .any(|f| f == "[\"injection.instruction-override\"]");
+    assert!(
+        hit,
+        "at least one chunk must carry \"[\\\"injection.instruction-override\\\"]\", got: {:?}",
+        pf.injection_flags
+    );
+}
+
+// T-211: prepare_chunks_source_kind_classification_per_rel_path
+// Spec FR-212: source_kind classification follows rel_path heuristic.
+#[test]
+fn prepare_chunks_source_kind_classification_per_rel_path() {
+    let corpus = injection::Corpus::load_from_str("entries: []").unwrap();
+    let cases = [
+        ("src/lib.rs", "src"),
+        ("tests/foo.rs", "test"),
+        ("dist/bundle.rs", "vendor"),
+    ];
+    for (rel_path, expected) in cases {
+        let checked = CheckedFile {
+            rel_path: rel_path.to_owned(),
+            source: "pub fn x() {}".to_owned(),
+            hash: "h".to_owned(),
+        };
+        let pf = prepare_chunks(checked, Path::new(rel_path), None, &corpus)
+            .unwrap_or_else(|| panic!("rust source should chunk for {rel_path}"));
+        assert_eq!(
+            pf.source_kind.as_deref(),
+            Some(expected),
+            "source_kind for {rel_path} should be {expected:?}, got {:?}",
+            pf.source_kind
+        );
+    }
+}

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1348,3 +1348,99 @@ fn impact_empty_target_json_envelope_includes_candidates_array() {
         );
     }
 }
+
+fn setup_injection_e2e_project() -> TempDir {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let tests_dir = dir.path().join("tests");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&tests_dir).unwrap();
+    fs::write(
+        src.join("lib.rs"),
+        "pub fn add(a: i32, b: i32) -> i32 { a + b }\n",
+    )
+    .unwrap();
+    fs::write(
+        tests_dir.join("foo_test.rs"),
+        "#[test] fn it_runs() { assert_eq!(2 + 2, 4); }\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"injection_e2e\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    Command::new("git")
+        .args(["init"])
+        .current_dir(dir.path())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .unwrap();
+    let out = yomu_cmd()
+        .arg("index")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "index failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    dir
+}
+
+// T-212: index_populates_injection_flags_for_all_chunks
+// Spec FR-214: After `yomu index`, every chunks row has non-NULL
+// injection_flags (matcher走行 over every chunk).
+#[test]
+fn index_populates_injection_flags_for_all_chunks() {
+    let dir = setup_injection_e2e_project();
+    let db_path = dir.path().join(".yomu").join("index.db");
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let null_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM chunks WHERE injection_flags IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let total_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM chunks", [], |row| row.get(0))
+        .unwrap();
+    assert!(total_count > 0, "fixture must produce at least one chunk");
+    assert_eq!(
+        null_count, 0,
+        "every chunk must have non-NULL injection_flags (got {null_count}/{total_count})"
+    );
+}
+
+// T-213: index_source_kind_is_subset_of_src_and_test
+// Spec FR-215: After `yomu index` on a repo with src + tests directories,
+// DISTINCT source_kind is a subset of {"src", "test"} (walker excludes
+// vendor via .gitignore).
+#[test]
+fn index_source_kind_is_subset_of_src_and_test() {
+    let dir = setup_injection_e2e_project();
+    let db_path = dir.path().join(".yomu").join("index.db");
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let mut stmt = conn
+        .prepare("SELECT DISTINCT source_kind FROM chunks ORDER BY source_kind")
+        .unwrap();
+    let kinds: Vec<String> = stmt
+        .query_map([], |row| row.get::<_, String>(0))
+        .unwrap()
+        .filter_map(Result::ok)
+        .collect();
+    assert!(!kinds.is_empty(), "chunks must have source_kind values");
+    for k in &kinds {
+        assert!(
+            k == "src" || k == "test",
+            "source_kind must be 'src' or 'test' (walker excludes vendor), got: {k:?}"
+        );
+    }
+    assert!(
+        kinds.contains(&"src".to_owned()),
+        "src fixture must produce src source_kind, got: {kinds:?}"
+    );
+}

--- a/tests/fixtures/injection/corpus.yaml
+++ b/tests/fixtures/injection/corpus.yaml
@@ -1,0 +1,69 @@
+# Canonical injection corpus bundled into the yomu binary via `include_str!`.
+#
+# PR#2 ships a minimal 5-entry seed. PR#4 (Verification) will expand this to
+# at least 30 entries with precision >= 0.90 / recall >= 0.95 per the design
+# verification-spec.
+#
+# Format reference:
+# .claude/workspace/planning/2026-05-19-indirect-prompt-injection-defense/verification-spec.md
+
+entries:
+  - id: ignore-previous-instructions
+    pattern_type: literal
+    pattern: "Ignore previous instructions"
+    severity: high
+    category: instruction-override
+    description: |
+      Classic prompt injection instruction. Observed in markdown, code
+      comments, and wiki snippets.
+    expected_flags:
+      - injection.instruction-override
+    source: https://owasp.org/www-project-top-10-for-large-language-model-applications/
+
+  - id: disregard-prior-instructions
+    pattern_type: literal
+    pattern: "Disregard all prior instructions"
+    severity: high
+    category: instruction-override
+    description: |
+      Alternate phrasing of the classic override directive.
+    expected_flags:
+      - injection.instruction-override
+    source: https://owasp.org/www-project-top-10-for-large-language-model-applications/
+
+  - id: system-role-injection
+    pattern_type: literal
+    pattern: "System: "
+    severity: medium
+    category: role-injection
+    description: |
+      Attempted role-injection by inserting a fake system-role prefix into
+      otherwise untrusted content.
+    expected_flags:
+      - injection.role-injection
+    source: https://owasp.org/www-project-top-10-for-large-language-model-applications/
+
+  - id: ignore-instructions-variant
+    pattern_type: regex
+    pattern: '(?i)ignore\s+(all|any)\s+(previous|prior)\s+(instructions|prompts)'
+    severity: high
+    category: instruction-override
+    description: |
+      Case-insensitive regex covering whitespace variants of the override
+      directive.
+    expected_flags:
+      - injection.instruction-override
+    source: https://owasp.org/www-project-top-10-for-large-language-model-applications/
+
+  - id: role-elevation-claim
+    pattern_type: regex
+    pattern: '(?i)\bas\s+(an?\s+)?(admin|root|sudo)\b'
+    severity: medium
+    category: role-elevation
+    description: |
+      Phrasing that asserts an elevated role in narrative form. Tuned to
+      catch sentence-level injections without flagging legitimate sysadmin
+      documentation that uses `admin`/`root` as nouns.
+    expected_flags:
+      - injection.role-elevation
+    source: https://owasp.org/www-project-top-10-for-large-language-model-applications/


### PR DESCRIPTION
## 背景

Issue #189 (ADR-0069) PR#2。PR#1 (#200) で `Corpus` プリミティブと `chunks.source_kind` / `injection_flags` 列は揃ったが、production caller がなく、index した全 chunk の 2 列が NULL のまま。PR#2 は indexer 起動時に bundle 済 corpus.yaml を `include_str!` で 1 度 load し、`prepare_chunks` 内で各 chunk に matcher を走らせて 2 列を populate する。silent-default-false 罠は clean-scan = `"[]"` literal で構造的に排除。

`--exclude-vendor` flag と JSON output 拡張は PR#3 に分離 (Narrow scope、user 確認済)。

## 変更内容

| File | 役割 |
|---|---|
| `src/indexer/source_kind.rs` (new) | path heuristic (vendor > test > src、8 vendor dirs + 5 test dirs + 拡張子) |
| `src/indexer/injection.rs` | `load_from_str` 追加 (`load_from_yaml` は `#[cfg(test)]` 化)、module-level `#![allow(dead_code)]` 削除 |
| `src/indexer.rs` | `IndexError::CorpusInit(#[from] CorpusError)` 追加、`PendingFile { source_kind, injection_flags }` 拡張、`&Corpus` を `run_chunk_only_index_inner → process_file → prepare_chunks` で thread、`to_new_chunks` は `.zip()` で borrow |
| `tests/fixtures/injection/corpus.yaml` (new) | 5-entry seed (OWASP LLM01:2025、PR#4 で 30 entries に拡充) |
| Tests | 14 new (T-201..T-213): classifier + load_from_str + integration + E2E |

## 検証

- [x] `cargo test --lib`: 551 passed (539 baseline + 12 new)
- [x] `cargo test --test cli_integration`: 48 passed (46 baseline + 2 new E2E)
- [x] `cargo clippy --all-targets`: warning-free
- [x] silent-default-false gate (T-209): clean-scan = `Some("[]")` を explicit assertion
- [x] include_str! corpus.yaml が compile 時に bundle される (T-205b)
- [x] E2E test (T-212/T-213): `yomu index` 実行後の DB で `injection_flags IS NULL` が 0 件 + `source_kind` が `{src, test}` の subset

## 設計判断

- **`PendingFile.injection_flags: Vec<String>` (Option 無し)**: reviewer-readability で初期案 `Vec<Option<String>>` を改善。Production は常に `Some` を NewChunk 境界で wrap、`None` の semantics は schema-level に残す。silent-default-false invariant を type-level に格上げ。
- **`include_str!("../tests/fixtures/injection/corpus.yaml")` で bundle**: ADR-0069 (単一バイナリ Constraint) + verification-spec.md line 12 (canonical path) に従う。`Corpus::load_from_str` を新規追加、`load_from_yaml` は `#[cfg(test)]` 化。
- **Empty flags short-circuit**: efficiency reviewer EFF-01 を反映。`serde_json::to_string(&empty_vec)` の per-chunk allocation を `"[]"` literal で短絡。corpus 拡大時 (PR#4) の余地として有効。
- **`enum SourceKind` を Not adopted**: reviewer-readability CQ-1 high。NewChunk / storage / 10+ test sites への literal 比較波及で wider scope、PR#3 候補に defer。
- **`SCHEMA_VERSION` bump (v9→v10) を Not adopted**: codex P1。PR#1 既存 v9 DB の NULL 列 backfill。3 storage migration test の assertion 更新が必要で scope を広げるため defer。Workaround: `.yomu/index.db` を退避して `yomu index` を実行する fresh 化手順を README に追記予定 (user base = thkt 1 人のため運用可能)。

## リスク

- 上記 schema bump defer: PR#2 merge 後の v9-fresh DB は unchanged file が CheckResult::Skip 路で `injection_flags = NULL` のまま残る。`yomu index --force` か DB 退避が必要。
- corpus.yaml は PR#2 seed 5 entries のみ。production matcher 精度は PR#4 (30 entries + precision/recall 測定) で評価。
- `process_file` 7 params (reviewer-readability CQ-2 medium): IndexingDeps 構造体への refactor は YAGNI Boundary (call sites = 1) 未到達のため PR#3 候補。

## 関連

- Refs: thkt/yomu#189
- ADR: 0069 (Adopt Yomu Indirect Prompt Injection Defense)
- Previous: #200 (PR#1 Foundation), merged 2026-05-20
- Next: PR#3 JSON 拡張 / PR#4 Verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)
