### PR TITLE
test: diff coverage gate の fail 動作確認 (DO NOT MERGE)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,13 +49,13 @@ jobs:
         run: cargo fmt -- --check
 
   coverage:
-    # Diff coverage gate. PR が追加/変更した行のテストカバレッジを直接判定し、
-    # threshold を下回ると fail させる。新規の未カバーコード (pub fn / 分岐) が
-    # テストなしで merge されるのを防ぐ。全体 percent の floor は持たない
-    # (既存の到達不可コードを誤検出しないため)。base との 2 回測定も不要。
-    # 根拠: Issue #223, THRESHOLDS.md "Coverage" 節。
-    # mlx-sys (MLX FFI) は BLAS + Apple silicon を要求し Linux でビルド不可。
-    # test job と同じ macos で測定する (ubuntu では mlx-sys ビルドが失敗する)。
+    # Diff coverage gate: fail when coverage of the lines this PR adds or
+    # changes drops below the threshold, so new uncovered code (pub fn /
+    # branches) cannot merge untested. No overall-percent floor (which would
+    # flag existing unreachable code); no base-vs-PR double measurement.
+    # Rationale: Issue #223, THRESHOLDS.md "Coverage" section.
+    # Runs on macos like the test job: mlx-sys (MLX FFI) needs BLAS + Apple
+    # silicon and cannot build on Linux.
     runs-on: macos-latest
     timeout-minutes: 30
     if: github.event_name == 'pull_request'
@@ -88,8 +88,8 @@ jobs:
       - name: Diff coverage gate (changed lines >= 95%)
         run: |
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-          # diff-cover は Python ツール。PEP 668 (Ubuntu の externally-managed)
-          # と runner image の pipx 有無に依存しないよう venv で隔離する。
+          # diff-cover is a Python tool; isolate it in a venv to avoid PEP 668
+          # (externally-managed environments) regardless of the runner's Python.
           python3 -m venv /tmp/diff-cover-venv
           /tmp/diff-cover-venv/bin/pip install --quiet diff-cover
           /tmp/diff-cover-venv/bin/diff-cover lcov.info \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,52 @@ jobs:
       - name: Format check
         run: cargo fmt -- --check
 
+  coverage:
+    # Diff coverage gate. PR が追加/変更した行のテストカバレッジを直接判定し、
+    # threshold を下回ると fail させる。新規の未カバーコード (pub fn / 分岐) が
+    # テストなしで merge されるのを防ぐ。全体 percent の floor は持たない
+    # (既存の到達不可コードを誤検出しないため)。base との 2 回測定も不要。
+    # 根拠: Issue #223, THRESHOLDS.md "Coverage" 節。
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
+        with:
+          toolchain: stable
+          components: llvm-tools-preview
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2.78.1
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate lcov coverage
+        run: cargo llvm-cov --lcov --output-path lcov.info
+
+      - name: Diff coverage gate (changed lines >= 95%)
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          # diff-cover は Python ツール。PEP 668 (Ubuntu の externally-managed)
+          # と runner image の pipx 有無に依存しないよう venv で隔離する。
+          python3 -m venv /tmp/diff-cover-venv
+          /tmp/diff-cover-venv/bin/pip install --quiet diff-cover
+          /tmp/diff-cover-venv/bin/diff-cover lcov.info \
+            --compare-branch=origin/main \
+            --fail-under=95
+
   security:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,9 @@ jobs:
     # テストなしで merge されるのを防ぐ。全体 percent の floor は持たない
     # (既存の到達不可コードを誤検出しないため)。base との 2 回測定も不要。
     # 根拠: Issue #223, THRESHOLDS.md "Coverage" 節。
-    runs-on: ubuntu-latest
+    # mlx-sys (MLX FFI) は BLAS + Apple silicon を要求し Linux でビルド不可。
+    # test job と同じ macos で測定する (ubuntu では mlx-sys ビルドが失敗する)。
+    runs-on: macos-latest
     timeout-minutes: 30
     if: github.event_name == 'pull_request'
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 docs/
 target/
 workspace/
+
+# Coverage artifacts (cargo llvm-cov)
+*.profraw
+/lcov.info

--- a/src/diff_cover_probe.rs
+++ b/src/diff_cover_probe.rs
@@ -1,0 +1,8 @@
+//! Throwaway probe for verifying the diff coverage gate. This module exists
+//! only on the test/verify-diff-cover-fail branch and must be deleted with it.
+
+/// Intentionally untested so diff-cover sees an uncovered added line and the
+/// coverage gate fails. Not called from anywhere.
+pub fn probe(n: usize) -> usize {
+    n.saturating_add(1)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod brief;
 pub mod config;
+pub mod diff_cover_probe;
 pub mod error;
 pub mod fs_optional;
 pub mod indexer;


### PR DESCRIPTION
## DO NOT MERGE — 使い捨て検証 PR

diff coverage gate (#223, PR #225) が未カバーの新規行を検出して fail するかを確認するための使い捨て PR。

`src/diff_cover_probe.rs` にテストのない `pub fn probe` を追加。coverage job の diff-cover が変更行カバレッジを判定し、未カバーの probe 関数により `--fail-under=95` を下回って **fail することを期待**する。

確認後すぐ close + ブランチ削除する。
