### PR TITLE
feat(yomu): --json search/brief 出力に source_kind を流す

### DIFF
--- a/src/brief.rs
+++ b/src/brief.rs
@@ -60,6 +60,7 @@ pub struct BriefChunk {
     pub chunk_type: ChunkType,
     pub content: String,
     pub included_reason: ChunkInclusionReason,
+    pub source_kind: Option<String>,
     pub injection_flags: Option<Vec<String>>,
 }
 
@@ -127,6 +128,7 @@ fn build_brief_chunks(chunks: Vec<Chunk>, depth_by_path: &HashMap<String, u32>) 
                 chunk_type: c.chunk_type,
                 content: c.content,
                 included_reason: determine_reason(depth),
+                source_kind: c.source_kind,
                 injection_flags: c.injection_flags,
             }
         })
@@ -304,6 +306,8 @@ struct JsonChunk<'a> {
     content: &'a str,
     included_reason: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
+    source_kind: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     injection_flags: Option<Vec<&'a str>>,
 }
 
@@ -324,6 +328,7 @@ pub fn render_json(output: &BriefOutput) -> String {
                 chunk_type: c.chunk_type.as_str(),
                 content: &c.content,
                 included_reason: c.included_reason.to_string(),
+                source_kind: c.source_kind.as_deref(),
                 injection_flags: c
                     .injection_flags
                     .as_ref()

--- a/src/brief.rs
+++ b/src/brief.rs
@@ -311,10 +311,8 @@ struct JsonChunk<'a> {
     injection_flags: Option<Vec<&'a str>>,
 }
 
-/// JSON CLI rendering (FR-012): emits
-/// `{"degraded": bool, "chunks": [{"file_path", "start_line", "end_line",
-/// "chunk_type", "content", "included_reason"}]}`. Compact (no pretty),
-/// suitable for `jq` piping.
+/// Renders `BriefOutput` as compact JSON for FR-012 (jq-friendly,
+/// no pretty-printing). See `JsonOutput` / `JsonChunk` for the shape.
 pub fn render_json(output: &BriefOutput) -> String {
     let json = JsonOutput {
         degraded: output.degraded,

--- a/src/brief/tests.rs
+++ b/src/brief/tests.rs
@@ -82,6 +82,7 @@ fn make_brief_chunk(file_path: &str, content: &str) -> BriefChunk {
         chunk_type: ChunkType::RustFn,
         content: content.to_owned(),
         included_reason: ChunkInclusionReason::Forward(1),
+        source_kind: None,
         injection_flags: None,
     }
 }
@@ -137,6 +138,7 @@ fn render_json_emits_spec_shape() {
             chunk_type: ChunkType::RustFn,
             content: "fn foo() {}".to_owned(),
             included_reason: ChunkInclusionReason::Forward(2),
+            source_kind: None,
             injection_flags: None,
         }],
         degraded: true,
@@ -165,6 +167,7 @@ fn render_json_includes_seed_and_modkinds() {
         chunk_type: ChunkType::Other,
         content: "".to_owned(),
         included_reason: reason,
+        source_kind: None,
         injection_flags: None,
     };
     let output = BriefOutput {
@@ -193,6 +196,7 @@ fn render_plain_outputs_separator_and_header() {
         chunk_type: ChunkType::RustFn,
         content: content.to_owned(),
         included_reason: ChunkInclusionReason::Seed,
+        source_kind: None,
         injection_flags: None,
     };
     let output = BriefOutput {
@@ -235,6 +239,7 @@ fn render_plain_prepends_degraded_note() {
             chunk_type: ChunkType::RustFn,
             content: "fn foo() {}".to_owned(),
             included_reason: ChunkInclusionReason::Seed,
+            source_kind: None,
             injection_flags: None,
         }],
         degraded: true,
@@ -379,6 +384,7 @@ fn render_json_emits_per_chunk_injection_flags() {
             chunk_type: ChunkType::RustFn,
             content: "fn foo() {}".to_owned(),
             included_reason: ChunkInclusionReason::Seed,
+            source_kind: None,
             injection_flags: Some(vec!["y".to_owned()]),
         }],
         degraded: false,
