### PR TITLE
refactor(mutex): DB ロック毒化時のパニックメッセージを改善

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -281,7 +281,7 @@ fn remove_orphans(
     conn: &Arc<Mutex<Db>>,
     current_rel_paths: &HashSet<String>,
 ) -> Result<(), IndexError> {
-    let conn = conn.lock().unwrap();
+    let conn = conn.lock().expect("DB lock poisoned (remove_orphans)");
     let indexed_paths = storage::get_all_file_paths(&conn)?;
 
     let orphans: Vec<_> = indexed_paths
@@ -381,7 +381,7 @@ pub fn dry_run_index(
     let mut files_errored = 0u32;
     let mut current_rel_paths = HashSet::with_capacity(files.len());
 
-    let conn_guard = conn.lock().unwrap();
+    let conn_guard = conn.lock().expect("DB lock poisoned (dry_run_index)");
     for file_path in &files {
         let rel_path = to_rel_path(root, file_path);
         current_rel_paths.insert(rel_path.clone());
@@ -434,7 +434,9 @@ fn run_chunk_only_index_inner(
         let mut files_errored = 0u32;
         let mut current_rel_paths = HashSet::with_capacity(files.len());
 
-        let conn_guard = conn.lock().unwrap();
+        let conn_guard = conn
+            .lock()
+            .expect("DB lock poisoned (run_chunk_only_index_inner)");
         let _automerge = storage::FtsAutomergeGuard::new(&conn_guard)?;
 
         for file_path in &files {

--- a/src/indexer/embed.rs
+++ b/src/indexer/embed.rs
@@ -120,7 +120,9 @@ fn fetch_unembedded_file(
     conn: &Arc<Mutex<Db>>,
     file_path: &str,
 ) -> Result<(Vec<i64>, Vec<String>), IndexError> {
-    let conn_guard = conn.lock().unwrap();
+    let conn_guard = conn
+        .lock()
+        .expect("DB lock poisoned (fetch_unembedded_file)");
     let rows = storage::get_unembedded_chunks_for_file(&conn_guard, file_path)?;
     let imports = storage::get_imports_for_file(&conn_guard, file_path)?;
     let ids: Vec<i64> = rows.iter().map(|r| r.id).collect();
@@ -187,7 +189,7 @@ fn embed_file_chunks(
     let pairs: Vec<(i64, ChunkedEmbedding)> = chunk_ids.into_iter().zip(embeddings).collect();
     let n = pairs.len() as u32;
     {
-        let conn_guard = conn.lock().unwrap();
+        let conn_guard = conn.lock().expect("DB lock poisoned (embed_file_chunks)");
         storage::add_chunked_embeddings(&conn_guard, &pairs)?;
     }
     Ok(Some(n))
@@ -213,7 +215,9 @@ pub fn run_incremental_embed_with_progress(
     mut on_progress: impl FnMut(u32),
 ) -> Result<EmbedResult, IndexError> {
     let ordered_files = {
-        let conn_guard = conn.lock().unwrap();
+        let conn_guard = conn
+            .lock()
+            .expect("DB lock poisoned (run_incremental_embed_with_progress)");
         order_files_for_embedding(&conn_guard, type_hints)?
     };
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -536,7 +536,7 @@ pub fn search(
         }
     };
 
-    let conn = conn.lock().unwrap();
+    let conn = conn.lock().expect("DB lock poisoned (query::search)");
     let (results, stages) = search_pipeline(
         &conn,
         query,

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -866,7 +866,7 @@ impl Yomu {
         let conn = self
             .conn
             .lock()
-            .expect("brief seed inference: lock poisoned");
+            .expect("DB lock poisoned (embedder_seed_paths)");
         let results = storage::vec_search(&conn, &task_emb, max_seeds, None, &[]).map_err(
             degrade_with_warn(
                 "brief seed inference: vec_search",
@@ -888,7 +888,7 @@ impl Yomu {
         let conn = self
             .conn
             .lock()
-            .expect("brief seed inference fts fallback: lock poisoned");
+            .expect("DB lock poisoned (fts_fallback_seed_paths)");
         let results = storage::search_by_fts(
             &conn,
             &keyword_refs,
@@ -962,7 +962,7 @@ impl Yomu {
     where
         F: FnOnce(&storage::Db) -> Result<T, storage::StorageError>,
     {
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().expect("DB lock poisoned (Yomu::with_db)");
         f(&conn).map_err(YomuError::from)
     }
 


### PR DESCRIPTION
## 概要

- 10 箇所の `Mutex::lock().unwrap()` を `.expect("DB lock poisoned (function_name)")` に置換
- DB ロック毒化時の panic メッセージを greppable な形式に統一
- tools.rs:869/891 の既存の非統一メッセージも同パターンに合わせて修正

## 対象範囲

| ファイル | 行 |
|------|-------|
| src/tools.rs | 869, 891, 965 |
| src/query.rs | 539 |
| src/indexer.rs | 284, 384, 437 |
| src/indexer/embed.rs | 123, 192, 218 |

## テスト計画

- [x] cargo test -q (599 passed)
- [x] cargo clippy (clean)
- [x] /polish レビュー (code-review / codex / coderabbit / gemini 全てクリア)

Closes #139