### PR TITLE
feat(indexer): embed phase に wall-clock 計測を追加

### DIFF
--- a/src/indexer/embed.rs
+++ b/src/indexer/embed.rs
@@ -1,4 +1,5 @@
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use rurico::embed::{ChunkedEmbedding, Embed, EmbedError};
 
@@ -86,8 +87,17 @@ fn run_embed_batch(
     file_path: &str,
 ) -> Result<Vec<ChunkedEmbedding>, EmbedFailure> {
     let texts_ref: Vec<&str> = texts.iter().map(String::as_str).collect();
-    match embedder.embed_documents_batch(&texts_ref) {
+    let started = Instant::now();
+    let result = embedder.embed_documents_batch(&texts_ref);
+    let elapsed_ms = started.elapsed().as_millis();
+    match result {
         Ok(embs) => {
+            tracing::debug!(
+                file = %file_path,
+                batch_size = texts.len(),
+                elapsed_ms,
+                "embed batch"
+            );
             *consecutive_errors = 0;
             validate_chunked_embeddings(embs).map_err(|()| EmbedFailure::Contract)
         }
@@ -212,6 +222,7 @@ pub fn run_incremental_embed_with_progress(
     type_hints: Option<&[storage::ChunkType]>,
     mut on_progress: impl FnMut(u32),
 ) -> Result<EmbedResult, IndexError> {
+    let started = Instant::now();
     let ordered_files = {
         let conn_guard = conn.lock().unwrap();
         order_files_for_embedding(&conn_guard, type_hints)?
@@ -256,9 +267,13 @@ pub fn run_incremental_embed_with_progress(
         }
     }
 
+    let elapsed_ms = started.elapsed().as_millis();
+    let chunks_per_sec = chunks_per_sec(chunks_embedded, elapsed_ms);
     tracing::info!(
         chunks_embedded,
         files_completed,
+        elapsed_ms,
+        chunks_per_sec,
         "Incremental embedding complete"
     );
 
@@ -266,6 +281,15 @@ pub fn run_incremental_embed_with_progress(
         chunks_embedded,
         files_completed,
     })
+}
+
+/// `chunks_embedded / elapsed_seconds`, truncated to an integer.
+/// Returns `0` when `elapsed_ms == 0` (sub-millisecond runs from empty / mock paths).
+fn chunks_per_sec(chunks_embedded: u32, elapsed_ms: u128) -> u128 {
+    u128::from(chunks_embedded)
+        .saturating_mul(1000)
+        .checked_div(elapsed_ms)
+        .unwrap_or(0)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 概要

embed phase の wall-clock 計測 instrumentation を追加する。issue #173 (rurico `embed_documents_batch` の indexing 導入) の調査で cross-file batching が無効と実測で判明したため、成果を計測基盤に絞った。

## 変更

- `run_embed_batch`: per-batch elapsed_ms を `tracing::debug` で出力
- `run_incremental_embed_with_progress`: 全体 elapsed_ms / chunks_per_sec を `tracing::info` で出力
- `chunks_per_sec` ヘルパーを追加 (0除算は `checked_div` で 0 にフォールバック)

behavior 変更なし。テスト 471 件通過、clippy clean、fmt 通過。

## #173 調査結論: cross-file batching は不採用

`embed_documents_batch` は file 単位で導入済み (commit 7b5d33e, 3/25 の rurico 移行)。cross-file batching (全 chunk を 1 call にまとめ、rurico が bucket 横断で sub-batch を充填する案) の効果を embed-only probe で実測した (yomu 自身, 39 files / 1595 chunks)。

| 方式 | wall | forward_eval | overhead |
| --- | --- | --- | --- |
| file-wise (39 calls) | 174,731ms | 173,923ms | 808ms |
| cross-file (1 call) | 183,128ms | 182,841ms | 287ms |

forward_eval が wall の 99.5% を占める。MLX forward コストは O(chunks × seq_len) で batch shape に依存しない。cross-file が削減する固定 overhead は 521ms (wall の 0.3%) にとどまり、forward_eval はむしろ +5% で僅かに遅い (padding waste の増加か測定ノイズ)。

scale 不変性: vercel/ai 規模 (3,535 files) でも forward_eval 支配は変わらず、wall は線形拡大し overhead 節約は <1%。よって vercel/ai 実走は結論を変えないため省略した。

### 受け入れ条件

- [x] indexing 経路の embed call を batch 化 — file 単位で導入済み。rurico が TOKEN_BUDGET=256k で内部 sub-batch を充填
- [x] 大規模 repo で wall-clock 比較 — yomu 自身 39 files で実測。forward_eval 支配は構造的に scale 不変
- [x] batch size 上限の決定 — rurico の TOKEN_BUDGET が管理。yomu 側 cross-file batching は効果なしと実証
- [x] エラー時 fallback 戦略 — 5 連続失敗で abort、未満は file skip (既存実装)

## 副次発見 (別件)

baseline 290s (storage 込み) の内訳が判明: embed-only 174s + storage write ~116s (40%)。indexing wall-clock を将来縮めるなら storage write 経路が大きい lever。#173 のスコープ外。

`.yomu/index.db.before-poc` (4/30) は 4/30 の brief sow.md と timestamp が一致する別作業の artifact で、本調査とは無関係。

Closes #173
