### PR TITLE
test: 実装の言い換えにすぎないテストを排除 (T-311 削除・全件精査)

### DIFF
--- a/src/tools/embedder.rs
+++ b/src/tools/embedder.rs
@@ -165,15 +165,3 @@ impl Yomu {
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // T-311: disabled_returns_disabled_reason
-    #[test]
-    fn disabled_returns_disabled_reason() {
-        let result = try_load_embedder(true);
-        assert!(matches!(result, Err(DegradedReason::Disabled)));
-    }
-}


### PR DESCRIPTION
## 結論

テストを「実装をなぞるだけのテスト」の4カテゴリで全件精査し、削除1件 (T-311) / 書き換え0件 / 他は全保持とした。`cargo nextest run` (688 passed, 4 skipped) と `cargo clippy --all-targets` (警告なし) は緑。

削除が1件にとどまるのは、過去のセッションで同種クリーンアップが既に実施済み (redundant な T-003 削除、vacuous guard の T-017 修正など) で現状の suite が既に高品質なため。網羅調査の結果としての「ほぼゼロ」であり、見逃しではない。

## 削除 (1件)

`src/tools/embedder.rs` の `disabled_returns_disabled_reason` (T-311)。

- `try_load_embedder(true)` の `if disabled { Err(Disabled) }` 分岐をそのままなぞる直接単体テスト (カテゴリ③内部関数の直接テスト + ④分岐なぞりエラー)。
- 公開 API テスト T-233 `embed_disabled_yields_degraded_disabled` が `Yomu::for_test_embed_disabled` -> `get_embedder` -> `try_embedder` -> `try_load_embedder(true)` 経由で同じ分岐を既にカバー。削除でカバレッジは落ちない (実装対比で確認)。
- `DegradedReason` は内部 enum で wire format などの外部契約を pin しない。

## カテゴリ別の判定

| カテゴリ | 候補 | 判定 |
| --- | --- | --- |
| ① mock 往復確認 | 0 | MockEmbedder / FailingEmbedder / MockReranker / ScriptedReranker / MismatchEmbedder などは全て実パイプライン (search / embed / rerank) を駆動し公開出力を検証。mock の戻り値そのものを assert する往復は不在 |
| ② トートロジー | 0 | const との assert (`parse_budget_value` -> `DEFAULT_EMBED_BUDGET` など) は境界 / 配線 / round-trip の検証。契約値は exit code (64/70/73/74/75)・budget 範囲 (1/500)・JSON 文字列 (`"ran"` / `"src"`) をリテラルで pin 済み |
| ③ 内部関数の直接テスト | 1 (T-311) | `chunk_*` / `format_*` / `extract_keywords` / `rerank_*` / graph 探索などは Logic 層の固有エッジで公開テストに重複なし -> 保持。公開テストで代替可能なのは T-311 のみ |
| ④ 分岐なぞりエラー | 1 (T-311 と同一) | 他のエラーテスト (NoQuery の2メッセージ、RC-005 の I/O 非握り潰し、InvalidInput 検証、EmbedderUnavailable の2要因) は振る舞い / UX 契約を pin |

## 書き換え (0件)

外部契約を pin するテストはトートロジー形ではなくリテラル形で既に書かれているため書き換え不要。

最も弱い候補は T-CFG001 の `assert_eq!(cfg.embed_budget, DEFAULT_EMBED_BUDGET)` だが、これは default-off 配線契約 (`embed_disabled` / `rerank_enabled` を bool リテラルで pin) の一部であり、`DEFAULT_EMBED_BUDGET` の数値自体は wire 契約でなく調整可能な default。「env 不在 -> default 配線」の検証として保持。

## addendum の契約名の読み替え

addendum の固有契約名 (`PROBE_EXIT_*` / `FORWARD allowlist` / `BUCKET_BOUNDS`) は rurico のものであり yomu には存在しない。yomu の実契約に読み替えて保持判定に適用した:

- wire format = `--json` スキーマ (`error.rs` の exit code / envelope、`format.rs` の injection_flags / source_kind / injection_check、`brief` の render_json)
- allowlist 相当 = injection corpus (`indexer/injection/tests.rs` の FR-006〜009、BR-004 の flag 順序 invariant、ADR-0069 の `schema_rs_has_no_alter_add_column` 静的チェック)
- spec gate = `tests/verification.rs` T-401 (`MUST NOT be #[ignore]` 明記)
- MLX / bench / timing の `#[ignore]` (T-291 / T-297 / log_emit_latency / bench_search_hot_path) は外部依存で軽量代替不可のため据え置き

## 検証

- `cargo nextest run`: 688 passed, 4 skipped (削除前 689 -> 688)
- `cargo clippy --all-targets --no-deps`: 警告なし
- Cargo.lock 変更なし、無関係な生成物なし