@@ -400,6 +406,60 @@ fn render_json_emits_per_chunk_injection_flags() {
             .len(),
         1,
         "per-chunk injection_flags must contain exactly the supplied entries, got: {parsed}"
+    );
+}
+
+// T-390: render_json_emits_per_chunk_source_kind
+#[test]
+fn render_json_emits_per_chunk_source_kind() {
+    let output = BriefOutput {
+        chunks: vec![BriefChunk {
+            file_path: "src/foo.rs".to_owned(),
+            start_line: 1,
+            end_line: 3,
+            chunk_type: ChunkType::RustFn,
+            content: "fn foo() {}".to_owned(),
+            included_reason: ChunkInclusionReason::Seed,
+            source_kind: Some("src".to_owned()),
+            injection_flags: None,
+        }],
+        degraded: false,
+        total_chunks: 1,
+        total_bytes: 11,
+    };
+
+    let rendered = render_json(&output);
+    let parsed: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+
+    assert_eq!(
+        parsed["chunks"][0]["source_kind"], "src",
+        "FR-009a: BriefChunk.source_kind must propagate to JsonChunk, got: {parsed}"
+    );
+}
+
+// T-395: render_json_skips_source_kind_when_none
+#[test]
+fn render_json_skips_source_kind_when_none() {
+    let output = BriefOutput {
+        chunks: vec![BriefChunk {
+            file_path: "src/foo.rs".to_owned(),
+            start_line: 1,
+            end_line: 3,
+            chunk_type: ChunkType::RustFn,
+            content: "fn foo() {}".to_owned(),
+            included_reason: ChunkInclusionReason::Seed,
+            source_kind: None,
+            injection_flags: None,
+        }],
+        degraded: false,
+        total_chunks: 1,
+        total_bytes: 11,
+    };
+
+    let rendered = render_json(&output);
+    assert!(
+        !rendered.contains("source_kind"),
+        "JsonChunk with source_kind=None must omit the field via skip_serializing_if, got: {rendered}"
     );
 }
 

--- a/src/tools/format.rs
+++ b/src/tools/format.rs
@@ -264,6 +264,8 @@ struct JsonChunk<'a> {
     content: &'a str,
     parent_chunk_id: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
+    source_kind: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     injection_flags: Option<Vec<&'a str>>,
 }
 
@@ -291,6 +293,7 @@ pub(super) fn format_results_json(
             score: r.score,
             content: &r.chunk.content,
             parent_chunk_id: r.chunk.parent_chunk_id,
+            source_kind: r.chunk.source_kind.as_deref(),
             injection_flags: r
                 .chunk
                 .injection_flags
@@ -567,7 +570,23 @@ mod tests {
             score: 0.5,
             content: "fn foo() {}",
             parent_chunk_id: None,
+            source_kind: None,
             injection_flags,
+        }
+    }
+
+    fn sample_chunk_with_source_kind<'a>(source_kind: Option<&'a str>) -> JsonChunk<'a> {
+        JsonChunk {
+            file: "src/foo.rs",
+            name: "foo",
+            r#type: "rust_fn",
+            start_line: 1,
+            end_line: 3,
+            score: 0.5,
+            content: "fn foo() {}",
+            parent_chunk_id: None,
+            source_kind,
+            injection_flags: None,
         }
     }
 
