### PR TITLE
test: #138 未カバー分岐へのテスト追加 6 件 (Step1)

### DIFF
--- a/src/brief/tests.rs
+++ b/src/brief/tests.rs
@@ -526,3 +526,59 @@ fn render_json_emits_injection_check_even_with_empty_chunks() {
         "BR-302: injection_check must be present at top level even when chunks is empty (no skip_serializing_if), got: {parsed}"
     );
 }
+
+// T-701: topo_sort_places_cycle_members_at_tail [Issue #138 COV-002]
+// BR-002: a cycle (a -> b -> a) leaves every node with a non-zero out-degree,
+// so the Kahn pass orders nothing and append_cycle_tail must place the cycle
+// members at the tail in lexicographic order.
+#[test]
+fn topo_sort_places_cycle_members_at_tail() {
+    let chunks = vec![
+        make_brief_chunk("src/b.rs", "b"),
+        make_brief_chunk("src/a.rs", "a"),
+    ];
+    let edges = vec![
+        ("src/a.rs".to_owned(), "src/b.rs".to_owned()),
+        ("src/b.rs".to_owned(), "src/a.rs".to_owned()),
+    ];
+
+    let sorted = topo_sort(chunks, &edges);
+
+    let order: Vec<&str> = sorted.iter().map(|c| c.file_path.as_str()).collect();
+    assert_eq!(
+        order,
+        vec!["src/a.rs", "src/b.rs"],
+        "BR-002: cycle members have no topological order; append_cycle_tail orders them lexicographically"
+    );
+}
+
+// T-702: expand_plan_queries_import_counts_when_over_cap [Issue #138]
+// BR-001: when the seed closure yields more chunks than max_chunks, expand_plan
+// takes the over-budget branch (get_import_counts) and drops to the cap. depth=1
+// with an import-free seed keeps the closure to src/a.rs alone, so its three
+// chunks exceed a max_chunks of 1.
+#[test]
+fn expand_plan_queries_import_counts_when_over_cap() {
+    let (conn, _dir) = test_db();
+    insert_test_chunk(&conn, "src/a.rs", "a1", 1);
+    insert_test_chunk(&conn, "src/a.rs", "a2", 10);
+    insert_test_chunk(&conn, "src/a.rs", "a3", 20);
+
+    let task = TaskBrief {
+        task: "find body".to_owned(),
+        seeds: vec![seed_file("src/a.rs")],
+        depth: 1,
+        max_chunks: 1,
+        max_bytes: 80_000,
+    };
+
+    let output = expand_plan(&conn, &task).unwrap();
+
+    assert_eq!(
+        output.chunks.len(),
+        1,
+        "BR-001: max_chunks=1 must drop the 3 seed chunks down to a single survivor"
+    );
+    assert_eq!(output.total_chunks, 1);
+    assert!(!output.degraded, "a satisfiable seed must not degrade");
+}

--- a/src/rust_resolver/tests.rs
+++ b/src/rust_resolver/tests.rs
@@ -369,3 +369,35 @@ fn resolve_without_cargo_toml_falls_through() {
         "crate:: must keep working when crate_name is None"
     );
 }
+
+// T-704: resolve_mod_decl_returns_none_when_target_absent [Issue #138 COV-005]
+// FR-002: `mod missing;` with neither src/missing.rs nor src/missing/mod.rs
+// present resolves to None (no panic, no false match).
+#[test]
+fn resolve_mod_decl_returns_none_when_target_absent() {
+    let tmp = tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("src")).unwrap();
+
+    let resolver = RustResolver::new(tmp.path());
+    assert_eq!(resolver.resolve_mod_decl("missing", "src/lib.rs"), None);
+}
+
+// T-705: resolve_mod_decl_via_resolve_trait_delegates [Issue #138 COV-005]
+// The Resolve trait impl forwards resolve_mod_decl to the inherent method
+// (rust_resolver.rs:189-191); calling through &dyn Resolve must match the
+// inherent resolution.
+#[test]
+fn resolve_mod_decl_via_resolve_trait_delegates() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("foo.rs"), "").unwrap();
+
+    let resolver = RustResolver::new(tmp.path());
+    let via_trait: &dyn Resolve = &resolver;
+    assert_eq!(
+        via_trait.resolve_mod_decl("foo", "src/lib.rs"),
+        Some("src/foo.rs".to_owned()),
+        "Resolve::resolve_mod_decl must delegate to the inherent resolver"
+    );
+}

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -2723,6 +2723,28 @@ fn yomu_brief_rejects_empty_task() {
     );
 }
 
