### PR TITLE
【P2】RC-007 `under_cap` のバイト合計と `collect_closure` のメモ化／バッチ化

### DIFF
--- a/src/brief.rs
+++ b/src/brief.rs
@@ -130,11 +130,15 @@ fn build_brief_chunks(chunks: Vec<Chunk>, depth_by_path: &HashMap<String, u32>) 
         .collect()
 }
 
-fn under_cap(chunks: &[BriefChunk], max_chunks: u32, max_bytes: u32) -> bool {
-    let count = u32::try_from(chunks.len()).unwrap_or(u32::MAX);
-    let bytes: usize = chunks.iter().map(|c| c.content.len()).sum();
-    let bytes_capped = u32::try_from(bytes).unwrap_or(u32::MAX);
-    count <= max_chunks && bytes_capped <= max_bytes
+fn to_u32_saturating(n: usize) -> u32 {
+    u32::try_from(n).unwrap_or(u32::MAX)
+}
+
+/// Pure budget check on pre-computed totals. Callers compute `chunk_count`
+/// and `total_bytes` once and pass them in, so the O(n) byte sum is not
+/// repeated per call.
+fn under_cap(chunk_count: usize, total_bytes: usize, max_chunks: u32, max_bytes: u32) -> bool {
+    to_u32_saturating(chunk_count) <= max_chunks && to_u32_saturating(total_bytes) <= max_bytes
 }
 
 fn deletion_priority(
@@ -153,7 +157,8 @@ fn select_drops(
     incoming_counts: &HashMap<String, u32>,
     max_chunks: u32,
     max_bytes: u32,
-) -> HashSet<usize> {
+    total_bytes: usize,
+) -> (HashSet<usize>, usize) {
     let mut order: Vec<(usize, u32, u32)> = chunks
         .iter()
         .enumerate()
@@ -165,47 +170,50 @@ fn select_drops(
     order.sort_by(|a, b| b.1.cmp(&a.1).then(a.2.cmp(&b.2)));
 
     let mut drop_idx: HashSet<usize> = HashSet::new();
-    let mut count = u32::try_from(chunks.len()).unwrap_or(u32::MAX);
-    let mut bytes: usize = chunks.iter().map(|c| c.content.len()).sum();
+    let mut count = chunks.len();
+    let mut bytes = total_bytes;
     for (idx, _, _) in order {
-        let bytes_capped = u32::try_from(bytes).unwrap_or(u32::MAX);
-        if count <= max_chunks && bytes_capped <= max_bytes {
+        if under_cap(count, bytes, max_chunks, max_bytes) {
             break;
         }
         drop_idx.insert(idx);
         count -= 1;
         bytes -= chunks[idx].content.len();
     }
-    drop_idx
+    (drop_idx, bytes)
 }
 
 /// Applies BR-001 cap deletion order: drop chunks first by
 /// `(seed_distance DESC, incoming_edge_count ASC)`. Pure: takes pre-computed
-/// `depth_by_path` and `incoming_counts` so callers can test deterministically
-/// without DB access.
+/// `depth_by_path`, `incoming_counts`, and `total_bytes` so callers can test
+/// deterministically without DB access and the byte sum is computed once.
+/// Returns the surviving chunks paired with their total byte count.
 pub fn apply_cap(
     chunks: Vec<BriefChunk>,
     depth_by_path: &HashMap<String, u32>,
     incoming_counts: &HashMap<String, u32>,
     max_chunks: u32,
     max_bytes: u32,
-) -> Vec<BriefChunk> {
-    if under_cap(&chunks, max_chunks, max_bytes) {
-        return chunks;
+    total_bytes: usize,
+) -> (Vec<BriefChunk>, usize) {
+    if under_cap(chunks.len(), total_bytes, max_chunks, max_bytes) {
+        return (chunks, total_bytes);
     }
-    let drop_idx = select_drops(
+    let (drop_idx, remaining_bytes) = select_drops(
         &chunks,
         depth_by_path,
         incoming_counts,
         max_chunks,
         max_bytes,
+        total_bytes,
     );
-    chunks
+    let kept = chunks
         .into_iter()
         .enumerate()
         .filter(|(i, _)| !drop_idx.contains(i))
         .map(|(_, c)| c)
-        .collect()
+        .collect();
+    (kept, remaining_bytes)
 }
 
 type DepGraph = (HashMap<String, u32>, HashMap<String, Vec<String>>);
@@ -374,19 +382,27 @@ pub fn expand_plan(conn: &Connection, task: &TaskBrief) -> Result<BriefOutput, S
     let paths: Vec<&str> = depth_by_path.keys().map(String::as_str).collect();
     let chunks = get_chunks_for_files(conn, &paths)?;
     let brief_chunks = build_brief_chunks(chunks, &depth_by_path);
+    // Single byte sum reused by the cap check and the final totals.
+    let total_bytes: usize = brief_chunks.iter().map(|c| c.content.len()).sum();
 
     // BR-001 priority data is only needed when chunks exceed the budget.
-    let incoming_counts = if under_cap(&brief_chunks, task.max_chunks, task.max_bytes) {
+    let incoming_counts = if under_cap(
+        brief_chunks.len(),
+        total_bytes,
+        task.max_chunks,
+        task.max_bytes,
+    ) {
         HashMap::new()
     } else {
         get_import_counts(conn, &paths)?
     };
-    let capped = apply_cap(
+    let (capped, capped_bytes) = apply_cap(
         brief_chunks,
         &depth_by_path,
         &incoming_counts,
         task.max_chunks,
         task.max_bytes,
+        total_bytes,
     );
 
     // Edges only matter for files that survived cap; querying the pre-cap
@@ -396,9 +412,9 @@ pub fn expand_plan(conn: &Connection, task: &TaskBrief) -> Result<BriefOutput, S
     let edges = get_edges_among_files(conn, &capped_paths)?;
     let ordered = topo_sort(capped, &edges);
 
+    // topo_sort only reorders chunks, so the cap's surviving byte count holds.
     let total_chunks = u32::try_from(ordered.len()).unwrap_or(u32::MAX);
-    let total_bytes_usize: usize = ordered.iter().map(|c| c.content.len()).sum();
-    let total_bytes = u32::try_from(total_bytes_usize).unwrap_or(u32::MAX);
+    let total_bytes = to_u32_saturating(capped_bytes);
 
     Ok(BriefOutput {
         chunks: ordered,

--- a/src/brief.rs
+++ b/src/brief.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use crate::injection_check::InjectionCheck;
 use crate::storage::{
     Chunk, ChunkType, SourceKind, StorageError, get_chunks_for_files, get_edges_among_files,
-    get_import_counts, get_transitive_dependencies,
+    get_import_counts, get_transitive_dependencies_multi,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -85,20 +85,11 @@ fn collect_closure(
     seeds: &[String],
     depth: u32,
 ) -> Result<HashMap<String, u32>, StorageError> {
-    let mut depth_by_path: HashMap<String, u32> = HashMap::new();
-    for seed in seeds {
-        for dep in get_transitive_dependencies(conn, seed, depth)? {
-            depth_by_path
-                .entry(dep.file_path)
-                .and_modify(|d| {
-                    if dep.depth < *d {
-                        *d = dep.depth;
-                    }
-                })
-                .or_insert(dep.depth);
-        }
-    }
-    Ok(depth_by_path)
+    // Single recursive query over all seeds; `MIN(depth)` inside the query
+    // already collapses per-seed distances, so no Rust-side merge is needed.
+    let seed_refs: Vec<&str> = seeds.iter().map(String::as_str).collect();
+    let deps = get_transitive_dependencies_multi(conn, &seed_refs, depth)?;
+    Ok(deps.into_iter().map(|d| (d.file_path, d.depth)).collect())
 }
 
 fn determine_reason(depth: u32) -> ChunkInclusionReason {

--- a/src/brief.rs
+++ b/src/brief.rs
@@ -413,7 +413,7 @@ pub fn expand_plan(conn: &Connection, task: &TaskBrief) -> Result<BriefOutput, S
     let ordered = topo_sort(capped, &edges);
 
     // topo_sort only reorders chunks, so the cap's surviving byte count holds.
-    let total_chunks = u32::try_from(ordered.len()).unwrap_or(u32::MAX);
+    let total_chunks = to_u32_saturating(ordered.len());
     let total_bytes = to_u32_saturating(capped_bytes);
 
     Ok(BriefOutput {

--- a/src/brief/tests.rs
+++ b/src/brief/tests.rs
@@ -113,7 +113,8 @@ fn apply_cap_drops_high_depth_low_incoming_first() {
     .into_iter()
     .collect();
 
-    let kept = apply_cap(chunks, &depth_by_path, &incoming_counts, 2, u32::MAX);
+    // Count cap (2) drives the drop; byte budget is unbounded (4 bytes total).
+    let (kept, _remaining) = apply_cap(chunks, &depth_by_path, &incoming_counts, 2, u32::MAX, 4);
 
     assert_eq!(kept.len(), 2);
     let kept_paths: Vec<&str> = kept.iter().map(|c| c.file_path.as_str()).collect();
@@ -124,6 +125,50 @@ fn apply_cap_drops_high_depth_low_incoming_first() {
     assert!(
         kept_paths.contains(&"src/b.rs"),
         "depth=1 incoming=5 must survive over depth=1 incoming=2, got: {kept_paths:?}"
+    );
+}
+
+// T-608: apply_cap_drops_to_fit_byte_budget [COV-001]
+//
+// Byte budget (not count) drives the drop: 4 chunks of 4 bytes each = 16,
+// budget 8 forces dropping the two lowest-priority chunks (highest depth,
+// lowest incoming). The returned remaining byte count must match survivors.
+#[test]
+fn apply_cap_drops_to_fit_byte_budget() {
+    let chunks = vec![
+        make_brief_chunk("src/a.rs", "aaaa"),
+        make_brief_chunk("src/b.rs", "bbbb"),
+        make_brief_chunk("src/c.rs", "cccc"),
+        make_brief_chunk("src/d.rs", "dddd"),
+    ];
+    let depth_by_path: HashMap<String, u32> = [
+        ("src/a.rs".to_owned(), 0),
+        ("src/b.rs".to_owned(), 1),
+        ("src/c.rs".to_owned(), 1),
+        ("src/d.rs".to_owned(), 2),
+    ]
+    .into_iter()
+    .collect();
+    let incoming_counts: HashMap<String, u32> = [
+        ("src/a.rs".to_owned(), 10),
+        ("src/b.rs".to_owned(), 5),
+        ("src/c.rs".to_owned(), 2),
+        ("src/d.rs".to_owned(), 1),
+    ]
+    .into_iter()
+    .collect();
+
+    let (kept, remaining) = apply_cap(chunks, &depth_by_path, &incoming_counts, u32::MAX, 8, 16);
+
+    let kept_paths: Vec<&str> = kept.iter().map(|c| c.file_path.as_str()).collect();
+    assert_eq!(
+        kept_paths,
+        vec!["src/a.rs", "src/b.rs"],
+        "byte cap must keep the two highest-priority chunks, got: {kept_paths:?}"
+    );
+    assert_eq!(
+        remaining, 8,
+        "remaining bytes must equal the surviving chunks' total"
     );
 }
 

--- a/src/storage/graph.rs
+++ b/src/storage/graph.rs
@@ -107,31 +107,59 @@ pub fn get_edges_among_files(
 
 /// Forward closure: files that `seed` transitively depends on, ordered by
 /// distance ascending. `seed` itself is included at depth 0 so brief output
-/// can group seed chunks alongside their forward dependencies. Reuses
-/// `Dependent` for shape; direction is implicit from the function name.
+/// can group seed chunks alongside their forward dependencies. Thin wrapper
+/// over [`get_transitive_dependencies_multi`].
 pub fn get_transitive_dependencies(
     conn: &Connection,
     seed: &str,
     max_depth: u32,
 ) -> Result<Vec<Dependent>, StorageError> {
+    get_transitive_dependencies_multi(conn, &[seed], max_depth)
+}
+
+/// Forward closure from multiple seeds in a single recursive query. Each seed
+/// is injected at depth 0; a file reachable from several seeds takes the
+/// minimum per-seed distance via `MIN(depth)`. Ordered by distance ascending,
+/// then file_path. Reuses `Dependent` for shape; direction is implicit from
+/// the function name. Returns an empty vec when `seeds` is empty.
+pub fn get_transitive_dependencies_multi(
+    conn: &Connection,
+    seeds: &[&str],
+    max_depth: u32,
+) -> Result<Vec<Dependent>, StorageError> {
+    if seeds.is_empty() {
+        return Ok(Vec::new());
+    }
     let max_depth = max_depth.min(10);
-    // See `get_transitive_dependents` for the cycle-handling rationale.
-    // `r.target_file != ?1` blocks back-edges to the seed; the seed is
-    // injected once at depth=0 in the anchor, so this only suppresses
-    // wasteful re-visits inside the recursion.
-    let mut stmt = conn.prepare_cached(
-        "WITH RECURSIVE deps(file_path, depth) AS (
-            SELECT ?1, 0
-          UNION
-            SELECT r.target_file, d.depth + 1
-            FROM file_references r
-            INNER JOIN deps d ON r.source_file = d.file_path
-            WHERE d.depth < ?2 AND r.target_file != ?1
-        )
-        SELECT file_path, MIN(depth) as depth
-        FROM deps GROUP BY file_path ORDER BY depth, file_path",
-    )?;
-    let rows = stmt.query_map(rusqlite::params![seed, max_depth], |row| {
+    // See `get_transitive_dependents` for the UNION cycle-handling rationale.
+    // Seeds ride in a CTE so the same bound values feed both the depth-0
+    // anchor and the `NOT IN` guard. `r.target_file NOT IN (carrier)` blocks
+    // back-edges to any seed; each seed is injected once at depth 0, so this
+    // only suppresses wasteful re-visits. Per-seed depths collapse via
+    // MIN(depth).
+    let carrier = (1..=seeds.len())
+        .map(|i| format!("SELECT ?{i}"))
+        .collect::<Vec<_>>()
+        .join(" UNION ALL ");
+    let depth_ph = seeds.len() + 1;
+    let sql = format!(
+        "WITH RECURSIVE
+           carrier(value) AS ({carrier}),
+           deps(file_path, depth) AS (
+             SELECT value, 0 FROM carrier
+           UNION
+             SELECT r.target_file, d.depth + 1
+             FROM file_references r
+             INNER JOIN deps d ON r.source_file = d.file_path
+             WHERE d.depth < ?{depth_ph} AND r.target_file NOT IN (SELECT value FROM carrier)
+           )
+         SELECT file_path, MIN(depth) AS depth
+         FROM deps GROUP BY file_path ORDER BY depth, file_path"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let mut params = as_sql_params(seeds);
+    params.push(&max_depth);
+    let rows = stmt.query_map(params.as_slice(), |row| {
         Ok(Dependent {
             file_path: row.get(0)?,
             depth: row.get(1)?,

--- a/src/storage/graph.rs
+++ b/src/storage/graph.rs
@@ -136,15 +136,16 @@ pub fn get_transitive_dependencies_multi(
     // anchor and the `NOT IN` guard. `r.target_file NOT IN (carrier)` blocks
     // back-edges to any seed; each seed is injected once at depth 0, so this
     // only suppresses wasteful re-visits. Per-seed depths collapse via
-    // MIN(depth).
+    // MIN(depth). The carrier is a `VALUES` list (not chained `UNION ALL`) so
+    // a large seed set does not trip SQLITE_LIMIT_COMPOUND_SELECT (500).
     let carrier = (1..=seeds.len())
-        .map(|i| format!("SELECT ?{i}"))
+        .map(|i| format!("(?{i})"))
         .collect::<Vec<_>>()
-        .join(" UNION ALL ");
+        .join(", ");
     let depth_ph = seeds.len() + 1;
     let sql = format!(
         "WITH RECURSIVE
-           carrier(value) AS ({carrier}),
+           carrier(value) AS (VALUES {carrier}),
            deps(file_path, depth) AS (
              SELECT value, 0 FROM carrier
            UNION

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -1204,6 +1204,89 @@ fn get_transitive_dependencies_similar_paths_no_collision() {
     );
 }
 
+// T-585: get_transitive_dependencies_multi_aggregates_min_depth
+//
+// Two seeds reach a shared file via paths of different length. The result
+// must carry the minimum per-seed depth: src/z.rs is depth 2 from src/a.rs
+// (a -> y -> z) but depth 1 from src/b.rs (b -> z), so MIN wins at 1.
+#[test]
+fn get_transitive_dependencies_multi_aggregates_min_depth() {
+    let (conn, _dir) = test_db();
+    let edge = |src: &str, tgt: &str| Reference {
+        source_file: src.into(),
+        target_file: tgt.into(),
+        symbol_name: None,
+        ref_kind: RefKind::Named,
+    };
+    replace_file_references(&conn, "src/a.rs", &[edge("src/a.rs", "src/y.rs")]).unwrap();
+    replace_file_references(&conn, "src/y.rs", &[edge("src/y.rs", "src/z.rs")]).unwrap();
+    replace_file_references(&conn, "src/b.rs", &[edge("src/b.rs", "src/z.rs")]).unwrap();
+
+    let deps = get_transitive_dependencies_multi(&conn, &["src/a.rs", "src/b.rs"], 5).unwrap();
+
+    assert_eq!(
+        deps,
+        vec![
+            Dependent {
+                file_path: "src/a.rs".into(),
+                depth: 0,
+            },
+            Dependent {
+                file_path: "src/b.rs".into(),
+                depth: 0,
+            },
+            Dependent {
+                file_path: "src/y.rs".into(),
+                depth: 1,
+            },
+            Dependent {
+                file_path: "src/z.rs".into(),
+                depth: 1,
+            },
+        ],
+        "shared dependency must take the minimum per-seed depth",
+    );
+}
+
+// T-586: get_transitive_dependencies_multi_seed_as_dependency_stays_depth_zero
+//
+// When one seed (src/b.rs) is reachable from another (src/a.rs -> src/x.rs ->
+// src/b.rs), the back-edge to the seed is suppressed and src/b.rs stays at
+// depth 0 from its own anchor row, not depth 2.
+#[test]
+fn get_transitive_dependencies_multi_seed_as_dependency_stays_depth_zero() {
+    let (conn, _dir) = test_db();
+    let edge = |src: &str, tgt: &str| Reference {
+        source_file: src.into(),
+        target_file: tgt.into(),
+        symbol_name: None,
+        ref_kind: RefKind::Named,
+    };
+    replace_file_references(&conn, "src/a.rs", &[edge("src/a.rs", "src/x.rs")]).unwrap();
+    replace_file_references(&conn, "src/x.rs", &[edge("src/x.rs", "src/b.rs")]).unwrap();
+
+    let deps = get_transitive_dependencies_multi(&conn, &["src/a.rs", "src/b.rs"], 5).unwrap();
+
+    assert_eq!(
+        deps,
+        vec![
+            Dependent {
+                file_path: "src/a.rs".into(),
+                depth: 0,
+            },
+            Dependent {
+                file_path: "src/b.rs".into(),
+                depth: 0,
+            },
+            Dependent {
+                file_path: "src/x.rs".into(),
+                depth: 1,
+            },
+        ],
+        "a seed that is also a dependency must stay at depth 0",
+    );
+}
+
 fn get_chunk_ids(conn: &Connection, file_path: &str) -> Vec<i64> {
     let mut stmt = conn
         .prepare("SELECT id FROM chunks WHERE file_path = ?1 ORDER BY id")

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -1287,6 +1287,44 @@ fn get_transitive_dependencies_multi_seed_as_dependency_stays_depth_zero() {
     );
 }
 
+// T-587: get_transitive_dependencies_multi_dedups_duplicate_seeds
+//
+// A path passed twice as a seed must collapse to a single depth-0 row, not
+// two. Pins the SQLite UNION dedup the multi-seed carrier relies on (the
+// carrier emits one VALUES row per seed, including duplicates).
+#[test]
+fn get_transitive_dependencies_multi_dedups_duplicate_seeds() {
+    let (conn, _dir) = test_db();
+    replace_file_references(
+        &conn,
+        "src/a.rs",
+        &[Reference {
+            source_file: "src/a.rs".into(),
+            target_file: "src/b.rs".into(),
+            symbol_name: None,
+            ref_kind: RefKind::Named,
+        }],
+    )
+    .unwrap();
+
+    let deps = get_transitive_dependencies_multi(&conn, &["src/a.rs", "src/a.rs"], 5).unwrap();
+
+    assert_eq!(
+        deps,
+        vec![
+            Dependent {
+                file_path: "src/a.rs".into(),
+                depth: 0,
+            },
+            Dependent {
+                file_path: "src/b.rs".into(),
+                depth: 1,
+            },
+        ],
+        "a duplicate seed must collapse to a single depth-0 row",
+    );
+}
+
 fn get_chunk_ids(conn: &Connection, file_path: &str) -> Vec<i64> {
     let mut stmt = conn
         .prepare("SELECT id FROM chunks WHERE file_path = ?1 ORDER BY id")


### PR DESCRIPTION
## What & Why

brief の forward-closure 取得と cap 判定にあった冗長な計算を削る。collect_closure は seed ごとに recursive CTE を 1 本ずつ発行し（最大 5 seed = 5 query）、cap 判定は同じ byte 合計を 3 回計算していた。これらを 1 query / 1 計算にまとめ、調査・計画フェーズの `yomu brief` のコストを下げる。

## Changes

- collect_closure を multi-seed の 1 query 化。`get_transitive_dependencies_multi` を新設し、単一 seed 版はその thin wrapper に。seed 間の距離集約は SQL の `MIN(depth)` が担い、Rust 側のマージループを削除
- cap の byte 合計を expand_plan で 1 回だけ計算し `under_cap` / `select_drops` / `apply_cap` に引き回す。`apply_cap` は `(chunks, remaining_bytes)` を返し、最終 total_bytes の再計算も削除
- carrier を `VALUES` 化し、501+ seeds で SQLite の compound SELECT 上限 (500) に当たる新規 failure mode を回避
- 最終 total_chunks のキャストを `to_u32_saturating` ヘルパーに統一

## Scope

- **含まない**: visited-set encoding の改善（RC-018 で別途）

## Design Decisions

- Issue 提案の visited-set SQL（`',' || target_file || ','` + INSTR）は不採用。path に comma を含むと（例 `src/a,b.rs`）既訪問判定が部分一致で誤爆し depth が狂う（T-582 で再現）。既存の `UNION` ベースのサイクル処理を維持したまま multi-seed 化した
- carrier は chained `UNION ALL` ではなく `VALUES`。`UNION ALL` は compound SELECT の項数として数えられ 500 で頭打ちになるが `VALUES` は数えられない（sqlite3 で 5000 行 VALUES は通過、501 項 UNION ALL は parse error を実証）

## How to Test

1. `cargo test --lib` → 603 passed
2. `cargo test --lib get_transitive` → multi-seed (T-585/586/587) と単一版 wrapper (T-572/573/582/584) が両方 green
3. `cargo test --lib brief` → cap の byte path (T-608) / count path (T-601) と expand_plan の determinism (T-603) が green

## Related

- Closes #136