@@ -657,6 +676,47 @@ mod tests {
         assert_eq!(
             parsed["results"][0]["injection_flags"][0], "x",
             "FR-310b: per-chunk injection_flags must be borrowed from SearchResult.chunk, got: {parsed}"
+        );
+    }
+
+    // T-372: json_chunk_skips_source_kind_when_none
+    #[test]
+    fn json_chunk_skips_source_kind_when_none() {
+        let chunk = sample_chunk_with_source_kind(None);
+        let serialized = serde_json::to_string(&chunk).unwrap();
+        assert!(
+            !serialized.contains("source_kind"),
+            "JsonChunk with source_kind=None must omit the field via skip_serializing_if, got: {serialized}"
+        );
+    }
+
+    // T-373: format_results_json_emits_per_chunk_source_kind
+    #[test]
+    fn format_results_json_emits_per_chunk_source_kind() {
+        let results = vec![storage::SearchResult {
+            chunk: storage::Chunk {
+                file_path: "src/foo.rs".to_owned(),
+                chunk_type: storage::ChunkType::RustFn,
+                name: Some("foo".to_owned()),
+                content: "fn foo() {}".to_owned(),
+                start_line: 1,
+                end_line: 3,
+                parent_chunk_id: None,
+                source_kind: Some("src".to_owned()),
+                injection_flags: None,
+            },
+            chunk_id: Some(1),
+            distance: 0.1,
+            match_source: storage::MatchSource::Fts,
+            score: 0.9,
+        }];
+
+        let json = format_results_json(&results, false, vec![]);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(
+            parsed["results"][0]["source_kind"], "src",
+            "FR-009a: per-chunk source_kind must be borrowed from SearchResult.chunk, got: {parsed}"
         );
     }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1390,6 +1390,42 @@ fn setup_injection_e2e_project() -> TempDir {
     dir
 }
 
+/// Runs `yomu` with `args`, parses stdout as JSON, requires the named array
+/// to be non-empty, and asserts that at least one entry satisfies `check`.
+/// Returns the parsed JSON so callers can run additional top-level asserts.
+fn run_json_array_check(
+    dir: &TempDir,
+    args: &[&str],
+    array_key: &str,
+    check: impl Fn(&serde_json::Value) -> bool,
+    check_msg: &str,
+) -> serde_json::Value {
+    let output = yomu_cmd()
+        .args(args)
+        .current_dir(dir.path())
+        .env_remove("YOMU_EMBED")
+        .env_remove("GEMINI_API_KEY")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "yomu {args:?} failed: stdout={stdout}, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("should parse as JSON: {e}\n{stdout}"));
+    let entries = parsed[array_key]
+        .as_array()
+        .unwrap_or_else(|| panic!("{array_key} must be an array: {stdout}"));
+    assert!(
+        !entries.is_empty(),
+        "{array_key} must be non-empty: {stdout}"
+    );
+    assert!(entries.iter().any(check), "{check_msg}: {stdout}");
+    parsed
+}
+
 // T-212: index_populates_injection_flags_for_all_chunks
 // Spec FR-214: After `yomu index`, every chunks row has non-NULL
 // injection_flags (matcher走行 over every chunk).
