### PR TITLE
refactor(yomu): index 系 3 メソッドを IndexRunOptions struct に refactor (#206)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,8 @@ use yomu::brief;
 use yomu::error::{self, ErrorCode};
 use yomu::io::write_output;
 use yomu::tools::{
-    InvalidInputKind, MAX_IMPACT_DEPTH, MAX_SEARCH_LIMIT, MAX_SEARCH_OFFSET, Yomu, YomuError,
-    YomuOptions,
+    IndexRunOptions, InvalidInputKind, MAX_IMPACT_DEPTH, MAX_SEARCH_LIMIT, MAX_SEARCH_OFFSET, Yomu,
+    YomuError, YomuOptions,
 };
 
 #[derive(Parser)]
@@ -317,20 +317,28 @@ fn main() -> ExitCode {
             dry_run,
             exclude_vendor,
         } => {
+            let opts = IndexRunOptions {
+                force: false,
+                exclude_vendor,
+            };
             if dry_run {
-                yomu.dry_run_index(false, json, exclude_vendor)
+                yomu.dry_run_index(opts, json)
             } else {
-                yomu.index(json, exclude_vendor)
+                yomu.index(opts, json)
             }
         }
         Command::Rebuild {
             dry_run,
             exclude_vendor,
         } => {
+            let opts = IndexRunOptions {
+                force: true,
+                exclude_vendor,
+            };
             if dry_run {
-                yomu.dry_run_index(true, json, exclude_vendor)
+                yomu.dry_run_index(opts, json)
             } else {
-                yomu.rebuild(json, exclude_vendor)
+                yomu.rebuild(opts, json)
             }
         }
         Command::Impact {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -156,6 +156,26 @@ pub struct YomuOptions {
     pub log_query: bool,
 }
 
+/// Behavioral options for index / rebuild / dry-run paths.
+///
+/// `force` is consumed only by [`Yomu::dry_run_index`] (where it predicts
+/// rebuild vs index semantics). [`Yomu::index`] and [`Yomu::rebuild`]
+/// **ignore** `force` entirely — they are hard-wired to `false` and `true`
+/// respectively. The struct is shared across all three for call-site parity
+/// (Issue #206 / PR#3 Spec AS-307); callers of `index` / `rebuild` should
+/// leave `force` at its default.
+///
+/// `json` stays a separate parameter because it controls presentation, not
+/// indexing behavior.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct IndexRunOptions {
+    /// Predict rebuild semantics in [`Yomu::dry_run_index`]. Ignored by
+    /// [`Yomu::index`] and [`Yomu::rebuild`].
+    pub force: bool,
+    /// Skip vendor directories (`node_modules`, `vendor`, etc.).
+    pub exclude_vendor: bool,
+}
+
 /// Env-derived runtime configuration for [`Yomu::with_root`].
 ///
 /// Production callers obtain this via [`YomuConfig::from_env`]; tests use
@@ -532,8 +552,9 @@ impl Yomu {
         Ok(text)
     }
 
-    pub fn index(&self, json: bool, exclude_vendor: bool) -> Result<String, YomuError> {
-        let chunk_result = indexer::run_chunk_only_index(&self.conn, &self.root, exclude_vendor)?;
+    pub fn index(&self, opts: IndexRunOptions, json: bool) -> Result<String, YomuError> {
+        let chunk_result =
+            indexer::run_chunk_only_index(&self.conn, &self.root, opts.exclude_vendor)?;
         let stats = self.with_db(storage::get_stats)?;
 
         if json {
@@ -554,13 +575,9 @@ impl Yomu {
         Ok(text)
     }
 
-    pub fn dry_run_index(
-        &self,
-        force: bool,
-        json: bool,
-        exclude_vendor: bool,
-    ) -> Result<String, YomuError> {
-        let preview = indexer::dry_run_index(&self.conn, &self.root, force, exclude_vendor)?;
+    pub fn dry_run_index(&self, opts: IndexRunOptions, json: bool) -> Result<String, YomuError> {
+        let preview =
+            indexer::dry_run_index(&self.conn, &self.root, opts.force, opts.exclude_vendor)?;
 
         if json {
             let (degraded, notes) = degraded_for_dry_run_errors(preview.files_errored);
@@ -583,9 +600,9 @@ impl Yomu {
         Ok(text)
     }
 
-    pub fn rebuild(&self, json: bool, exclude_vendor: bool) -> Result<String, YomuError> {
+    pub fn rebuild(&self, opts: IndexRunOptions, json: bool) -> Result<String, YomuError> {
         let chunk_result =
-            indexer::run_chunk_only_index_force(&self.conn, &self.root, exclude_vendor)?;
+            indexer::run_chunk_only_index_force(&self.conn, &self.root, opts.exclude_vendor)?;
         let stats = self.with_db(storage::get_stats)?;
 
         if json {

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -696,7 +696,7 @@ fn format_results_grouped_shows_score_for_all() {
 #[test]
 fn index_works_without_api_key() {
     let (y, _dir) = test_yomu_with_files(&[("src/A.tsx", "function A() {}")]);
-    let text = y.index(false, false).unwrap();
+    let text = y.index(IndexRunOptions::default(), false).unwrap();
     assert!(text.contains("complete"), "expected success: {text}");
 }
 
@@ -714,7 +714,7 @@ fn index_chunks_without_embedding() {
         ),
     ]);
 
-    let text = y.index(false, false).unwrap();
+    let text = y.index(IndexRunOptions::default(), false).unwrap();
     assert!(text.contains("complete"), "expected completion: {text}");
     assert!(
         text.contains("Embedding coverage:"),
@@ -733,7 +733,7 @@ fn index_chunks_without_embedding() {
 #[test]
 fn rebuild_re_parses_all_files() {
     let (y, dir) = test_yomu_with_files(&[("src/A.tsx", "export function A() { return <div/>; }")]);
-    y.index(false, false).unwrap();
+    y.index(IndexRunOptions::default(), false).unwrap();
 
     let chunks_before = {
         let c = y.conn.lock().unwrap();
@@ -747,7 +747,7 @@ fn rebuild_re_parses_all_files() {
     )
     .unwrap();
 
-    let text = y.rebuild(false, false).unwrap();
+    let text = y.rebuild(IndexRunOptions::default(), false).unwrap();
     assert!(text.contains("complete"), "expected completion: {text}");
 
     let chunks_after = {
@@ -1337,7 +1337,7 @@ fn dry_run_index_does_not_write_to_db() {
         ("src/B.tsx", "export function B() {}"),
     ]);
 
-    let text = y.dry_run_index(false, false, false).unwrap();
+    let text = y.dry_run_index(IndexRunOptions::default(), false).unwrap();
     assert!(
         text.contains("2 files to process"),
         "should report files to process: {text}"
@@ -1363,7 +1363,7 @@ fn dry_run_index_shows_skip_for_unchanged() {
 
     indexer::run_chunk_only_index(&y.conn, y.root.as_path(), false).unwrap();
 
-    let text = y.dry_run_index(false, false, false).unwrap();
+    let text = y.dry_run_index(IndexRunOptions::default(), false).unwrap();
     assert!(
         text.contains("0 files to process"),
         "all files should be skipped: {text}"
@@ -1564,7 +1564,7 @@ fn subchunk_innerfn_is_hit_at_1_for_inner_function_query() {
 
     let (y, _dir) = test_yomu_with_files(&[("src/UserForm.tsx", &fixture)]);
 
-    y.index(false, false).unwrap();
+    y.index(IndexRunOptions::default(), false).unwrap();
 
     let result = y
         .search(Some("handleSubmit"), 10, 0, &[], false, None)
@@ -1588,7 +1588,7 @@ fn below_threshold_no_subchunks_in_index() {
   return <div><button onClick={handleClick}>{count}</button></div>;
 }"#;
     let (y, _dir) = test_yomu_with_files(&[("src/SmallCard.tsx", fixture)]);
-    y.index(false, false).unwrap();
+    y.index(IndexRunOptions::default(), false).unwrap();
 
     let stats = y.status(false).unwrap();
     assert!(
@@ -1952,7 +1952,7 @@ fn embed_embedder_unavailable_returns_error() {
         dir.path().to_path_buf(),
         Err(DegradedReason::NotInstalled),
     );
-    y.index(false, false).unwrap();
+    y.index(IndexRunOptions::default(), false).unwrap();
 
     let result = y.embed(false);
     assert!(
@@ -1970,7 +1970,7 @@ fn embed_disabled_returns_embedder_unavailable() {
         dir.path().to_path_buf(),
         Err(DegradedReason::Disabled),
     );
-    y.index(false, false).unwrap();
+    y.index(IndexRunOptions::default(), false).unwrap();
 
     let result = y.embed(false);
     assert!(
@@ -2062,7 +2062,7 @@ fn index_json_returns_valid_json() {
         ("src/A.tsx", "export function A() {}"),
         ("src/B.tsx", "export function B() {}"),
     ]);
-    let json = y.index(true, false).unwrap();
+    let json = y.index(IndexRunOptions::default(), true).unwrap();
     let parsed = parse_json(&json);
     assert_eq!(parsed["files_processed"], 2);
     assert!(parsed["chunks_created"].as_u64().unwrap() > 0);
@@ -2078,9 +2078,9 @@ fn index_json_returns_valid_json() {
 #[test]
 fn rebuild_json_returns_valid_json() {
     let (y, _dir) = test_yomu_with_files(&[("src/A.tsx", "export function A() {}")]);
-    y.index(false, false).unwrap();
+    y.index(IndexRunOptions::default(), false).unwrap();
 
-    let json = y.rebuild(true, false).unwrap();
+    let json = y.rebuild(IndexRunOptions::default(), true).unwrap();
     let parsed = parse_json(&json);
     assert_eq!(parsed["files_processed"], 1);
     assert!(parsed["chunks_created"].as_u64().unwrap() > 0);
@@ -2099,7 +2099,7 @@ fn dry_run_index_json_returns_valid_json() {
         ("src/B.tsx", "export function B() {}"),
     ]);
 
-    let json = y.dry_run_index(false, true, false).unwrap();
+    let json = y.dry_run_index(IndexRunOptions::default(), true).unwrap();
     let parsed = parse_json(&json);
     assert_eq!(parsed["files_to_process"], 2);
     assert_eq!(parsed["files_to_skip"], 0);
@@ -2114,7 +2114,7 @@ fn dry_run_index_json_shows_skip_for_unchanged() {
     let (y, _dir) = test_yomu_with_files(&[("src/A.tsx", "export function A() {}")]);
     indexer::run_chunk_only_index(&y.conn, y.root.as_path(), false).unwrap();
 
-    let json = y.dry_run_index(false, true, false).unwrap();
+    let json = y.dry_run_index(IndexRunOptions::default(), true).unwrap();
     let parsed = parse_json(&json);
     assert_eq!(parsed["files_to_process"], 0);
     assert_eq!(parsed["files_to_skip"], 1);


### PR DESCRIPTION
## 概要

- `index` / `rebuild` / `dry_run_index` の 3 メソッドを 3-bool API から `IndexRunOptions` struct に置換 (Issue #206)
- LANG.md anti-pattern (`fn f(force: bool, dry_run: bool)`) を解消
- 既存 `YomuOptions` パターンと統一

## 変更内容

### 型定義 (`src/tools.rs`)
```rust
#[derive(Debug, Default, Clone, Copy)]
pub struct IndexRunOptions {
    pub force: bool,           // dry_run_index 専用
    pub exclude_vendor: bool,
}
```

- `Debug, Default, Clone, Copy` derive (`YomuOptions` precedent と一致)
- `force` は `dry_run_index` でのみ意味を持つ (rustdoc 明記)
- Spec AS-307 (PR#3) で pre-declare 済みの parity 設計

### メソッドシグネチャ
| 旧 | 新 |
|---|---|
| `index(&self, json: bool, exclude_vendor: bool)` | `index(&self, opts: IndexRunOptions, json: bool)` |
| `rebuild(&self, json: bool, exclude_vendor: bool)` | `rebuild(&self, opts: IndexRunOptions, json: bool)` |
| `dry_run_index(&self, force: bool, json: bool, exclude_vendor: bool)` | `dry_run_index(&self, opts: IndexRunOptions, json: bool)` |

### CLI dispatch 部分 (`src/main.rs`)
- `Command::Index` / `Command::Rebuild` 各分岐で `IndexRunOptions` を構築
- `force` 値は method と正しくペア (`Index` = false, `Rebuild` = true)

### test fixture 部分 (`src/tools/tests.rs`)
- 15 callsite を positional bool から `IndexRunOptions::default(), ...` に置換
- 全 test の `exclude_vendor` / `force` が default 値のため `::default()` で簡潔

## 受入条件 (Issue #206)

- [x] 3 メソッドの API が struct based
- [x] 全 test green (590 passed)
- [x] callsite が positional bool literal 連発を回避

## ファイル変更 (3)

```
 src/main.rs        | 20 ++++++++++++++------
 src/tools.rs       | 39 ++++++++++++++++++++++++++++-----------
 src/tools/tests.rs | 30 +++++++++++++++---------------
 3 files changed, 57 insertions(+), 32 deletions(-)
```

## レビュー結果 (polish)

| Tool | 結果 |
|---|---|
| code-review (high) | 2 件 fix (rustdoc 引き締め), 1 件 deferred (意図的設計) |
| Codex | 0 findings |
| CodeRabbit | 0 findings |
| Gemini | 1 Major (force semantic overloading) — code-review deferred と重複論点 |

`force` field が `index`/`rebuild` で無視される点は Issue #206 Spec AS-307 で明示された parity 設計のため deferred。production callsite (main.rs) は force 値と method を常に正しくペア。

## テスト確認

- [x] `cargo test` 全テスト通過 (590 passed)
- [x] `cargo clippy --all-targets -- -D warnings` クリーン
- [x] CLI dispatch 動作確認 (main.rs)

## 関連

- Closes #206
- PR#3 polish F-001 / CQ-1 (critic-audit verdict: disputed because pre-declared AS-307)
- LANG.md "AI tends to: `fn f(force: bool, dry_run: bool)` → enum or struct"