+// T-703: yomu_brief_rejects_symbol_seed [Issue #138 COV-004]
+// FR-010b: --seed-symbol is not yet implemented, so a TaskBrief carrying any
+// Symbol-kind seed must be rejected with SeedSymbolUnimplemented before any
+// closure expansion runs.
+#[test]
+fn yomu_brief_rejects_symbol_seed() {
+    let (yomu, _dir) = test_yomu();
+    let mut task = brief_task("src/a.rs");
+    task.seeds = vec![brief::Seed {
+        kind: brief::SeedKind::Symbol,
+        value: "Foo".to_owned(),
+    }];
+    let err = yomu.brief(&task, false).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            YomuError::InvalidInput(InvalidInputKind::SeedSymbolUnimplemented)
+        ),
+        "Symbol seed must be rejected with SeedSymbolUnimplemented, got: {err:?}"
+    );
+}
+
 // --- CliError / ErrorCode mapping (ADR-0066 Group 2) ---
 
 fn io_err() -> io::Error {

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1081,6 +1081,36 @@ fn brief_integration_rejects_empty_task() {
     );
 }
 
+// T-706: brief_integration_rejects_seed_symbol [Issue #138 COV-008]
+// FR-010b: --seed-symbol is not yet implemented. The CLI must exit 64
+// (sysexits USAGE) and point the user at --seed-file.
+#[test]
+fn brief_integration_rejects_seed_symbol() {
+    let dir = setup_brief_chain_project();
+    let output = yomu_cmd()
+        .args(["brief", "find work", "--seed-symbol", "work"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "--seed-symbol must fail, got success with: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(64),
+        "--seed-symbol must exit 64 (sysexits USAGE), got: {:?} (stderr: {})",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("seed-file"),
+        "rejection must point the user at --seed-file, got stderr: {stderr}"
+    );
+}
+
 // T-612: brief_integration_json_output_includes_chunks [Spec FR-012]
 #[test]
 fn brief_integration_json_output_includes_chunks() {


### PR DESCRIPTION
## 概要

Issue #138 (RC-010) Step1: 未カバー分岐へのテスト追加 6 件。プロダクションコード変更なし、テスト追加のみ。

## 変更内容

| Test | 解消対象 | 内容 |
| ---- | -------- | ---- |
| T-701 | brief.rs:246-248 | topo_sort cycle tail 配置 (append_cycle_tail) |
| T-702 | brief.rs:397 | expand_plan cap 超過経路 (get_import_counts) |
| T-703 | tools.rs:920-922 | Symbol seed の reject |
| T-704-705 | rust_resolver.rs:189-191 | Resolve trait 委譲 |
| T-706 | CLI | `--seed-symbol` の reject (exit 64) |

解消した COV 項目: COV-002, COV-004, COV-005, + brief:397

## 到達不可で残置 (ADR-0062 準拠)

- `brief.rs:271` — kahn の if-let None アーム。build_dep_graph の構造上 dep は必ず out_degree に存在するため到達不可
- `brief.rs:108-118` — build_brief_chunks の debug_assert 防御コード

## 関連

- Closes #138 (Step1)
- coverage gate 整備 (Step2) は #223 に分離
