### PR TITLE
refactor(yomu): RC-002 .ok() 規律 — fs_optional helper で意図的不在と予期しない失敗を分離 (#134)

### DIFF
--- a/src/brief.rs
+++ b/src/brief.rs
@@ -114,6 +114,10 @@ fn build_brief_chunks(chunks: Vec<Chunk>, depth_by_path: &HashMap<String, u32>) 
         .into_iter()
         .map(|c| {
             let depth = depth_by_path.get(&c.file_path).copied().unwrap_or_else(|| {
+                tracing::warn!(
+                    file_path = %c.file_path,
+                    "chunk file_path missing from depth_by_path; defaulting depth=0"
+                );
                 debug_assert!(
                     false,
                     "chunk file_path not in depth_by_path: {}",

--- a/src/fs_optional.rs
+++ b/src/fs_optional.rs
@@ -1,0 +1,219 @@
+//! Filesystem reads that distinguish "expected absence" from "unexpected I/O failure".
+//!
+//! Each helper returns `None` on the `NotFound` absence path silently, but
+//! emits `tracing::warn!` for other I/O errors (permissions, corrupted FS,
+//! platform mtime unsupported, pre-1970 mtime, etc.) so operators can
+//! investigate anomalies that previously hid behind plain `.ok()` calls
+//! (Issue #134 SIL-003, SIL-006, SIL-007, RES-002).
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+/// Read a UTF-8 file. `NotFound` returns `None` silently; other errors warn
+/// and return `None`.
+pub fn read_to_string_optional(path: &Path) -> Option<String> {
+    match fs::read_to_string(path) {
+        Ok(c) => Some(c),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => None,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "unexpected I/O error reading file"
+            );
+            None
+        }
+    }
+}
+
+/// Canonicalize a path. `NotFound` returns `None` silently; other errors warn
+/// and return `None`.
+pub fn canonicalize_optional(path: &Path) -> Option<PathBuf> {
+    match path.canonicalize() {
+        Ok(p) => Some(p),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => None,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "canonicalize failed unexpectedly"
+            );
+            None
+        }
+    }
+}
+
+/// Read a file's mtime as Unix epoch seconds (saturating at `i64::MAX` for
+/// year-2262+ wraparound). `NotFound` returns `None` silently; other errors
+/// (permissions, platform without mtime, pre-1970 mtime) warn and return `None`.
+pub fn read_mtime_epoch(path: &Path) -> Option<i64> {
+    let metadata = match fs::metadata(path) {
+        Ok(m) => m,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "metadata read failed"
+            );
+            return None;
+        }
+    };
+    let modified = match metadata.modified() {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "mtime unsupported on this platform"
+            );
+            return None;
+        }
+    };
+    match modified.duration_since(UNIX_EPOCH) {
+        Ok(d) => Some(i64::try_from(d.as_secs()).unwrap_or(i64::MAX)),
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "mtime predates UNIX epoch"
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs as stdfs;
+    use tempfile::tempdir;
+    use tracing_test::traced_test;
+
+    // T-FSO-001: read_to_string_optional returns Some(content) for an existing file.
+    #[test]
+    fn read_to_string_optional_returns_content() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("file.txt");
+        stdfs::write(&path, "hello").unwrap();
+        assert_eq!(read_to_string_optional(&path), Some("hello".to_owned()));
+    }
+
+    // T-FSO-002: read_to_string_optional returns None silently for NotFound.
+    #[test]
+    #[traced_test]
+    fn read_to_string_optional_silent_on_notfound() {
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("nope.txt");
+        assert_eq!(read_to_string_optional(&missing), None);
+        assert!(
+            !logs_contain("unexpected I/O error"),
+            "NotFound must not emit warn"
+        );
+    }
+
+    // T-FSO-003: read_to_string_optional warns on non-NotFound errors.
+    #[test]
+    #[traced_test]
+    fn read_to_string_optional_warns_on_unexpected_error() {
+        let dir = tempdir().unwrap();
+        // Read a directory as a file — yields a non-NotFound I/O error.
+        assert_eq!(read_to_string_optional(dir.path()), None);
+        assert!(
+            logs_contain("unexpected I/O error"),
+            "non-NotFound error must emit warn"
+        );
+    }
+
+    // T-FSO-004: canonicalize_optional returns Some(canonical) for an existing path.
+    #[test]
+    fn canonicalize_optional_returns_canonical() {
+        let dir = tempdir().unwrap();
+        let resolved = canonicalize_optional(dir.path()).expect("tempdir must canonicalize");
+        assert!(resolved.is_absolute());
+    }
+
+    // T-FSO-005: canonicalize_optional returns None silently for NotFound.
+    #[test]
+    #[traced_test]
+    fn canonicalize_optional_silent_on_notfound() {
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("nope");
+        assert_eq!(canonicalize_optional(&missing), None);
+        assert!(
+            !logs_contain("canonicalize failed unexpectedly"),
+            "NotFound must not emit warn"
+        );
+    }
+
+    // T-FSO-005b: canonicalize_optional warns on non-NotFound errors.
+    #[cfg(unix)]
+    #[test]
+    #[traced_test]
+    fn canonicalize_optional_warns_on_unexpected_error() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempdir().unwrap();
+        let restricted = dir.path().join("locked");
+        stdfs::create_dir(&restricted).unwrap();
+        let inside = restricted.join("target");
+        stdfs::write(&inside, "x").unwrap();
+        // Remove search permission so canonicalize traversal yields PermissionDenied.
+        stdfs::set_permissions(&restricted, stdfs::Permissions::from_mode(0o000)).unwrap();
+        let result = canonicalize_optional(&inside);
+        // Restore permission so tempdir cleanup succeeds.
+        stdfs::set_permissions(&restricted, stdfs::Permissions::from_mode(0o700)).unwrap();
+        assert_eq!(result, None);
+        assert!(
+            logs_contain("canonicalize failed unexpectedly"),
+            "non-NotFound error must emit warn"
+        );
+    }
+
+    // T-FSO-006: read_mtime_epoch returns Some(epoch) for an existing file.
+    #[test]
+    fn read_mtime_epoch_returns_value() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("file.txt");
+        stdfs::write(&path, "x").unwrap();
+        let epoch = read_mtime_epoch(&path).expect("just-written file must have mtime");
+        assert!(epoch > 0, "epoch must be positive, got {epoch}");
+    }
+
+    // T-FSO-007: read_mtime_epoch returns None silently for NotFound.
+    #[test]
+    #[traced_test]
+    fn read_mtime_epoch_silent_on_notfound() {
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("nope.txt");
+        assert_eq!(read_mtime_epoch(&missing), None);
+        assert!(
+            !logs_contain("metadata read failed"),
+            "NotFound must not emit warn"
+        );
+    }
+
+    // T-FSO-008: read_mtime_epoch warns on non-NotFound metadata errors.
+    #[cfg(unix)]
+    #[test]
+    #[traced_test]
+    fn read_mtime_epoch_warns_on_unexpected_error() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempdir().unwrap();
+        let restricted = dir.path().join("locked");
+        stdfs::create_dir(&restricted).unwrap();
+        let inside = restricted.join("target.txt");
+        stdfs::write(&inside, "x").unwrap();
+        // Remove search permission so fs::metadata traversal yields PermissionDenied.
+        stdfs::set_permissions(&restricted, stdfs::Permissions::from_mode(0o000)).unwrap();
+        let result = read_mtime_epoch(&inside);
+        // Restore permission so tempdir cleanup succeeds.
+        stdfs::set_permissions(&restricted, stdfs::Permissions::from_mode(0o700)).unwrap();
+        assert_eq!(result, None);
+        assert!(
+            logs_contain("metadata read failed"),
+            "non-NotFound error must emit warn"
+        );
+    }
+}

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -12,10 +12,10 @@ use std::fs;
 use std::io;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-use std::time::UNIX_EPOCH;
 
 use rurico::embed::EmbedError;
 
