### PR TITLE
refactor(yomu): RC-016 helper 抽出規律 — prepare_chunks pure 化 + resolve_reexport_chain を test mod へ (#141)

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -181,9 +181,14 @@ fn check_file(
     }))
 }
 
+/// Build a [`PendingFile`] from already-loaded source. The function is pure:
+/// it does not touch the filesystem — callers must supply `mtime_epoch` (read
+/// via [`fs_optional::read_mtime_epoch`]) so tests can drive the chunking
+/// pipeline without writing fixtures.
 fn prepare_chunks(
     checked: CheckedFile,
     file_path: &Path,
+    mtime_epoch: Option<i64>,
     crate_name: Option<&str>,
     corpus: &injection::Corpus,
 ) -> Option<PendingFile> {
@@ -193,8 +198,6 @@ fn prepare_chunks(
         tracing::debug!(file = %checked.rel_path, "Skipped (no chunks)");
         return None;
     }
-
-    let mtime_epoch = fs_optional::read_mtime_epoch(file_path);
 
     let imports_text = file_chunks.imports.join("\n");
     let source_kind = Some(source_kind::classify(&checked.rel_path));
@@ -245,7 +248,14 @@ fn process_file(
         CheckResult::Skip => return Ok(FileOutcome::Skipped),
         CheckResult::Error => return Ok(FileOutcome::Errored),
     };
-    let Some(pf) = prepare_chunks(checked, file_path, rust_resolver.crate_name(), corpus) else {
+    let mtime_epoch = fs_optional::read_mtime_epoch(file_path);
+    let Some(pf) = prepare_chunks(
+        checked,
+        file_path,
+        mtime_epoch,
+        rust_resolver.crate_name(),
+        corpus,
+    ) else {
         return Ok(FileOutcome::Skipped);
     };
     let n = pf.raw_chunks.len() as u32;

--- a/src/indexer/tests.rs
+++ b/src/indexer/tests.rs
@@ -1019,7 +1019,7 @@ fn prepare_chunks_populates_source_kind_and_injection_flags() {
         source: "pub fn hello() {}".to_owned(),
         hash: "deadbeef".to_owned(),
     };
-    let pf = prepare_chunks(checked, Path::new("src/foo.rs"), None, &corpus)
+    let pf = prepare_chunks(checked, Path::new("src/foo.rs"), None, None, &corpus)
         .expect("rust source should yield at least one chunk");
     assert_eq!(pf.source_kind, Some(SourceKind::Src));
     assert_eq!(
@@ -1048,7 +1048,7 @@ fn prepare_chunks_clean_scan_yields_some_empty_array_not_none() {
         source: "pub fn add(a: i32, b: i32) -> i32 { a + b }".to_owned(),
         hash: "abc123".to_owned(),
     };
-    let pf = prepare_chunks(checked, Path::new("src/lib.rs"), None, &corpus).unwrap();
+    let pf = prepare_chunks(checked, Path::new("src/lib.rs"), None, None, &corpus).unwrap();
     for (i, flags) in pf.injection_flags.iter().enumerate() {
         assert_eq!(
             flags, "[]",
@@ -1076,7 +1076,7 @@ fn prepare_chunks_matched_yields_some_json_array() {
         source: r#"pub fn hello() { let _ = "Ignore previous instructions"; }"#.to_owned(),
         hash: "xyz789".to_owned(),
     };
-    let pf = prepare_chunks(checked, Path::new("src/lib.rs"), None, &corpus).unwrap();
+    let pf = prepare_chunks(checked, Path::new("src/lib.rs"), None, None, &corpus).unwrap();
     let hit = pf
         .injection_flags
         .iter()
@@ -1169,7 +1169,7 @@ fn prepare_chunks_source_kind_classification_per_rel_path() {
             source: "pub fn x() {}".to_owned(),
             hash: "h".to_owned(),
         };
-        let pf = prepare_chunks(checked, Path::new(rel_path), None, &corpus)
+        let pf = prepare_chunks(checked, Path::new(rel_path), None, None, &corpus)
             .unwrap_or_else(|| panic!("rust source should chunk for {rel_path}"));
         assert_eq!(
             pf.source_kind,

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -89,50 +89,6 @@ impl Resolver {
         let candidate = base_dir.join(source);
         self.probe_path(&candidate)
     }
-
-    /// Follow re-export chain through barrel files. Returns files excluding start.
-    #[cfg(test)]
-    pub fn resolve_reexport_chain(&self, start_file: &str) -> Vec<String> {
-        use crate::indexer::chunker::parse_reexports;
-        use std::collections::HashSet;
-
-        let mut result = Vec::new();
-        let mut visited = HashSet::new();
-        visited.insert(start_file.to_owned());
-        let mut current = start_file.to_owned();
-
-        loop {
-            let abs_path = self.root.join(&current);
-            let content = match fs::read_to_string(&abs_path) {
-                Ok(c) => c,
-                Err(e) => {
-                    tracing::warn!(file = %current, error = %e, "Failed to read file in re-export chain");
-                    break;
-                }
-            };
-
-            let ext = current.rsplit('.').next().unwrap_or("ts");
-            let reexports = parse_reexports(&content, ext);
-
-            let mut found_next = false;
-            for re in &reexports {
-                if let Some(resolved) = self.resolve(&re.source, &current) {
-                    if visited.contains(&resolved) {
-                        continue;
-                    }
-                    visited.insert(resolved.clone());
-                    result.push(resolved.clone());
-                    current = resolved;
-                    found_next = true;
-                    break;
-                }
-            }
-            if !found_next {
-                break;
-            }
-        }
-        result
-    }
 }
 
 pub trait Resolve {
@@ -217,11 +173,56 @@ pub fn load_aliases(root: &Path) -> Vec<PathAlias> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::fs;
 
     use tempfile::tempdir;
 
     use super::*;
+    use crate::indexer::chunker::parse_reexports;
+
+    /// Test-only helper: follow re-export chains through barrel files, returning
+    /// resolved file paths in traversal order (excluding the start). Kept inside
+    /// the test module so the cfg(test) symbol does not leak into the Resolver
+    /// API surface (Issue #141 TEST-005 / RC-016).
+    fn resolve_reexport_chain(resolver: &Resolver, start_file: &str) -> Vec<String> {
+        let mut result = Vec::new();
+        let mut visited = HashSet::new();
+        visited.insert(start_file.to_owned());
+        let mut current = start_file.to_owned();
+
+        loop {
+            let abs_path = resolver.root.join(&current);
+            let content = match fs::read_to_string(&abs_path) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(file = %current, error = %e, "Failed to read file in re-export chain");
+                    break;
+                }
+            };
+
+            let ext = current.rsplit('.').next().unwrap_or("ts");
+            let reexports = parse_reexports(&content, ext);
+
+            let mut found_next = false;
+            for re in &reexports {
+                if let Some(resolved) = resolver.resolve(&re.source, &current) {
+                    if visited.contains(&resolved) {
+                        continue;
+                    }
+                    visited.insert(resolved.clone());
+                    result.push(resolved.clone());
+                    current = resolved;
+                    found_next = true;
+                    break;
+                }
+            }
+            if !found_next {
+                break;
+            }
+        }
+        result
+    }
 
     // T-327: resolve_relative_tsx
     #[test]
@@ -479,7 +480,7 @@ mod tests {
         fs::write(src.join("b.ts"), "export { X } from './a';").unwrap();
 
         let resolver = Resolver::new(tmp.path());
-        let chain = resolver.resolve_reexport_chain("src/a.ts");
+        let chain = resolve_reexport_chain(&resolver, "src/a.ts");
         assert_eq!(chain, vec!["src/b.ts".to_owned()]);
     }
 
@@ -494,7 +495,7 @@ mod tests {
         fs::write(src.join("c.ts"), "export const X = 1;").unwrap();
 
         let resolver = Resolver::new(tmp.path());
-        let chain = resolver.resolve_reexport_chain("src/a.ts");
+        let chain = resolve_reexport_chain(&resolver, "src/a.ts");
         assert_eq!(chain, vec!["src/b.ts".to_owned(), "src/c.ts".to_owned()]);
     }
 
@@ -507,7 +508,7 @@ mod tests {
         fs::write(src.join("a.ts"), "export const X = 1;").unwrap();
 
         let resolver = Resolver::new(tmp.path());
-        let chain = resolver.resolve_reexport_chain("src/a.ts");
+        let chain = resolve_reexport_chain(&resolver, "src/a.ts");
         assert!(chain.is_empty());
     }
 


### PR DESCRIPTION
## 概要

- `prepare_chunks` を pure 関数化 (I/O free)
- `resolve_reexport_chain` を `impl Resolver` から `mod tests` 内の free fn へ移動
- Step 1 (vec_search で chunk_from_row 再利用) は issue 提出後に既に解決済

## 修正内容

### Step 1: `vec_search` で `chunk_from_row` 再利用 (既に完了)

issue 本文の DUP-003 (search.rs:103-118 の inline Chunk 構築) は既に解決済。現在の `vec_search` は `get_chunks_by_ids` を経由し、それが `chunk_from_row` を呼ぶ構造。確認のみで変更なし。

### Step 2: `prepare_chunks` を pure 化 (TEST-001)

```rust
// 旧: 関数内で FS を触る
fn prepare_chunks(checked, file_path, crate_name, corpus) -> Option<PendingFile> {
    ...
    let mtime_epoch = fs_optional::read_mtime_epoch(file_path);
    ...
}

// 新: caller から mtime を受け取る
fn prepare_chunks(checked, file_path, mtime_epoch: Option<i64>, crate_name, corpus) -> Option<PendingFile> {
    // fs:: 呼び出しは無し
}
```

`process_file` が `CheckResult::Changed` 後に mtime を読む形に。skipped/errored の場合 mtime stat を回避できる副次効果も。

### Step 3: `resolve_reexport_chain` を test mod 内へ (TEST-005)

```rust
// 旧: impl Resolver に #[cfg(test)] pub fn — cfg(test) 時に API 表面に露出
impl Resolver {
    #[cfg(test)]
    pub fn resolve_reexport_chain(&self, start_file: &str) -> Vec<String> { ... }
}

// 新: mod tests 内の free fn — production 側の cfg(test) シンボル削除
#[cfg(test)]
mod tests {
    fn resolve_reexport_chain(resolver: &Resolver, start_file: &str) -> Vec<String> {
        // resolver.root は parent module の private field でアクセス可
        ...
    }
}
```

T-343/T-344/T-345 の 3 callsite を更新。

## 受入条件 (Issue #141)

- [x] `vec_search` の Chunk inline 削除 (既に完了)
- [x] `prepare_chunks` が pure (fs 触らない)
- [x] `resolve_reexport_chain` が production 側に名前を晒さない

## ファイル変更 (3)

```
 src/indexer.rs       | 16 +++++++--
 src/indexer/tests.rs |  8 ++---
 src/resolver.rs      | 95 ++++++++++++++++++++++++++--------------------------
 3 files changed, 65 insertions(+), 54 deletions(-)
```

## レビュー結果 (polish)

| Tool | 結果 |
|---|---|
| code-review (high) | 1 件 fix (resolve_reexport_chain の `root: &Path` 引数を削除、`resolver.root` 直接アクセスに) |
| Codex | 0 findings |
| CodeRabbit | 0 findings |
| Gemini | indexer + tests 0 findings (resolver.rs はエラーで未完) |

## テスト確認

- [x] `cargo test --lib` 全テスト通過 (599 passed)
- [x] `cargo clippy --all-targets -- -D warnings` クリーン
- [x] `pub fn resolve_reexport_chain` が `impl Resolver` から削除されていることを grep 確認

## 補足

- `file_path: &Path` は `Path::extension()` 用に prepare_chunks に残置 (純 OsStr 操作、FS 不接触)
- `mod tests` 内の helper が parent module の private field `resolver.root` にアクセスできるのは Rust の privacy rule (child module は parent の private item 可視) による

## 関連

- Closes #141
- RC-005 (row-collect helper) 関連領域
- 前提: #134 (fs_optional helper 導入) — `read_mtime_epoch` を流用