### PR TITLE
v9/v10 migration で stale file_references を wipe する

### DIFF
--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -255,6 +255,12 @@ fn migrate(conn: &Connection, from: u32, path: &Path) -> Result<(), StorageError
              DROP TABLE IF EXISTS fts_chunks_vocab; \
              DROP TABLE IF EXISTS fts_chunks;",
         )?;
+        // file_references rows reference chunks-side file_paths; wiping
+        // chunks invalidates them. Leaving the table populated would leak
+        // stale references across the reindex boundary into `impact` and
+        // `status` queries (F-005). The next `yomu index` rebuilds entries
+        // per surviving file via replace_file_references.
+        conn.execute_batch("DELETE FROM file_references")?;
         conn.execute_batch(DDL)?;
         conn.execute_batch(&ddl_vec_chunks())?;
         conn.execute_batch(DDL_EMBEDDED_CHUNK_IDS)?;
@@ -277,6 +283,9 @@ fn migrate(conn: &Connection, from: u32, path: &Path) -> Result<(), StorageError
              DROP TABLE IF EXISTS fts_chunks_vocab; \
              DROP TABLE IF EXISTS fts_chunks;",
         )?;
+        // Mirror v9 file_references wipe: dropping chunks invalidates the
+        // references; the next reindex repopulates per surviving file (F-005).
+        conn.execute_batch("DELETE FROM file_references")?;
         conn.execute_batch(DDL)?;
         conn.execute_batch(&ddl_vec_chunks())?;
         conn.execute_batch(DDL_EMBEDDED_CHUNK_IDS)?;

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -283,8 +283,9 @@ fn migrate(conn: &Connection, from: u32, path: &Path) -> Result<(), StorageError
              DROP TABLE IF EXISTS fts_chunks_vocab; \
              DROP TABLE IF EXISTS fts_chunks;",
         )?;
-        // Mirror v9 file_references wipe: dropping chunks invalidates the
-        // references; the next reindex repopulates per surviving file (F-005).
+        // Wipe file_references: dropping chunks invalidates the source_file /
+        // target_file rows (F-005). The next reindex repopulates per surviving
+        // file via replace_file_references.
         conn.execute_batch("DELETE FROM file_references")?;
         conn.execute_batch(DDL)?;
         conn.execute_batch(&ddl_vec_chunks())?;

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -4151,6 +4151,70 @@ fn opening_v8_store_drops_chunks_and_bumps_schema_version_to_10() {
     assert_eq!(version, "10");
 }
 
+// T-009: opening_v8_store_drops_stale_file_references
+// F-005 follow-up to ADR-0069 PR#4: pre-existing v9/v10 migration blocks drop
+// chunks but leave `file_references` populated, so post-migration
+// `impact`/`status` queries can surface references to files whose chunks no
+// longer exist (and which may have been deleted on disk before the reindex
+// runs). The migration must also wipe `file_references` so the next index
+// repopulates it deterministically per surviving file.
+#[test]
+fn opening_v8_store_drops_stale_file_references() {
+    const V8_DDL_WITH_REFS: &str = "
+        CREATE TABLE chunks (
+            id INTEGER PRIMARY KEY,
+            file_path TEXT NOT NULL,
+            chunk_type TEXT NOT NULL,
+            name TEXT,
+            content TEXT NOT NULL,
+            start_line INTEGER NOT NULL,
+            end_line INTEGER NOT NULL,
+            file_hash TEXT NOT NULL,
+            parent_chunk_id INTEGER REFERENCES chunks(id)
+        );
+        CREATE TABLE index_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        CREATE TABLE file_references (
+            id INTEGER PRIMARY KEY,
+            source_file TEXT NOT NULL,
+            target_file TEXT NOT NULL,
+            symbol_name TEXT,
+            ref_kind TEXT NOT NULL
+        );
+    ";
+
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("v8_refs.db");
+
+    {
+        let raw = Connection::open(&db_path).unwrap();
+        raw.execute_batch(V8_DDL_WITH_REFS).unwrap();
+        raw.execute(
+            "INSERT INTO file_references (source_file, target_file, symbol_name, ref_kind) \
+             VALUES ('src/deleted.ts', 'src/other.ts', 'Other', 'named')",
+            [],
+        )
+        .unwrap();
+        raw.execute(
+            "INSERT INTO index_meta (key, value) VALUES ('schema_version', '8')",
+            [],
+        )
+        .unwrap();
+    }
+
+    let conn = open_db(&db_path).unwrap();
+
+    let refs_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM file_references", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(
+        refs_count, 0,
+        "F-005: v8 → v10 migration must wipe file_references so stale rows do not survive the reindex boundary"
+    );
+}
+
 // ── PR#3 Phase 2: schema v10 bump (FR-307a, FR-307b, FR-307c) ──
 
 // T-307: opening_v9_store_drops_chunks_and_bumps_schema_version_to_10

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -4215,6 +4215,44 @@ fn opening_v8_store_drops_stale_file_references() {
     );
 }
 