+use crate::fs_optional;
 use crate::resolver::{Resolve, Resolver};
 use crate::rust_resolver::RustResolver;
 use crate::storage::{self, Db, RefKind, Reference, StorageError};
@@ -194,11 +194,7 @@ fn prepare_chunks(
         return None;
     }
 
-    let mtime_epoch = fs::metadata(file_path)
-        .ok()
-        .and_then(|m| m.modified().ok())
-        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-        .map(|d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX));
+    let mtime_epoch = fs_optional::read_mtime_epoch(file_path);
 
     let imports_text = file_chunks.imports.join("\n");
     let source_kind = Some(source_kind::classify(&checked.rel_path));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod brief;
 pub mod config;
 pub mod error;
+pub mod fs_optional;
 pub mod indexer;
 pub mod injection_check;
 pub mod io;

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -2,6 +2,8 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
+use crate::fs_optional;
+
 const PROBE_EXTENSIONS: &[&str] = &["tsx", "ts", "jsx", "js"];
 const SUPPORTED_EXTENSIONS: &[&str] = &["tsx", "ts", "jsx", "js", "css", "html"];
 const INDEX_FILES: &[&str] = &["index.tsx", "index.ts", "index.jsx", "index.js"];
@@ -60,7 +62,7 @@ impl Resolver {
     }
 
     pub fn new(root: &Path) -> Self {
-        let canonical_root = root.canonicalize().ok();
+        let canonical_root = fs_optional::canonicalize_optional(root);
         Self {
             root: root.to_path_buf(),
             canonical_root,

--- a/src/rust_resolver.rs
+++ b/src/rust_resolver.rs
@@ -1,6 +1,6 @@
-use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::fs_optional;
 use crate::resolver::{Resolve, strip_canonical_prefix};
 
 pub struct RustResolver {
@@ -127,7 +127,7 @@ impl RustResolver {
     }
 
     pub fn new(root: &Path) -> Self {
-        let canonical_root = root.canonicalize().ok();
+        let canonical_root = fs_optional::canonicalize_optional(root);
         let crate_name = read_crate_name(root);
         Self {
             root: root.to_path_buf(),
@@ -157,7 +157,7 @@ impl RustResolver {
 }
 
 fn read_crate_name(root: &Path) -> Option<String> {
-    let content = fs::read_to_string(root.join("Cargo.toml")).ok()?;
+    let content = fs_optional::read_to_string_optional(&root.join("Cargo.toml"))?;
     let mut in_package = false;
     for line in content.lines() {
         let trimmed = line.trim();


### PR DESCRIPTION
## 概要

- 5 sites の bare `.ok()` を `fs_optional` helper に置換 (Issue #134)
- `NotFound` = 期待される不在 (silent)、その他 = 予期しない失敗 (`tracing::warn!`)
- 9 unit tests 追加

## 修正内容

### 新規モジュール: `src/fs_optional.rs`

| Helper | 用途 |
|---|---|
| `read_to_string_optional(path)` | SIL-006 (Cargo.toml read) |
| `canonicalize_optional(path)` | SIL-007 (canonicalize ×2) |
| `read_mtime_epoch(path)` | SIL-003 + RES-002 (mtime triple .ok()) |

**共通パターン**:
```rust
match operation(path) {
    Ok(value) => Some(value),
    Err(e) if e.kind() == io::ErrorKind::NotFound => None,
    Err(e) => {
        tracing::warn!(path = %path.display(), error = %e, "<context>");
        None
    }
}
```

### Fix sites

| Site | Before | After |
|---|---|---|
| `indexer.rs:197` (SIL-003, RES-002) | `fs::metadata.ok().and_then(modified.ok()).and_then(duration_since.ok())` | `fs_optional::read_mtime_epoch(path)` |
| `rust_resolver.rs:130` (SIL-007a) | `root.canonicalize().ok()` | `fs_optional::canonicalize_optional(root)` |
| `rust_resolver.rs:159` (SIL-006) | `fs::read_to_string(Cargo.toml).ok()?` | `fs_optional::read_to_string_optional(&path)?` |
| `resolver.rs:63` (SIL-007b) | 同上 canonicalize | 同上 |
| `brief.rs:115` (SIL-004) | `debug_assert!(false)` only (release silent) | `tracing::warn!` + `debug_assert!` (dual notify) |

## 受入条件 (Issue #134)

- [x] 6 site で `.ok()` 直書き廃止 or NotFound 限定
- [x] 失敗時 warn が出ることをテストで確認 (T-FSO-005b: canonicalize PermissionDenied、T-FSO-008: mtime PermissionDenied)
- [x] `cargo test` pass (599 passed)

## ファイル変更 (6)

```
 src/brief.rs         |   4 +
 src/fs_optional.rs   | 219 +++++++++++++++++++++++++++++++++++++++++++++++++++
 src/indexer.rs       |   8 +-
 src/lib.rs           |   1 +
 src/resolver.rs      |   4 +-
 src/rust_resolver.rs |   6 +-
 6 files changed, 232 insertions(+), 10 deletions(-)
```

## テスト追加 (9 件)

| Test ID | Scenario |
|---|---|
| T-FSO-001 | read_to_string_optional: 既存ファイル content 返却 |
| T-FSO-002 | read_to_string_optional: NotFound silent |
| T-FSO-003 | read_to_string_optional: 予期しないエラーで warn (dir-as-file) |
| T-FSO-004 | canonicalize_optional: 既存パスで canonical 返却 |
| T-FSO-005 | canonicalize_optional: NotFound silent |
| T-FSO-005b | canonicalize_optional: PermissionDenied で warn (`#[cfg(unix)]`) |
| T-FSO-006 | read_mtime_epoch: 新規ファイルで正値返却 |
| T-FSO-007 | read_mtime_epoch: NotFound silent |
| T-FSO-008 | read_mtime_epoch: PermissionDenied で warn (`#[cfg(unix)]`) |

## レビュー結果 (polish)

| Tool | 結果 |
|---|---|
| code-review (high) | 2 件 fix (docstring 整合、T-FSO-005b/008 追加) |
| Codex | 0 findings |
| CodeRabbit | 0 findings |
| Gemini | Minor 1 件 (drop per spec) |

## 補足

- `resolver.rs:104, 161, 176` の bare `fs::read_to_string`/`canonicalize` は固有 error message を保持するため deferred (helper にすると "Failed to read file in re-export chain" のような context が失われる)
- `rust_resolver.rs:41, 45, 55` の `.canonicalize().ok()` は probe-and-discard pattern (候補探索の全位置で missing が想定内) のため意図的に bare のまま

## 関連

- Closes #134
- LANG.md "Error Handling" 節
- RC-002 (RC-001 logging discipline の規約準備)