@@ -1570,46 +1606,17 @@ fn index_exclude_vendor_drops_vendor_source_kind() {
 #[test]
 fn search_json_emits_injection_check_and_per_chunk_flags() {
     let dir = setup_injection_e2e_project();
-    let output = yomu_cmd()
-        .args(["--json", "search", "add", "--no-embed"])
-        .current_dir(dir.path())
-        .env_remove("YOMU_EMBED")
-        .env_remove("GEMINI_API_KEY")
-        .output()
-        .unwrap();
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        output.status.success(),
-        "--json search failed: stdout={stdout}, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
+    let parsed = run_json_array_check(
+        &dir,
+        &["--json", "search", "add", "--no-embed"],
+        "results",
+        |r| r.get("injection_flags").is_some(),
+        "FR-319b: at least one result chunk must include injection_flags field \
+         (PR#2 populates every chunk)",
     );
-    let parsed: serde_json::Value = serde_json::from_str(&stdout)
-        .unwrap_or_else(|e| panic!("should parse as JSON: {e}\n{stdout}"));
-
-    // FR-319a: top-level injection_check = "ran" (mandatory, no skip_serializing_if).
     assert_eq!(
         parsed["injection_check"], "ran",
-        "FR-319a: response must include top-level injection_check='ran': {stdout}"
-    );
-
-    // FR-319b prerequisite: results[] must be non-empty so the per-chunk
-    // assertion exercises a real chunk.
-    let results = parsed["results"]
-        .as_array()
-        .unwrap_or_else(|| panic!("results must be an array: {stdout}"));
-    assert!(
-        !results.is_empty(),
-        "fixture must produce at least one matching chunk for query 'add': {stdout}"
-    );
-
-    // FR-319b: at least one result chunk SHALL include injection_flags
-    // (PR#2 populates every chunk with Some(...), so the field must surface
-    // through the JSON envelope).
-    let has_flags = results.iter().any(|r| r.get("injection_flags").is_some());
-    assert!(
-        has_flags,
-        "FR-319b: at least one result chunk must include injection_flags field \
-         (PR#2 populates every chunk): {stdout}"
+        "FR-319a: response must include top-level injection_check='ran': {parsed}"
     );
 }
 
@@ -1625,52 +1632,24 @@ fn search_json_emits_injection_check_and_per_chunk_flags() {
 #[test]
 fn brief_json_emits_injection_check_and_per_chunk_flags() {
     let dir = setup_injection_e2e_project();
-    let output = yomu_cmd()
-        .args([
+    let parsed = run_json_array_check(
+        &dir,
+        &[
             "--json",
             "brief",
             "task",
             "--seed-file",
             "src/lib.rs",
             "--no-embed",
-        ])
-        .current_dir(dir.path())
-        .env_remove("YOMU_EMBED")
-        .env_remove("GEMINI_API_KEY")
-        .output()
-        .unwrap();
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        output.status.success(),
-        "--json brief failed: stdout={stdout}, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
+        ],
+        "chunks",
+        |c| c.get("injection_flags").is_some(),
+        "FR-320b: at least one brief chunk must include injection_flags field \
+         (PR#2 populates every chunk)",
     );
-    let parsed: serde_json::Value = serde_json::from_str(&stdout)
-        .unwrap_or_else(|e| panic!("should parse as JSON: {e}\n{stdout}"));
-
-    // FR-320a: top-level injection_check = "ran" (mandatory).
     assert_eq!(
         parsed["injection_check"], "ran",
-        "FR-320a: response must include top-level injection_check='ran': {stdout}"
-    );
-
-    // FR-320b prerequisite: chunks[] must be non-empty (seed file always
-    // contributes).
-    let chunks = parsed["chunks"]
-        .as_array()
-        .unwrap_or_else(|| panic!("chunks must be an array: {stdout}"));
-    assert!(
-        !chunks.is_empty(),
-        "seed file must contribute at least one chunk: {stdout}"
-    );
-
-    // FR-320b: at least one chunk SHALL include injection_flags (PR#2
-    // populates every chunk; field surfaces when source is Some(...)).
-    let has_flags = chunks.iter().any(|c| c.get("injection_flags").is_some());
-    assert!(
-        has_flags,
-        "FR-320b: at least one brief chunk must include injection_flags field \
-         (PR#2 populates every chunk): {stdout}"
+        "FR-320a: response must include top-level injection_check='ran': {parsed}"
     );
 }
 
@@ -1685,39 +1664,17 @@ fn brief_json_emits_injection_check_and_per_chunk_flags() {
 #[test]
 fn search_json_emits_per_chunk_source_kind() {
     let dir = setup_injection_e2e_project();
-    let output = yomu_cmd()
-        .args(["--json", "search", "add", "--no-embed"])
-        .current_dir(dir.path())
-        .env_remove("YOMU_EMBED")
-        .env_remove("GEMINI_API_KEY")
-        .output()
-        .unwrap();
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        output.status.success(),
-        "--json search failed: stdout={stdout}, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let parsed: serde_json::Value = serde_json::from_str(&stdout)
-        .unwrap_or_else(|e| panic!("should parse as JSON: {e}\n{stdout}"));
-
-    let results = parsed["results"]
-        .as_array()
-        .unwrap_or_else(|| panic!("results must be an array: {stdout}"));
-    assert!(
-        !results.is_empty(),
-        "fixture must produce at least one matching chunk for query 'add': {stdout}"
-    );
-
-    let has_source_kind = results.iter().any(|r| {
-        r.get("source_kind")
-            .and_then(|v| v.as_str())
-            .is_some_and(|s| s == "src")
-    });
-    assert!(
-        has_source_kind,
+    run_json_array_check(
+        &dir,
+        &["--json", "search", "add", "--no-embed"],
+        "results",
+        |r| {
+            r.get("source_kind")
+                .and_then(|v| v.as_str())
+                .is_some_and(|s| s == "src")
+        },
         "FR-009a: at least one result chunk must carry source_kind='src' \
-         (default classification for non-vendor/non-test files): {stdout}"
+         (default classification for non-vendor/non-test files)",
     );
 }
 
@@ -1731,45 +1688,23 @@ fn search_json_emits_per_chunk_source_kind() {
 #[test]
 fn brief_json_emits_per_chunk_source_kind() {
     let dir = setup_injection_e2e_project();
-    let output = yomu_cmd()
-        .args([
+    run_json_array_check(
+        &dir,
+        &[
             "--json",
             "brief",
             "task",
             "--seed-file",
             "src/lib.rs",
             "--no-embed",
-        ])
-        .current_dir(dir.path())
-        .env_remove("YOMU_EMBED")
-        .env_remove("GEMINI_API_KEY")
-        .output()
-        .unwrap();
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        output.status.success(),
-        "--json brief failed: stdout={stdout}, stderr={}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let parsed: serde_json::Value = serde_json::from_str(&stdout)
-        .unwrap_or_else(|e| panic!("should parse as JSON: {e}\n{stdout}"));
-
-    let chunks = parsed["chunks"]
-        .as_array()
-        .unwrap_or_else(|| panic!("chunks must be an array: {stdout}"));
-    assert!(
-        !chunks.is_empty(),
-        "seed file must contribute at least one chunk: {stdout}"
-    );
-
-    let has_source_kind = chunks.iter().any(|c| {
-        c.get("source_kind")
-            .and_then(|v| v.as_str())
-            .is_some_and(|s| s == "src")
-    });
-    assert!(
-        has_source_kind,
-        "FR-009a: at least one brief chunk must carry source_kind='src': {stdout}"
+        ],
+        "chunks",
+        |c| {
+            c.get("source_kind")
+                .and_then(|v| v.as_str())
+                .is_some_and(|s| s == "src")
+        },
+        "FR-009a: at least one brief chunk must carry source_kind='src'",
     );
 }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1668,11 +1668,7 @@ fn search_json_emits_per_chunk_source_kind() {
         &dir,
         &["--json", "search", "add", "--no-embed"],
         "results",
-        |r| {
-            r.get("source_kind")
-                .and_then(|v| v.as_str())
-                .is_some_and(|s| s == "src")
-        },
+        |r| r["source_kind"].as_str() == Some("src"),
         "FR-009a: at least one result chunk must carry source_kind='src' \
          (default classification for non-vendor/non-test files)",
     );
@@ -1699,11 +1695,7 @@ fn brief_json_emits_per_chunk_source_kind() {
             "--no-embed",
         ],
         "chunks",
-        |c| {
-            c.get("source_kind")
-                .and_then(|v| v.as_str())
-                .is_some_and(|s| s == "src")
-        },
+        |c| c["source_kind"].as_str() == Some("src"),
         "FR-009a: at least one brief chunk must carry source_kind='src'",
     );
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1674,6 +1674,105 @@ fn brief_json_emits_injection_check_and_per_chunk_flags() {
     );
 }
 
+// T-576: search_json_emits_per_chunk_source_kind
+// Spec FR-009a (per-chunk `source_kind` carried from chunks table to JSON
+// envelope). Perspective: State + Equivalence (one representative result
+// classified as "src" since the fixture is non-vendor / non-test).
+//
+// Given a project indexed with default config, `yomu --json search "add"`
+// SHALL emit a JSON object whose `results[]` entries each carry
+// `source_kind="src"` (the walker classifies fixture files under `src/`).
+#[test]
+fn search_json_emits_per_chunk_source_kind() {
+    let dir = setup_injection_e2e_project();
+    let output = yomu_cmd()
+        .args(["--json", "search", "add", "--no-embed"])
+        .current_dir(dir.path())
+        .env_remove("YOMU_EMBED")
+        .env_remove("GEMINI_API_KEY")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "--json search failed: stdout={stdout}, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("should parse as JSON: {e}\n{stdout}"));
+
+    let results = parsed["results"]
+        .as_array()
+        .unwrap_or_else(|| panic!("results must be an array: {stdout}"));
+    assert!(
+        !results.is_empty(),
+        "fixture must produce at least one matching chunk for query 'add': {stdout}"
+    );
+
+    let has_source_kind = results.iter().any(|r| {
+        r.get("source_kind")
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| s == "src")
+    });
+    assert!(
+        has_source_kind,
+        "FR-009a: at least one result chunk must carry source_kind='src' \
+         (default classification for non-vendor/non-test files): {stdout}"
+    );
+}
+
+// T-577: brief_json_emits_per_chunk_source_kind
+// Spec FR-009a (per-chunk `source_kind` carried from chunks table to JSON
+// envelope). Perspective: State + Equivalence (seed-file chunk path).
+//
+// Given a project indexed with default config, `yomu --json brief "task"
+// --seed-file src/lib.rs` SHALL emit `chunks[]` entries each carrying
+// `source_kind="src"` (the walker classifies the seed file under `src/`).
+#[test]
+fn brief_json_emits_per_chunk_source_kind() {
+    let dir = setup_injection_e2e_project();
+    let output = yomu_cmd()
+        .args([
+            "--json",
+            "brief",
+            "task",
+            "--seed-file",
+            "src/lib.rs",
+            "--no-embed",
+        ])
+        .current_dir(dir.path())
+        .env_remove("YOMU_EMBED")
+        .env_remove("GEMINI_API_KEY")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "--json brief failed: stdout={stdout}, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("should parse as JSON: {e}\n{stdout}"));
+
+    let chunks = parsed["chunks"]
+        .as_array()
+        .unwrap_or_else(|| panic!("chunks must be an array: {stdout}"));
+    assert!(
+        !chunks.is_empty(),
+        "seed file must contribute at least one chunk: {stdout}"
+    );
+
+    let has_source_kind = chunks.iter().any(|c| {
+        c.get("source_kind")
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| s == "src")
+    });
+    assert!(
+        has_source_kind,
+        "FR-009a: at least one brief chunk must carry source_kind='src': {stdout}"
+    );
+}
+
 // ── verify subcommand (T-402, T-403) ────────────────────────────────
 
 // T-402: yomu --json verify emits structured precision/recall report


### PR DESCRIPTION
## 概要

- `JsonChunk` (format.rs / brief.rs) と `BriefChunk` に additive な `source_kind: Option<...>` を追加。`skip_serializing_if = "Option::is_none"` で既存 consumer 非破壊。
- `storage::Chunk` → `BriefChunk` → `JsonChunk` の 3-layer flow を `injection_flags` pattern に parallel で実装。
- consumer (Claude Code 等) が per-chunk の `vendor` / `test` / `src` 起源を `--json` 出力から取得可能に。OUTCOME.md の Behavior「素材と per-chunk marker の付与まで」を consumer に届ける loop が完了。

## テスト計画

- [x] `cargo test --lib` (590 passed)
- [x] `cargo test --test cli_integration` (55 passed)
- [x] T-372 / T-373 (search JsonChunk struct + `format_results_json` borrow)
- [x] T-390 / T-395 (brief `render_json` — Some / None 分岐)
- [x] T-576 / T-577 (e2e CLI: `source_kind="src"` が envelope に届く)
- [x] `cargo clippy --all-targets --all-features` clean
- [x] `cargo fmt --check` clean

Closes #208 (ADR-0069 PR#4 F-008 EFF-02 defer: consumer-side flow).