+// T-009b: opening_v9_store_drops_stale_file_references
+// F-005 v10-block isolation. T-009 covers the v8 starting path, which runs
+// BOTH the v9 and v10 migration blocks sequentially. Removing the DELETE from
+// either block alone would still leave T-009 green because the other block's
+// DELETE runs. This companion test starts at v9, so only the v10 block runs
+// and the assertion isolates that block's behavior. Mirrors T-307's roll-back
+// pattern at line 4231.
+#[test]
+fn opening_v9_store_drops_stale_file_references() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("v9_refs.db");
+
+    {
+        let conn = open_db(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO file_references (source_file, target_file, symbol_name, ref_kind) \
+             VALUES ('src/deleted.rs', 'src/other.rs', 'Other', 'named')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE index_meta SET value = '9' WHERE key = 'schema_version'",
+            [],
+        )
+        .unwrap();
+    }
+
+    let conn = open_db(&db_path).unwrap();
+
+    let refs_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM file_references", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(
+        refs_count, 0,
+        "F-005: v9 → v10 migration alone must wipe file_references"
+    );
+}
+
 // ── PR#3 Phase 2: schema v10 bump (FR-307a, FR-307b, FR-307c) ──
 
 // T-307: opening_v9_store_drops_chunks_and_bumps_schema_version_to_10


### PR DESCRIPTION
## 背景

ADR-0069 PR#4 (#204) polish の codex P2-1 が disputed defer として記録した pre-existing bug の fix。v9 / v10 schema migration block は `chunks` 関連 table を drop するが `file_references` を放置していたため、reindex 前の状態で `yomu impact` / `yomu status` queries が、もはやファイル本体が存在しない (削除済 / リネーム済) `source_file` への references を返す可能性があった。

両 migration block に `DELETE FROM file_references` を追加し、reindex 境界で stale 状態を構造的に解消する。

## 変更内容

- **`src/storage/schema.rs`**: `if from < 9` と `if from < 10` の両 block に `DELETE FROM file_references` を追加 (各 block に WHY コメント付き、self-contained で v9 と v10 が独立して読める)
- **`src/storage/tests.rs`**: 2 regression test 追加
  - T-009 `opening_v8_store_drops_stale_file_references`: v8 DB に `file_references` 行を seed → migration trigger → COUNT(*) = 0 (compound path coverage)
  - T-009b `opening_v9_store_drops_stale_file_references`: v9-start companion test。T-009 単独だと v9 / v10 のどちらか片方の DELETE を消しても green になる discrimination gap を解消、v10 block を isolation する

## スコープ

- **本 PR に含めない**: v6 / v7 / v8 等の earlier migration block は chunks rows を survive させるため file_references の wipe は不要 (`chunks` を invalidate しない)
- **`DROP TABLE` ではなく `DELETE FROM`**: file_references の schema 自体は v8-v10 で変更なし、data だけ wipe すれば足りる。`DROP + CREATE` だと indexes 3 件の再構築が無駄

## 設計判断

- **2 test に分けた根拠 (polish CQ-001)**: T-009 alone は v8 起動でしか migrate path を回さず、v9 と v10 の DELETE のどちらかを isolation できない。「片方を消してもう一方が wipe しているので green」が成立してしまうため、v9-start companion test (T-009b) を追加して v10 block の挙動を独立 verify。
- **v9 / v10 コメントを self-contained 化 (polish CQ-002)**: 当初は "Mirror v9 file_references wipe" の back-reference にしていたが、v9 block 側の文言が変わると v10 のコメントが silent stale になる。v10 でも独立した WHY を述べる。

## 検証

1. `cargo test --lib` → 586 passed (584 ADR-0069 PR#4 baseline + T-009 + T-009b)
2. `cargo test --test cli_integration` → 53 passed (unchanged)
3. `cargo test --test verification` → 2 passed (unchanged)
4. `cargo clippy --all-targets -- -D warnings` → clean
5. polish review (4 reviewer parallel): codex 0 findings / coderabbit 0 findings / gemini 0 critical+major / code-review 2 confirmed (CQ-001, CQ-002) を本 PR の commit 4e509f0 で適用済

## 関連

- ADR-0069 (yomu Indirect Prompt Injection Defense) PR#4 polish follow-up
- 本 PR は #189 implementation の defer ledger のうち F-005 (v9/v10 file_references stale) を消化
- 元 PR: #200 (Foundation), #201 (Indexer), #202 (JSON), #204 (Verification)
- 残 defer: F-001 (IndexOpts struct), F-004 (walker filter_entry), F-008 (source_kind in JsonChunk), F-009 (prepare_cached), Indicator-class latency 計測
