### PR TITLE
refactor(yomu): RC-003 cast 安全化 — TryFrom / clamp で 4 site を整理 (#135)

### DIFF
--- a/src/brief.rs
+++ b/src/brief.rs
@@ -135,9 +135,8 @@ fn build_brief_chunks(chunks: Vec<Chunk>, depth_by_path: &HashMap<String, u32>) 
         .collect()
 }
 
-#[allow(clippy::cast_possible_truncation)]
 fn under_cap(chunks: &[BriefChunk], max_chunks: u32, max_bytes: u32) -> bool {
-    let count = chunks.len() as u32;
+    let count = u32::try_from(chunks.len()).unwrap_or(u32::MAX);
     let bytes: usize = chunks.iter().map(|c| c.content.len()).sum();
     let bytes_capped = u32::try_from(bytes).unwrap_or(u32::MAX);
     count <= max_chunks && bytes_capped <= max_bytes
@@ -153,7 +152,6 @@ fn deletion_priority(
     (depth, incoming)
 }
 
-#[allow(clippy::cast_possible_truncation)]
 fn select_drops(
     chunks: &[BriefChunk],
     depth_by_path: &HashMap<String, u32>,
@@ -172,10 +170,11 @@ fn select_drops(
     order.sort_by(|a, b| b.1.cmp(&a.1).then(a.2.cmp(&b.2)));
 
     let mut drop_idx: HashSet<usize> = HashSet::new();
-    let mut count = chunks.len() as u32;
+    let mut count = u32::try_from(chunks.len()).unwrap_or(u32::MAX);
     let mut bytes: usize = chunks.iter().map(|c| c.content.len()).sum();
     for (idx, _, _) in order {
-        if count <= max_chunks && bytes as u32 <= max_bytes {
+        let bytes_capped = u32::try_from(bytes).unwrap_or(u32::MAX);
+        if count <= max_chunks && bytes_capped <= max_bytes {
             break;
         }
         drop_idx.insert(idx);
@@ -364,7 +363,6 @@ pub fn render_plain(output: &BriefOutput) -> String {
     }
 }
 
-#[allow(clippy::cast_possible_truncation)]
 pub fn expand_plan(conn: &Connection, task: &TaskBrief) -> Result<BriefOutput, StorageError> {
     let seeds = collect_seed_paths(task);
     if seeds.is_empty() {
@@ -403,8 +401,9 @@ pub fn expand_plan(conn: &Connection, task: &TaskBrief) -> Result<BriefOutput, S
     let edges = get_edges_among_files(conn, &capped_paths)?;
     let ordered = topo_sort(capped, &edges);
 
-    let total_chunks = ordered.len() as u32;
-    let total_bytes: u32 = ordered.iter().map(|c| c.content.len() as u32).sum();
+    let total_chunks = u32::try_from(ordered.len()).unwrap_or(u32::MAX);
+    let total_bytes_usize: usize = ordered.iter().map(|c| c.content.len()).sum();
+    let total_bytes = u32::try_from(total_bytes_usize).unwrap_or(u32::MAX);
 
     Ok(BriefOutput {
         chunks: ordered,

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -198,7 +198,7 @@ fn prepare_chunks(
         .ok()
         .and_then(|m| m.modified().ok())
         .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-        .map(|d| d.as_secs() as i64);
+        .map(|d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX));
 
     let imports_text = file_chunks.imports.join("\n");
     let source_kind = Some(source_kind::classify(&checked.rel_path));

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -140,7 +140,6 @@ pub fn vec_search(
     Ok(build_semantic_results(best, &meta, limit))
 }
 
-#[allow(clippy::cast_possible_truncation)]
 pub fn search_by_fts(
     conn: &Connection,
     keywords: &[&str],
@@ -207,7 +206,14 @@ pub fn search_by_fts(
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(params_from_iter(params.iter()), |row| {
         let bm25_score: f64 = row.get(10)?;
-        let abs = (bm25_score as f32).abs();
+        // Saturate to the f32 range so an extreme bm25 magnitude cannot become ±INF and
+        // produce NaN through `abs / (1.0 + abs)` below.
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "value saturated to f32 range by clamp()"
+        )]
+        let bm25_f32 = bm25_score.clamp(f64::from(f32::MIN), f64::from(f32::MAX)) as f32;
+        let abs = bm25_f32.abs();
         let base_score = abs / (1.0 + abs);
         Ok(SearchResult {
             chunk: chunk_from_row(row, 1)?,

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -133,9 +133,18 @@ impl IndexStatus {
         }
     }
 
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     pub fn embed_percentage(&self) -> u32 {
-        (self.embed_coverage() as f64 * 100.0) as u32
+        // Truncate (floor) rather than round so partial coverage like 199/200 reports
+        // 99 — only fully complete coverage (1.0) is allowed to surface as 100.
+        // `embed_coverage()` is bounded to [0.0, 1.0] by construction, so the product
+        // is in [0.0, 100.0]; the trailing clamp(0, 100) is defense-in-depth.
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "input <= 100.0 by embed_coverage() invariant; trailing clamp is defense-in-depth"
+        )]
+        let pct = (self.embed_coverage() * 100.0) as u32;
+        pct.clamp(0, 100)
     }
 }
 


### PR DESCRIPTION
## 概要

- 4 site の `as` cast を `TryFrom` / `clamp` パターンに置換 (Issue #135)
- LANG.md `cast_possible_truncation = "deny"` policy に準拠
- 残存 `#[allow]` には reason コメント必須化

## 修正内容

### Site 1: `embed_percentage` (types.rs)

- 旧: `(coverage as f64 * 100.0) as u32` (silent truncate)
- 新: `(coverage * 100.0) as u32` + `clamp(0, 100)` (floor + bounded)

**重要**: floor (`.round()` ではない) を採用。`.round()` だと 199/200 (99.5%) が 100% と誤報され "100% = 完了" セマンティクスが壊れる。Polish の Codex review で発見された P2。

### Site 2: mtime epoch (indexer.rs)

- 旧: `d.as_secs() as i64` (年 2262 wrap)
- 新: `i64::try_from(d.as_secs()).unwrap_or(i64::MAX)` (saturate)

### Site 3: bm25 score (search.rs)

- 旧: `bm25_score as f32` (extreme magnitude で ±INF → NaN)
- 新: `bm25_score.clamp(f64::from(f32::MIN), f64::from(f32::MAX)) as f32` (saturate to f32 range)

NaN 化を回避: `INF / (1.0 + INF) = NaN` で ranking が破綻する経路を遮断。

### Site 4: `len() as u32` パターン (brief.rs, 5 箇所)

- 旧: `chunks.len() as u32`, `bytes as u32`, `c.content.len() as u32`
- 新: `u32::try_from(...).unwrap_or(u32::MAX)` (saturate)

関数レベル `#[allow(clippy::cast_possible_truncation)]` を 3 箇所削除し、block レベル + reason comment に縮小。

## 受入条件 (Issue #135)

- [x] 上記 4 site の `as` を `TryFrom` / `clamp` ベースに置換
- [x] `#[allow(...)]` を残す場所には reason comment
- [x] `cargo clippy` clean

## ファイル変更 (4)

```
 src/brief.rs          | 15 +++++++--------
 src/indexer.rs        |  2 +-
 src/storage/search.rs | 10 ++++++++--
 src/storage/types.rs  | 13 +++++++++++--
 4 files changed, 27 insertions(+), 13 deletions(-)
```

## レビュー結果 (polish)

| Tool | 結果 |
|---|---|
| code-review (high) | 2 件 fix (reason 文言、pattern 整合) |
| **Codex** | **1 件 P2 fix — embed_percentage の round() で 100% 誤報** |
| CodeRabbit | 0 findings |
| Gemini | 0 findings (approval のみ) |

## テスト確認

- [x] `cargo test --lib` 全テスト通過 (590 passed)
- [x] `cargo clippy --all-targets -- -D warnings` クリーン
- [x] embed_percentage の semantic 維持 (199/200 = 99% を確認)

## 関連

- Closes #135
- LANG.md "Idioms" 節 cast 規約
- RC-003 (issue STR-003, STR-004, STR-005, STR-008)