### PR TITLE
refactor(yomu): source_kind を Option<String> から SourceKind enum に置換 (#212)

### DIFF
--- a/src/brief.rs
+++ b/src/brief.rs
@@ -8,8 +8,8 @@ use serde::Serialize;
 
 use crate::injection_check::InjectionCheck;
 use crate::storage::{
-    Chunk, ChunkType, StorageError, get_chunks_for_files, get_edges_among_files, get_import_counts,
-    get_transitive_dependencies,
+    Chunk, ChunkType, SourceKind, StorageError, get_chunks_for_files, get_edges_among_files,
+    get_import_counts, get_transitive_dependencies,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -60,7 +60,7 @@ pub struct BriefChunk {
     pub chunk_type: ChunkType,
     pub content: String,
     pub included_reason: ChunkInclusionReason,
-    pub source_kind: Option<String>,
+    pub source_kind: Option<SourceKind>,
     pub injection_flags: Option<Vec<String>>,
 }
 
@@ -306,7 +306,7 @@ struct JsonChunk<'a> {
     content: &'a str,
     included_reason: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    source_kind: Option<&'a str>,
+    source_kind: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     injection_flags: Option<Vec<&'a str>>,
 }
@@ -326,7 +326,7 @@ pub fn render_json(output: &BriefOutput) -> String {
                 chunk_type: c.chunk_type.as_str(),
                 content: &c.content,
                 included_reason: c.included_reason.to_string(),
-                source_kind: c.source_kind.as_deref(),
+                source_kind: c.source_kind.map(SourceKind::as_str),
                 injection_flags: c
                     .injection_flags
                     .as_ref()

--- a/src/brief/tests.rs
+++ b/src/brief/tests.rs
@@ -6,7 +6,7 @@ use tracing_test::traced_test;
 
 use super::*;
 use crate::storage::{
-    EMBEDDING_DIMS, NewChunk, RefKind, Reference, ce, insert_chunk, open_db,
+    EMBEDDING_DIMS, NewChunk, RefKind, Reference, SourceKind, ce, insert_chunk, open_db,
     replace_file_references,
 };
 
@@ -420,7 +420,7 @@ fn render_json_emits_per_chunk_source_kind() {
             chunk_type: ChunkType::RustFn,
             content: "fn foo() {}".to_owned(),
             included_reason: ChunkInclusionReason::Seed,
-            source_kind: Some("src".to_owned()),
+            source_kind: Some(SourceKind::Src),
             injection_flags: None,
         }],
         degraded: false,

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -4,6 +4,8 @@ pub mod injection;
 mod source_kind;
 pub mod walker;
 
+pub use crate::storage::SourceKind;
+
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::fs;
@@ -61,7 +63,7 @@ struct PendingFile {
     parsed_imports: Vec<chunker::ParsedImport>,
     hash: String,
     mtime_epoch: Option<i64>,
-    source_kind: Option<String>,
+    source_kind: Option<SourceKind>,
     /// One JSON array string per `raw_chunks` element. Invariant:
     /// `injection_flags.len() == raw_chunks.len()`. Clean-scan is `"[]"`,
     /// hit is `"[\"flag.id\", ...]"`. PR#2 always produces `Some` at the
@@ -82,7 +84,7 @@ impl PendingFile {
                 start_line: c.start_line,
                 end_line: c.end_line,
                 parent_index: c.parent_index,
-                source_kind: self.source_kind.as_deref(),
+                source_kind: self.source_kind,
                 injection_flags: Some(flags.as_str()),
             })
             .collect()
@@ -199,7 +201,7 @@ fn prepare_chunks(
         .map(|d| d.as_secs() as i64);
 
     let imports_text = file_chunks.imports.join("\n");
-    let source_kind = Some(source_kind::classify(&checked.rel_path).to_owned());
+    let source_kind = Some(source_kind::classify(&checked.rel_path));
     let injection_flags: Vec<String> = file_chunks
         .chunks
         .iter()

--- a/src/indexer/source_kind.rs
+++ b/src/indexer/source_kind.rs
@@ -1,8 +1,11 @@
-//! Path-based classification of source files into `"vendor"` / `"test"` / `"src"`.
+//! Path-based classification of source files into [`SourceKind::Vendor`] /
+//! [`SourceKind::Test`] / [`SourceKind::Src`].
 //!
 //! Precedence per FR-202: vendor > test > src.
 
 use std::path::Path;
+
+use crate::storage::SourceKind;
 
 const VENDOR_DIRS: &[&str] = &[
     "node_modules",
@@ -21,10 +24,10 @@ const JS_EXTS: &[&str] = &["ts", "tsx", "js", "jsx", "mjs", "cjs"];
 
 const RS_GO_PY_EXTS: &[&str] = &["rs", "go", "py"];
 
-/// Classify a relative path into one of `"vendor"`, `"test"`, or `"src"`.
+/// Classify a relative path into a [`SourceKind`].
 ///
 /// Precedence: vendor > test > src (FR-202).
-pub fn classify(rel_path: &str) -> &'static str {
+pub fn classify(rel_path: &str) -> SourceKind {
     let components: Vec<&str> = Path::new(rel_path)
         .components()
         .filter_map(|c| c.as_os_str().to_str())
@@ -34,15 +37,15 @@ pub fn classify(rel_path: &str) -> &'static str {
     let ancestors = &components[..ancestor_count];
 
     if ancestors.iter().any(|c| VENDOR_DIRS.contains(c)) {
-        return "vendor";
+        return SourceKind::Vendor;
     }
     if ancestors.iter().any(|c| TEST_DIRS.contains(c)) {
-        return "test";
+        return SourceKind::Test;
     }
     if components.last().is_some_and(|f| is_test_filename(f)) {
-        return "test";
+        return SourceKind::Test;
     }
-    "src"
+    SourceKind::Src
 }
 
 fn is_test_filename(name: &str) -> bool {
@@ -84,8 +87,8 @@ mod tests {
         for input in cases {
             assert_eq!(
                 classify(input),
-                "vendor",
-                "expected \"vendor\" for input {input:?}"
+                SourceKind::Vendor,
+                "expected SourceKind::Vendor for input {input:?}"
             );
         }
     }
@@ -99,8 +102,8 @@ mod tests {
     //
     // | row | extension match | dir match | expected |
     // | --- | --------------- | --------- | -------- |
-    // | a   | T               | F         | "test"   |
-    // | b   | F               | T         | "test"   |
+    // | a   | T               | F         | Test     |
+    // | b   | F               | T         | Test     |
     //
     // FR: FR-201, FR-204
     #[test]
@@ -109,8 +112,8 @@ mod tests {
         for input in extension_cases {
             assert_eq!(
                 classify(input),
-                "test",
-                "expected \"test\" (extension branch) for input {input:?}"
+                SourceKind::Test,
+                "expected SourceKind::Test (extension branch) for input {input:?}"
             );
         }
 
@@ -118,8 +121,8 @@ mod tests {
         for input in directory_cases {
             assert_eq!(
                 classify(input),
-                "test",
-                "expected \"test\" (directory branch) for input {input:?}"
+                SourceKind::Test,
+                "expected SourceKind::Test (directory branch) for input {input:?}"
             );
         }
     }
@@ -127,7 +130,7 @@ mod tests {
     // T-203: non_vendor_non_test_paths_return_src
     //
     // Perspective: Branch (fallback). Both vendor and test predicates are
-    // false; the function must fall through to "src".
+    // false; the function must fall through to `SourceKind::Src`.
     //
     // FR: FR-201
     #[test]
@@ -136,8 +139,8 @@ mod tests {
         for input in cases {
             assert_eq!(
                 classify(input),
-                "src",
-                "expected \"src\" for input {input:?}"
+                SourceKind::Src,
+                "expected SourceKind::Src for input {input:?}"
             );
         }
     }
@@ -146,11 +149,11 @@ mod tests {
     //
     // Perspective: Combination + Hazard. Decision table for the precedence
     // rule (BR-202): when both vendor and test predicates are true, the
-    // result must be "vendor".
+    // result must be `SourceKind::Vendor`.
     //
     // | row | vendor match | test match | expected |
     // | --- | ------------ | ---------- | -------- |
-    // |  1  | T            | T          | "vendor" |
+    // |  1  | T            | T          | Vendor   |
     //
     // Inputs exercise the row from multiple angles (extension-based test
     // signal nested under vendor; directory-based test signal nested under
@@ -167,8 +170,8 @@ mod tests {
         for input in cases {
             assert_eq!(
                 classify(input),
-                "vendor",
-                "expected \"vendor\" (precedence over test) for input {input:?}"
+                SourceKind::Vendor,
+                "expected SourceKind::Vendor (precedence over test) for input {input:?}"
             );
         }
     }

--- a/src/indexer/tests.rs
+++ b/src/indexer/tests.rs
@@ -1021,7 +1021,7 @@ fn prepare_chunks_populates_source_kind_and_injection_flags() {
     };
     let pf = prepare_chunks(checked, Path::new("src/foo.rs"), None, &corpus)
         .expect("rust source should yield at least one chunk");
-    assert_eq!(pf.source_kind.as_deref(), Some("src"));
+    assert_eq!(pf.source_kind, Some(SourceKind::Src));
     assert_eq!(
         pf.injection_flags.len(),
         pf.raw_chunks.len(),
@@ -1029,7 +1029,7 @@ fn prepare_chunks_populates_source_kind_and_injection_flags() {
     );
     let new_chunks = pf.to_new_chunks();
     for nc in &new_chunks {
-        assert_eq!(nc.source_kind, Some("src"));
+        assert_eq!(nc.source_kind, Some(SourceKind::Src));
         assert!(
             nc.injection_flags.is_some(),
             "NewChunk.injection_flags must be Some after matcher runs"
@@ -1159,9 +1159,9 @@ fn run_chunk_only_index_inner_propagates_exclude_vendor() {
 fn prepare_chunks_source_kind_classification_per_rel_path() {
     let corpus = injection::Corpus::load_from_str("entries: []").unwrap();
     let cases = [
-        ("src/lib.rs", "src"),
-        ("tests/foo.rs", "test"),
-        ("dist/bundle.rs", "vendor"),
+        ("src/lib.rs", SourceKind::Src),
+        ("tests/foo.rs", SourceKind::Test),
+        ("dist/bundle.rs", SourceKind::Vendor),
     ];
     for (rel_path, expected) in cases {
         let checked = CheckedFile {
@@ -1172,7 +1172,7 @@ fn prepare_chunks_source_kind_classification_per_rel_path() {
         let pf = prepare_chunks(checked, Path::new(rel_path), None, &corpus)
             .unwrap_or_else(|| panic!("rust source should chunk for {rel_path}"));
         assert_eq!(
-            pf.source_kind.as_deref(),
+            pf.source_kind,
             Some(expected),
             "source_kind for {rel_path} should be {expected:?}, got {:?}",
             pf.source_kind

--- a/src/indexer/walker.rs
+++ b/src/indexer/walker.rs
@@ -2,13 +2,15 @@ use ignore::{DirEntry, WalkBuilder};
 use std::path::{Path, PathBuf};
 
 use super::source_kind;
+use crate::storage::SourceKind;
 
 const SUPPORTED_EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx", "mjs", "css", "html", "rs", "md"];
 
 /// Walks source files under `root`. When `exclude_vendor` is `true`, any
-/// entry whose path classifies as `"vendor"` per [`source_kind::classify`]
-/// is filtered out — this is additive to the walker's existing `.gitignore`
-/// exclusion (ADR-0069 pillar 1, walker-level vendor filter).
+/// entry whose path classifies as [`SourceKind::Vendor`] per
+/// [`source_kind::classify`] is filtered out — this is additive to the
+/// walker's existing `.gitignore` exclusion (ADR-0069 pillar 1, walker-level
+/// vendor filter).
 pub fn walk_source_files(root: &Path, exclude_vendor: bool) -> Vec<PathBuf> {
     WalkBuilder::new(root)
         .hidden(true)
@@ -38,7 +40,7 @@ pub fn walk_source_files(root: &Path, exclude_vendor: bool) -> Vec<PathBuf> {
             }
             let rel = entry.path().strip_prefix(root).unwrap_or(entry.path());
             let rel_str = rel.to_string_lossy();
-            source_kind::classify(&rel_str) != "vendor"
+            source_kind::classify(&rel_str) != SourceKind::Vendor
         })
         .map(DirEntry::into_path)
         .collect()
@@ -186,9 +188,10 @@ mod tests {
     //
     // Perspective: Branch (FR-314b true-branch) + Equivalence. The
     // `exclude_vendor=true` branch filters out paths whose
-    // `source_kind::classify` returns `"vendor"`. `vendor/lib.ts` is the
-    // representative for the vendor equivalence class; `src/foo.ts` is the
-    // representative for the non-vendor equivalence class that must remain.
+    // `source_kind::classify` returns `SourceKind::Vendor`. `vendor/lib.ts`
+    // is the representative for the vendor equivalence class; `src/foo.ts`
+    // is the representative for the non-vendor equivalence class that must
+    // remain.
     //
     // FR: FR-314b
     #[test]

--- a/src/storage/mutation.rs
+++ b/src/storage/mutation.rs
@@ -6,7 +6,8 @@ use rurico::embed::ChunkedEmbedding;
 use crate::text::split_identifier;
 
 use super::{
-    ChunkType, FileData, NewChunk, Reference, StorageError, fts_normalization, normalize_for_fts,
+    ChunkType, FileData, NewChunk, Reference, SourceKind, StorageError, fts_normalization,
+    normalize_for_fts,
 };
 
 pub(crate) fn insert_chunk_row(
@@ -31,7 +32,7 @@ pub(crate) fn insert_chunk_row(
         chunk.end_line,
         file_hash,
         parent_chunk_id,
-        chunk.source_kind,
+        chunk.source_kind.map(SourceKind::as_str),
         chunk.injection_flags,
     ])?;
     let chunk_id = conn.last_insert_rowid();

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -8,7 +8,7 @@ use rurico::storage::{fts_quote, prepare_match_query};
 use rusqlite::{Connection, Error as RusqliteError, Row, params, params_from_iter, types::ToSql};
 
 use super::{
-    Chunk, ChunkType, MatchSource, SearchResult, StorageError, anon_placeholders,
+    Chunk, ChunkType, MatchSource, SearchResult, SourceKind, StorageError, anon_placeholders,
     fts_normalization, in_placeholders,
 };
 
@@ -82,7 +82,9 @@ fn chunk_from_row(row: &Row<'_>, offset: usize) -> rusqlite::Result<Chunk> {
         start_line: row.get(offset + 4)?,
         end_line: row.get(offset + 5)?,
         parent_chunk_id: row.get(offset + 6)?,
-        source_kind: row.get(offset + 7)?,
+        source_kind: row
+            .get::<_, Option<String>>(offset + 7)?
+            .map(|s| SourceKind::from_db(s.as_ref())),
         injection_flags,
     })
 }

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -4433,7 +4433,7 @@ fn new_chunk_with_some_fields_persists_as_values() {
             start_line: 1,
             end_line: 1,
             parent_index: None,
-            source_kind: Some("src"),
+            source_kind: Some(SourceKind::Src),
             injection_flags: Some("[]"),
         },
         "h1",
@@ -4470,13 +4470,13 @@ fn chunk_struct_carries_source_kind_and_injection_flags() {
         start_line: 1,
         end_line: 3,
         parent_chunk_id: None,
-        source_kind: Some("src".into()),
+        source_kind: Some(SourceKind::Src),
         injection_flags: Some(vec!["flag.a".into()]),
     };
 
     assert_eq!(
-        chunk.source_kind.as_deref(),
-        Some("src"),
+        chunk.source_kind,
+        Some(SourceKind::Src),
         "Chunk.source_kind must expose the supplied value"
     );
     assert_eq!(
@@ -4504,7 +4504,7 @@ fn chunk_from_row_reads_source_kind_and_parses_injection_flags_json() {
         start_line: 1,
         end_line: 3,
         parent_index: None,
-        source_kind: Some("src"),
+        source_kind: Some(SourceKind::Src),
         injection_flags: Some("[\"flag.a\",\"flag.b\"]"),
     }];
     replace_file_chunks_only(&conn, "src/a.rs", &chunks, "h1", "", &[], None).unwrap();
@@ -4522,8 +4522,8 @@ fn chunk_from_row_reads_source_kind_and_parses_injection_flags_json() {
         .expect("chunk must be readable by id");
 
     assert_eq!(
-        chunk.source_kind.as_deref(),
-        Some("src"),
+        chunk.source_kind,
+        Some(SourceKind::Src),
         "chunk_from_row must read source_kind at offset+7"
     );
     assert_eq!(
@@ -4551,7 +4551,7 @@ fn chunk_from_row_degrades_malformed_injection_flags_to_none() {
         start_line: 1,
         end_line: 3,
         parent_index: None,
-        source_kind: Some("src"),
+        source_kind: Some(SourceKind::Src),
         injection_flags: Some("{malformed"),
     }];
     replace_file_chunks_only(&conn, "src/b.rs", &chunks, "h1", "", &[], None).unwrap();
@@ -4573,8 +4573,8 @@ fn chunk_from_row_degrades_malformed_injection_flags_to_none() {
         "malformed injection_flags JSON must degrade to None without panic"
     );
     assert_eq!(
-        chunk.source_kind.as_deref(),
-        Some("src"),
+        chunk.source_kind,
+        Some(SourceKind::Src),
         "source_kind must remain readable even when injection_flags JSON is malformed"
     );
 }
@@ -4596,7 +4596,7 @@ fn get_chunk_by_id_projects_source_kind_and_injection_flags() {
         start_line: 1,
         end_line: 3,
         parent_index: None,
-        source_kind: Some("test"),
+        source_kind: Some(SourceKind::Test),
         injection_flags: Some("[\"flag.x\"]"),
     }];
     replace_file_chunks_only(&conn, "src/c.rs", &chunks, "h1", "", &[], None).unwrap();
@@ -4614,8 +4614,8 @@ fn get_chunk_by_id_projects_source_kind_and_injection_flags() {
         .expect("get_chunk_by_id must return Some for an existing id");
 
     assert_eq!(
-        chunk.source_kind.as_deref(),
-        Some("test"),
+        chunk.source_kind,
+        Some(SourceKind::Test),
         "get_chunk_by_id SELECT must include source_kind column"
     );
     assert_eq!(
@@ -4643,7 +4643,7 @@ fn get_chunks_by_ids_projects_source_kind_and_injection_flags() {
             start_line: 1,
             end_line: 3,
             parent_index: None,
-            source_kind: Some("src"),
+            source_kind: Some(SourceKind::Src),
             injection_flags: Some("[\"flag.1\"]"),
         },
         NewChunk {
@@ -4653,7 +4653,7 @@ fn get_chunks_by_ids_projects_source_kind_and_injection_flags() {
             start_line: 5,
             end_line: 7,
             parent_index: None,
-            source_kind: Some("vendor"),
+            source_kind: Some(SourceKind::Vendor),
             injection_flags: Some("[]"),
         },
         NewChunk {
@@ -4663,7 +4663,7 @@ fn get_chunks_by_ids_projects_source_kind_and_injection_flags() {
             start_line: 9,
             end_line: 11,
             parent_index: None,
-            source_kind: Some("test"),
+            source_kind: Some(SourceKind::Test),
             injection_flags: Some("[\"flag.2\",\"flag.3\"]"),
         },
     ];
@@ -4687,8 +4687,8 @@ fn get_chunks_by_ids_projects_source_kind_and_injection_flags() {
 
     let one = map.get(&ids[0]).expect("id[0] must be present");
     assert_eq!(
-        one.source_kind.as_deref(),
-        Some("src"),
+        one.source_kind,
+        Some(SourceKind::Src),
         "row 1 source_kind must be projected"
     );
     assert_eq!(
@@ -4699,8 +4699,8 @@ fn get_chunks_by_ids_projects_source_kind_and_injection_flags() {
 
     let two = map.get(&ids[1]).expect("id[1] must be present");
     assert_eq!(
-        two.source_kind.as_deref(),
-        Some("vendor"),
+        two.source_kind,
+        Some(SourceKind::Vendor),
         "row 2 source_kind must be projected"
     );
     assert_eq!(
@@ -4711,8 +4711,8 @@ fn get_chunks_by_ids_projects_source_kind_and_injection_flags() {
 
     let three = map.get(&ids[2]).expect("id[2] must be present");
     assert_eq!(
-        three.source_kind.as_deref(),
-        Some("test"),
+        three.source_kind,
+        Some(SourceKind::Test),
         "row 3 source_kind must be projected"
     );
     assert_eq!(
@@ -4739,7 +4739,7 @@ fn get_chunks_for_files_projects_source_kind_and_injection_flags() {
         start_line: 1,
         end_line: 2,
         parent_index: None,
-        source_kind: Some("src"),
+        source_kind: Some(SourceKind::Src),
         injection_flags: Some("[\"flag.a\"]"),
     }];
     replace_file_chunks_only(&conn, "src/a.rs", &a_chunks, "ha", "", &[], None).unwrap();
@@ -4751,7 +4751,7 @@ fn get_chunks_for_files_projects_source_kind_and_injection_flags() {
         start_line: 1,
         end_line: 2,
         parent_index: None,
-        source_kind: Some("test"),
+        source_kind: Some(SourceKind::Test),
         injection_flags: Some("[]"),
     }];
     replace_file_chunks_only(&conn, "src/b.rs", &b_chunks, "hb", "", &[], None).unwrap();
@@ -4772,8 +4772,8 @@ fn get_chunks_for_files_projects_source_kind_and_injection_flags() {
     );
 
     assert_eq!(
-        chunks[0].source_kind.as_deref(),
-        Some("src"),
+        chunks[0].source_kind,
+        Some(SourceKind::Src),
         "src/a.rs source_kind must be projected"
     );
     assert_eq!(
@@ -4783,8 +4783,8 @@ fn get_chunks_for_files_projects_source_kind_and_injection_flags() {
     );
 
     assert_eq!(
-        chunks[1].source_kind.as_deref(),
-        Some("test"),
+        chunks[1].source_kind,
+        Some(SourceKind::Test),
         "src/b.rs source_kind must be projected"
     );
     assert_eq!(
@@ -4811,7 +4811,7 @@ fn search_by_fts_projects_source_kind_and_injection_flags() {
         start_line: 1,
         end_line: 3,
         parent_index: None,
-        source_kind: Some("src"),
+        source_kind: Some(SourceKind::Src),
         injection_flags: Some("[\"flag.alpha\"]"),
     }];
     replace_file_chunks_only(&conn, "src/alpha.rs", &chunks, "h1", "", &[], None).unwrap();
@@ -4828,8 +4828,8 @@ fn search_by_fts_projects_source_kind_and_injection_flags() {
         .expect("must find the alpha chunk in FTS results");
 
     assert_eq!(
-        hit.chunk.source_kind.as_deref(),
-        Some("src"),
+        hit.chunk.source_kind,
+        Some(SourceKind::Src),
         "search_by_fts SELECT must include source_kind column"
     );
     assert_eq!(

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -1,6 +1,38 @@
 use std::io;
 use std::path::PathBuf;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceKind {
+    Vendor,
+    Test,
+    Src,
+}
+
+impl SourceKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Vendor => "vendor",
+            Self::Test => "test",
+            Self::Src => "src",
+        }
+    }
+
+    pub fn from_db(s: &str) -> Self {
+        match s {
+            "vendor" => Self::Vendor,
+            "test" => Self::Test,
+            "src" => Self::Src,
+            other => {
+                tracing::warn!(
+                    source_kind = other,
+                    "Unknown source_kind in DB, defaulting to Src"
+                );
+                Self::Src
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum ChunkType {
     Component,
@@ -75,8 +107,8 @@ pub struct Chunk {
     pub start_line: u32,
     pub end_line: u32,
     pub parent_chunk_id: Option<i64>,
-    /// chunk 起源 (`vendor` / `test` / `src` の enum 文字列)。NULL = 未分類 (ADR-0069)。
-    pub source_kind: Option<String>,
+    /// chunk 起源 (`Vendor` / `Test` / `Src`)。NULL = 未分類 (ADR-0069)。
+    pub source_kind: Option<SourceKind>,
     /// matcher の per-chunk 検出結果。
     /// `None` = matcher 未走行 (PR#1-era v9 行 / matcher 未走行 chunk)、
     /// `Some(vec![])` = 走行 + ヒットなし、`Some(vec![...])` = 走行 + ヒット。
@@ -148,8 +180,8 @@ pub struct NewChunk<'a> {
     pub start_line: u32,
     pub end_line: u32,
     pub parent_index: Option<usize>,
-    /// chunk 起源 (`vendor` / `test` / `src` の enum 文字列)。NULL = 未分類 (ADR-0069)。
-    pub source_kind: Option<&'a str>,
+    /// chunk 起源 (`Vendor` / `Test` / `Src`)。NULL = 未分類 (ADR-0069)。
+    pub source_kind: Option<SourceKind>,
     /// matcher の per-chunk 検出結果 (JSON 配列文字列)。
     /// NULL = matcher 未走行、`"[]"` = 走行 + ヒットなし、`"[...]"` = 走行 + ヒット。
     pub injection_flags: Option<&'a str>,

--- a/src/tools/format.rs
+++ b/src/tools/format.rs
@@ -264,7 +264,7 @@ struct JsonChunk<'a> {
     content: &'a str,
     parent_chunk_id: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    source_kind: Option<&'a str>,
+    source_kind: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     injection_flags: Option<Vec<&'a str>>,
 }
@@ -293,7 +293,7 @@ pub(super) fn format_results_json(
             score: r.score,
             content: &r.chunk.content,
             parent_chunk_id: r.chunk.parent_chunk_id,
-            source_kind: r.chunk.source_kind.as_deref(),
+            source_kind: r.chunk.source_kind.map(storage::SourceKind::as_str),
             injection_flags: r
                 .chunk
                 .injection_flags
@@ -575,7 +575,7 @@ mod tests {
         }
     }
 
-    fn sample_chunk_with_source_kind<'a>(source_kind: Option<&'a str>) -> JsonChunk<'a> {
+    fn sample_chunk_with_source_kind(source_kind: Option<&'static str>) -> JsonChunk<'static> {
         JsonChunk {
             file: "src/foo.rs",
             name: "foo",
@@ -657,7 +657,7 @@ mod tests {
                 start_line: 1,
                 end_line: 3,
                 parent_chunk_id: None,
-                source_kind: Some("src".to_owned()),
+                source_kind: Some(storage::SourceKind::Src),
                 injection_flags: Some(vec!["x".to_owned()]),
             },
             chunk_id: Some(1),
@@ -702,7 +702,7 @@ mod tests {
                 start_line: 1,
                 end_line: 3,
                 parent_chunk_id: None,
-                source_kind: Some("src".to_owned()),
+                source_kind: Some(storage::SourceKind::Src),
                 injection_flags: None,
             },
             chunk_id: Some(1),


### PR DESCRIPTION
## 概要

- `Option<String>` の source_kind を型安全な `SourceKind` enum に置換 (Issue #212)
- enum を `storage/types.rs` に配置し、既存の `ChunkType` / `RefKind` と統一されたパターンに
- JSON 出力 byte-identical を維持 (consumer 非破壊)

## 変更内容

### 型定義 (`src/storage/types.rs`)
- `SourceKind` enum を新設: `Vendor` / `Test` / `Src`
- `Debug, Clone, Copy, PartialEq, Eq` derive
- `as_str() -> &'static str` と `from_db(s: &str) -> Self` (warn-on-unknown default)

### 影響構造体
| 構造体 | 旧 | 新 |
|--------|------|------|
| `Chunk` (storage/types.rs) | `Option<String>` | `Option<SourceKind>` |
| `NewChunk` (storage/types.rs) | `Option<&'a str>` | `Option<SourceKind>` |
| `BriefChunk` (brief.rs) | `Option<String>` | `Option<SourceKind>` |
| `PendingFile` (indexer.rs) | `Option<String>` | `Option<SourceKind>` |

### JSON 境界
- `JsonChunk::source_kind` は `Option<&'static str>` を維持
- 変換は serialize 時点で `c.source_kind.map(SourceKind::as_str)`
- `skip_serializing_if` 含め byte-identical を保証 (T-372/T-373/T-576/T-577)

### 依存方向
- `indexer` → `storage` (正方向、既存 `NewChunk` パターンと一致)
- `indexer/source_kind.rs` を `mod` に絞り、`pub use crate::storage::SourceKind` で再公開

## 受入条件 (Issue #212)

- [x] `enum SourceKind` 導入
- [x] `classify()` の戻り値が `SourceKind`
- [x] 全 test fixture が enum literal に置換
- [x] `cargo test` green (590 passed)
- [x] `yomu --json` 出力の `source_kind` 値が byte-identical
- [x] ADR-0069 NFR の stringly-typed 解消を反映

## ファイル変更 (11)

```
 src/brief.rs               | 10 ++++----
 src/brief/tests.rs         |  4 +--
 src/indexer.rs             |  8 +++---
 src/indexer/source_kind.rs | 47 +++++++++++++++++++----------------
 src/indexer/tests.rs       | 12 ++++-----
 src/indexer/walker.rs      | 17 +++++++------
 src/storage/mutation.rs    |  5 ++--
 src/storage/search.rs      |  6 +++--
 src/storage/tests.rs       | 62 +++++++++++++++++++++++-----------------------
 src/storage/types.rs       | 40 +++++++++++++++++++++++++++---
 src/tools/format.rs        | 10 ++++----
 11 files changed, 132 insertions(+), 89 deletions(-)
```

## テスト確認

- [x] `cargo test` 全テスト通過 (590 passed)
- [x] `cargo clippy --all-targets -- -D warnings` クリーン
- [x] JSON output byte-identical 検証 (T-372/T-373/T-576/T-577)
- [x] DB round-trip (insert→read) で SourceKind が保持される
- [x] 未知の source_kind 文字列は `Src` にフォールバック (warn ログ)

## 関連

- Closes #212
- ADR-0069 FR-009a (per-chunk source_kind)
- PR #211 /polish F3 finding (stringly-typed defer)
- LANG.md "AI tends to: String for every identifier → Newtype"