### PR TITLE
feat(tools): 検索時の自動 index を廃止して read-only 化

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,9 @@ Examples:
   yomu search \"streaming chat hooks\"
   yomu search --from src/query.rs:rerank
   yomu search \"auth\" --path src/auth --limit 5
-  yomu --json search \"useAuth\"")]
+  yomu --json search \"useAuth\"
+
+Search is read-only; build the index first with `yomu index` then `yomu embed`.")]
     Search {
         /// Natural language query (reads from stdin if omitted or "-")
         query: Option<String>,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -81,18 +81,6 @@ pub fn get_stats(conn: &Connection) -> Result<IndexStatus, StorageError> {
     })
 }
 
-pub fn is_index_fresh(conn: &Connection, max_age_secs: u32) -> Result<bool, StorageError> {
-    match conn.query_row(
-        "SELECT strftime('%s', 'now') - strftime('%s', value) < ?1 FROM index_meta WHERE key = 'last_indexed_at'",
-        [max_age_secs],
-        |row| row.get(0),
-    ) {
-        Ok(fresh) => Ok(fresh),
-        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(false),
-        Err(e) => Err(e.into()),
-    }
-}
-
 pub fn get_all_file_paths(conn: &Connection) -> Result<HashSet<String>, StorageError> {
     let mut stmt = conn.prepare_cached("SELECT DISTINCT file_path FROM chunks")?;
     let paths = stmt.query_map([], |row| row.get::<_, String>(0))?;

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -28,9 +28,7 @@ use crate::query::{self, QueryError};
 use crate::query_log::{self, QueryLogRecord};
 use crate::storage;
 
-#[cfg(any(test, feature = "test-support"))]
-use embedder::DEFAULT_EMBED_BUDGET;
-use embedder::{DegradedReason, degraded_reason_user_note, parse_budget_value};
+use embedder::{DegradedReason, degraded_reason_user_note};
 use format::{
     EnrichmentContext, format_coverage, format_coverage_note, format_dry_run_json,
     format_embed_result, format_impact_all, format_impact_json, format_impact_results,
@@ -40,7 +38,6 @@ use format::{
 
 const SEMANTIC_THRESHOLD: f32 = 0.7;
 
-const INDEX_FRESHNESS_SECS: u32 = 60;
 const MAX_QUERY_LENGTH: usize = 2000;
 
 pub const MAX_SEARCH_LIMIT: u32 = 100;
@@ -52,23 +49,17 @@ const BRIEF_MAX_INFERRED_SEEDS: u32 = 5;
 /// A short, scannable list is the actionable shape per ADR-0060.
 pub const MAX_EMPTY_TARGET_CANDIDATES: usize = 10;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-enum IndexState {
-    Empty,
-    ChunkedOnly,
-    PartiallyEmbedded,
-    FullyEmbedded,
-}
-
-fn determine_index_state(stats: &storage::IndexStatus) -> IndexState {
+/// Note guiding the user to build the index, or `None` when fully embedded.
+/// Search routes are read-only, so this surfaces what the user must run manually.
+fn index_hint(stats: &storage::IndexStatus) -> Option<String> {
     if stats.total_chunks == 0 {
-        IndexState::Empty
+        Some("index is empty; run `yomu index` then `yomu embed`".to_owned())
     } else if stats.embedded_chunks == 0 {
-        IndexState::ChunkedOnly
+        Some("no embeddings; run `yomu embed` to enable semantic search".to_owned())
     } else if stats.embedded_chunks < stats.embeddable_chunks {
-        IndexState::PartiallyEmbedded
+        Some("embeddings incomplete; run `yomu embed` to finish".to_owned())
     } else {
-        IndexState::FullyEmbedded
+        None
     }
 }
 
@@ -184,7 +175,6 @@ pub struct IndexRunOptions {
 pub struct YomuConfig {
     pub embed_disabled: bool,
     pub rerank_enabled: bool,
-    pub embed_budget: u32,
 }
 
 impl YomuConfig {
@@ -198,7 +188,6 @@ impl YomuConfig {
         Self {
             embed_disabled: get("YOMU_EMBED").as_deref() == Some("0"),
             rerank_enabled: get("YOMU_RERANK").as_deref() == Some("1"),
-            embed_budget: parse_budget_value(get("YOMU_EMBED_BUDGET").as_deref()),
         }
     }
 }
@@ -340,7 +329,6 @@ pub struct Yomu {
     conn: Arc<Mutex<storage::Db>>,
     embedder: OnceLock<Result<Arc<dyn Embed>, DegradedReason>>,
     root: PathBuf,
-    embed_budget: u32,
     embed_disabled: bool,
     rerank_enabled: bool,
     reranker: OnceLock<ModelLoad<Box<dyn Rerank>>>,
@@ -368,7 +356,6 @@ impl Yomu {
             conn: Arc::new(Mutex::new(conn)),
             embedder: OnceLock::new(),
             root,
-            embed_budget: config.embed_budget,
             embed_disabled,
             rerank_enabled: config.rerank_enabled,
             reranker: OnceLock::new(),
@@ -388,7 +375,6 @@ impl Yomu {
             conn: Arc::new(Mutex::new(conn)),
             embedder: embedder_lock,
             root,
-            embed_budget: DEFAULT_EMBED_BUDGET,
             embed_disabled: false,
             rerank_enabled: false,
             reranker: OnceLock::new(),
@@ -436,16 +422,7 @@ impl Yomu {
 
         tracing::debug!(query, limit, offset, ?paths, "search request");
 
-        let type_hints = query::extract_type_hints(query);
-        let hints_ref = if type_hints.is_empty() {
-            None
-        } else {
-            Some(type_hints.as_slice())
-        };
-
         let stats = self.with_db(storage::get_stats)?;
-        let state = determine_index_state(&stats);
-        let index_notes = self.ensure_indexed(embedder, state, hints_ref)?;
 
         let start = Instant::now();
         let outcome = query::search(
@@ -464,7 +441,7 @@ impl Yomu {
         }
 
         let mut notes: Vec<String> = Vec::new();
-        if let Some(msg) = index_notes {
+        if let Some(msg) = index_hint(&stats) {
             notes.push(msg);
         }
         if let Some(note) = self.reranker_note() {
@@ -492,10 +469,7 @@ impl Yomu {
         let (file, symbol) = parse_impact_target(from);
         validate_path(file)?;
 
-        let embedder = self.get_embedder();
         let stats = self.with_db(storage::get_stats)?;
-        let state = determine_index_state(&stats);
-        let index_notes = self.ensure_indexed(embedder, state, None)?;
 
         let (chunk_ids, embedding_bytes) = self.with_db(|c| {
             let chunk_ids = storage::get_chunks_for_from_target(c, file, symbol)?;
@@ -505,7 +479,7 @@ impl Yomu {
         })?;
 
         let mut notes: Vec<String> = Vec::new();
-        if let Some(msg) = index_notes {
+        if let Some(msg) = index_hint(&stats) {
             notes.push(msg);
         }
 
@@ -681,8 +655,7 @@ impl Yomu {
         })?;
 
         let semantic_related = if semantic {
-            let state = determine_index_state(&stats);
-            self.semantic_search(file_path, symbol_filter, state)?
+            self.semantic_search(file_path, symbol_filter)?
         } else {
             vec![]
         };
@@ -966,94 +939,6 @@ impl Yomu {
         f(&conn).map_err(YomuError::from)
     }
 
-    fn check_index_fresh(&self) -> bool {
-        match self.with_db(|conn| storage::is_index_fresh(conn, INDEX_FRESHNESS_SECS)) {
-            Ok(fresh) => fresh,
-            Err(e) => {
-                tracing::warn!(error = %e, "Failed to check index freshness, assuming stale");
-                false
-            }
-        }
-    }
-
-    fn try_rechunk(&self) -> Option<String> {
-        match indexer::run_chunk_only_index(&self.conn, &self.root, false) {
-            Ok(r) if r.files_errored > 0 => Some(format!(
-                "{} files had errors during re-indexing",
-                r.files_errored
-            )),
-            Ok(_) => None,
-            Err(e) => Some(format!("re-chunking failed: {e}")),
-        }
-    }
-
-    fn handle_empty_index(&self) -> Result<bool, YomuError> {
-        tracing::info!("Index is empty, running chunk-only index");
-        indexer::run_chunk_only_index(&self.conn, &self.root, false)?;
-        Ok(true)
-    }
-
-    fn rechunk_if_stale(&self) -> Option<String> {
-        if self.check_index_fresh() {
-            return None;
-        }
-        self.try_rechunk()
-    }
-
-    fn handle_fully_embedded(&self) -> Result<(bool, Option<String>), YomuError> {
-        if self.check_index_fresh() {
-            return Ok((false, None));
-        }
-        let note = self.try_rechunk();
-        let stats = self.with_db(storage::get_stats)?;
-        Ok((stats.embedded_chunks < stats.embeddable_chunks, note))
-    }
-
-    fn ensure_indexed(
-        &self,
-        embedder: &dyn Embed,
-        state: IndexState,
-        type_hints: Option<&[storage::ChunkType]>,
-    ) -> Result<Option<String>, YomuError> {
-        let (needs_embed, rechunk_note) = match state {
-            IndexState::Empty => (self.handle_empty_index()?, None),
-            IndexState::ChunkedOnly | IndexState::PartiallyEmbedded => {
-                let note = self.rechunk_if_stale();
-                (true, note)
-            }
-            IndexState::FullyEmbedded => self.handle_fully_embedded()?,
-        };
-
-        let embed_note = if needs_embed && self.embedding_available() {
-            match indexer::run_incremental_embed(
-                &self.conn,
-                embedder,
-                self.embed_budget,
-                type_hints,
-            ) {
-                Ok(_) => None,
-                Err(e @ indexer::IndexError::Storage(_)) => return Err(e.into()),
-                Err(e) => {
-                    tracing::warn!(error = %e, "Incremental embed failed, searching existing embeddings");
-                    Some(format!("embedding failed: {e}"))
-                }
-            }
-        } else {
-            None
-        };
-
-        let notes: Vec<&str> = [rechunk_note.as_deref(), embed_note.as_deref()]
-            .into_iter()
-            .flatten()
-            .collect();
-
-        Ok(if notes.is_empty() {
-            None
-        } else {
-            Some(notes.join("; "))
-        })
-    }
-
     fn fetch_enrichment_context(
         &self,
         results: &[storage::SearchResult],
@@ -1092,11 +977,7 @@ impl Yomu {
         &self,
         file_path: &str,
         symbol: Option<&str>,
-        state: IndexState,
     ) -> Result<Vec<storage::SearchResult>, YomuError> {
-        let embedder = self.get_embedder();
-        self.ensure_indexed(embedder, state, None)?;
-
         let fp = file_path.to_owned();
         let sym = symbol.map(str::to_owned);
         let mut results = self.with_db(move |c| {

--- a/src/tools/embedder.rs
+++ b/src/tools/embedder.rs
@@ -14,10 +14,6 @@ use std::path::PathBuf;
 #[cfg(test)]
 use std::sync::{Mutex, OnceLock};
 
-pub(super) const DEFAULT_EMBED_BUDGET: u32 = 50;
-const MIN_EMBED_BUDGET: u32 = 1;
-const MAX_EMBED_BUDGET: u32 = 500;
-
 pub(super) fn record_embedder_warning(reason: DegradedReason, detail: &str) {
     tracing::warn!(reason = ?reason, detail, "Embedder unavailable, using text search only");
     #[cfg(test)]
@@ -46,28 +42,6 @@ impl Embed for NoOpEmbedder {
     }
     fn embed_text(&self, _text: &str, _prefix: &str) -> Result<Vec<f32>, EmbedError> {
         Err(EmbedError::Inference("embedder not available".into()))
-    }
-}
-
-pub(super) fn parse_budget_value(value: Option<&str>) -> u32 {
-    match value {
-        Some(v) => match v.parse::<u32>() {
-            Ok(n) if (MIN_EMBED_BUDGET..=MAX_EMBED_BUDGET).contains(&n) => n,
-            Ok(n) => {
-                tracing::warn!(
-                    value = n,
-                    "YOMU_EMBED_BUDGET out of range ({}..={}), using default",
-                    MIN_EMBED_BUDGET,
-                    MAX_EMBED_BUDGET
-                );
-                DEFAULT_EMBED_BUDGET
-            }
-            Err(_) => {
-                tracing::warn!(value = %v, "Invalid YOMU_EMBED_BUDGET, using default");
-                DEFAULT_EMBED_BUDGET
-            }
-        },
-        None => DEFAULT_EMBED_BUDGET,
     }
 }
 
@@ -121,10 +95,6 @@ impl Yomu {
     pub(super) fn degraded_reason(&self) -> Option<&DegradedReason> {
         self.embedder.get().and_then(|r| r.as_ref().err())
     }
-
-    pub(super) fn embedding_available(&self) -> bool {
-        self.embedder.get().is_some_and(Result::is_ok)
-    }
 }
 
 #[cfg(test)]
@@ -143,7 +113,6 @@ impl Yomu {
             conn: Arc::new(Mutex::new(conn)),
             embedder: embedder_lock,
             root,
-            embed_budget: DEFAULT_EMBED_BUDGET,
             embed_disabled: false,
             rerank_enabled: false,
             reranker: OnceLock::new(),
@@ -157,7 +126,6 @@ impl Yomu {
             conn: Arc::new(Mutex::new(conn)),
             embedder: OnceLock::new(),
             root,
-            embed_budget: DEFAULT_EMBED_BUDGET,
             embed_disabled: true,
             rerank_enabled: false,
             reranker: OnceLock::new(),

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -1,6 +1,5 @@
 use super::embedder::{
-    DegradedReason, RECORDED_WARNINGS, get_recorded_warnings, parse_budget_value,
-    record_embedder_warning,
+    DegradedReason, RECORDED_WARNINGS, get_recorded_warnings, record_embedder_warning,
 };
 use super::*;
 use std::collections::HashMap;
@@ -181,9 +180,9 @@ fn search_without_embedder_degrades_gracefully() {
     );
 }
 
-// T-181: search_auto_indexes_empty_db
+// T-181: search_does_not_auto_index_empty_db
 #[test]
-fn search_auto_indexes_empty_db() {
+fn search_does_not_auto_index_empty_db() {
     let (y, _dir) = test_yomu_with_files_and_embedder(
         &[("src/Button.tsx", "function Button() { return <div/>; }")],
         Arc::new(MockEmbedder::default()),
@@ -192,29 +191,25 @@ fn search_auto_indexes_empty_db() {
     let text = y
         .search(Some("button component"), 10, 0, &[], false, None)
         .unwrap();
-    assert!(
-        !text.contains("No results found"),
-        "expected results after auto-index, got: {text}"
-    );
-    assert!(
-        text.contains("Button"),
-        "expected Button in results, got: {text}"
-    );
 
+    // Search must not mutate the index: an empty DB stays empty.
     let stats = {
         let c = y.conn.lock().unwrap();
         storage::get_stats(&c).unwrap()
     };
-    assert!(stats.total_chunks > 0, "expected chunks after auto-index");
+    assert_eq!(stats.total_chunks, 0, "search must not auto-index");
+    assert_eq!(stats.embedded_chunks, 0, "search must not auto-embed");
+
+    // The result guides the user to build the index manually.
     assert!(
-        stats.embedded_chunks > 0,
-        "expected embeddings after auto-index"
+        text.contains("yomu index"),
+        "expected `yomu index` hint, got: {text}"
     );
 }
 
-// T-182: search_incremental_embeds_chunked_only
+// T-182: search_does_not_auto_embed_chunked_only
 #[test]
-fn search_incremental_embeds_chunked_only() {
+fn search_does_not_auto_embed_chunked_only() {
     let (y, _dir) = test_yomu_with_files_and_embedder(
         &[("src/Form.tsx", "export function Form() { return <form/>; }")],
         Arc::new(MockEmbedder::default()),
@@ -222,26 +217,26 @@ fn search_incremental_embeds_chunked_only() {
 
     indexer::run_chunk_only_index(&y.conn, y.root.as_path(), false).unwrap();
 
-    {
-        let c = y.conn.lock().unwrap();
-        let stats = storage::get_stats(&c).unwrap();
-        assert!(stats.total_chunks > 0, "should have chunks");
-        assert_eq!(stats.embedded_chunks, 0, "should have no embeddings yet");
-    }
-
     let text = y
         .search(Some("form component"), 10, 0, &[], false, None)
         .unwrap();
-    assert!(text.contains("Form"), "expected Form in results: {text}");
 
-    {
+    // Search must not embed: a chunk-only index stays at zero embeddings.
+    let stats = {
         let c = y.conn.lock().unwrap();
-        let stats = storage::get_stats(&c).unwrap();
-        assert!(
-            stats.embedded_chunks > 0,
-            "expected embeddings after incremental embed"
-        );
-    }
+        storage::get_stats(&c).unwrap()
+    };
+    assert!(
+        stats.total_chunks > 0,
+        "chunks remain after chunk-only index"
+    );
+    assert_eq!(stats.embedded_chunks, 0, "search must not auto-embed");
+
+    // The result guides the user to embed manually.
+    assert!(
+        text.contains("yomu embed"),
+        "expected `yomu embed` hint, got: {text}"
+    );
 }
 
 // T-183: search_shows_coverage_on_no_results
@@ -1118,121 +1113,6 @@ fn parse_impact_target_multiple_colons() {
     assert_eq!(symbol, Some("C"));
 }
 
-// T-214: parse_budget_value_valid
-#[test]
-fn parse_budget_value_valid() {
-    assert_eq!(parse_budget_value(Some("100")), 100);
-    assert_eq!(parse_budget_value(Some("1")), 1);
-    assert_eq!(parse_budget_value(Some("500")), 500);
-}
-
-// T-215: parse_budget_value_out_of_range
-#[test]
-fn parse_budget_value_out_of_range() {
-    assert_eq!(parse_budget_value(Some("0")), DEFAULT_EMBED_BUDGET);
-    assert_eq!(parse_budget_value(Some("501")), DEFAULT_EMBED_BUDGET);
-}
-
-// T-216: parse_budget_value_invalid
-#[test]
-fn parse_budget_value_invalid() {
-    assert_eq!(parse_budget_value(Some("abc")), DEFAULT_EMBED_BUDGET);
-    assert_eq!(parse_budget_value(Some("")), DEFAULT_EMBED_BUDGET);
-}
-
-// T-217: parse_budget_value_missing
-#[test]
-fn parse_budget_value_missing() {
-    assert_eq!(parse_budget_value(None), DEFAULT_EMBED_BUDGET);
-}
-
-// T-218: determine_index_state_variants
-#[test]
-fn determine_index_state_variants() {
-    let empty = storage::IndexStatus {
-        total_files: 0,
-        total_chunks: 0,
-        embeddable_chunks: 0,
-        embedded_chunks: 0,
-        last_indexed_at: None,
-    };
-    assert!(matches!(determine_index_state(&empty), IndexState::Empty));
-
-    let chunked = storage::IndexStatus {
-        total_files: 5,
-        total_chunks: 20,
-        embeddable_chunks: 20,
-        embedded_chunks: 0,
-        last_indexed_at: Some("2026-01-01".into()),
-    };
-    assert!(matches!(
-        determine_index_state(&chunked),
-        IndexState::ChunkedOnly
-    ));
-
-    let partial = storage::IndexStatus {
-        total_files: 5,
-        total_chunks: 20,
-        embeddable_chunks: 20,
-        embedded_chunks: 10,
-        last_indexed_at: Some("2026-01-01".into()),
-    };
-    assert!(matches!(
-        determine_index_state(&partial),
-        IndexState::PartiallyEmbedded
-    ));
-
-    let full = storage::IndexStatus {
-        total_files: 5,
-        total_chunks: 20,
-        embeddable_chunks: 20,
-        embedded_chunks: 20,
-        last_indexed_at: Some("2026-01-01".into()),
-    };
-    assert!(matches!(
-        determine_index_state(&full),
-        IndexState::FullyEmbedded
-    ));
-}
-
-// T-219: ensure_indexed_partially_embedded_triggers_embed
-#[test]
-fn ensure_indexed_partially_embedded_triggers_embed() {
-    let (y, _dir) = test_yomu_with_files_and_embedder(
-        &[("src/App.tsx", "export function App() { return <div/>; }")],
-        Arc::new(MockEmbedder::default()),
-    );
-
-    indexer::run_chunk_only_index(&y.conn, y.root.as_path(), false).unwrap();
-
-    let stats_before = {
-        let c = y.conn.lock().unwrap();
-        storage::get_stats(&c).unwrap()
-    };
-    assert!(stats_before.total_chunks > 0, "should have chunks");
-    assert_eq!(
-        stats_before.embedded_chunks, 0,
-        "should have no embeddings yet"
-    );
-
-    let result = y
-        .search(Some("App component"), 10, 0, &[], false, None)
-        .unwrap();
-    assert!(
-        result.contains("App"),
-        "should find App after embedding: {result}"
-    );
-
-    let stats_after = {
-        let c = y.conn.lock().unwrap();
-        storage::get_stats(&c).unwrap()
-    };
-    assert!(
-        stats_after.embedded_chunks > 0,
-        "should have embeddings after search"
-    );
-}
-
 // T-222: with_root_creates_db_and_returns_yomu
 #[test]
 fn with_root_creates_db_and_returns_yomu() {
@@ -1880,10 +1760,10 @@ fn json_notes_present_when_degraded() {
         "notes should contain degradation reason: {json}"
     );
     assert!(
-        notes[0]
+        notes.iter().any(|n| n
             .as_str()
-            .is_some_and(|n| n.contains("yomu model download")),
-        "note should include `yomu model download` hint: {json}"
+            .is_some_and(|s| s.contains("yomu model download"))),
+        "notes should include `yomu model download` hint: {json}"
     );
 }
 
@@ -1989,6 +1869,8 @@ fn json_notes_empty_via_search_with_ok_embedder() {
         dir.path().to_path_buf(),
         Some(Arc::new(MockEmbedder::default()) as Arc<dyn Embed>),
     );
+    indexer::run_chunk_only_index(&y.conn, y.root.as_path(), false).unwrap();
+    indexer::run_incremental_embed(&y.conn, &MockEmbedder::default(), 100, None).unwrap();
 
     let json = y.search(Some("nav"), 10, 0, &[], true, None).unwrap();
     let parsed = parse_json(&json);
@@ -2021,9 +1903,11 @@ fn json_notes_outcome_degraded_fallback() {
         !notes.is_empty(),
         "notes should contain fallback reason: {json}"
     );
-    assert_eq!(
-        notes[0], "embedding model not loaded; results from text search only",
-        "note should match outcome.degraded fallback: {json}"
+    assert!(
+        notes
+            .iter()
+            .any(|n| n == "embedding model not loaded; results from text search only"),
+        "notes should match outcome.degraded fallback: {json}"
     );
 }
 
@@ -2047,9 +1931,11 @@ fn json_notes_backend_unavailable() {
     let notes = parsed["notes"]
         .as_array()
         .expect("notes should be an array");
-    assert_eq!(
-        notes[0], "embedding model unavailable; results from text search only",
-        "note should match BackendUnavailable variant: {json}"
+    assert!(
+        notes
+            .iter()
+            .any(|n| n == "embedding model unavailable; results from text search only"),
+        "notes should match BackendUnavailable variant: {json}"
     );
 }
 
@@ -2418,6 +2304,8 @@ fn search_from_file_integration() {
         ],
         Arc::new(MockEmbedder::default()),
     );
+    indexer::run_chunk_only_index(&y.conn, y.root.as_path(), false).unwrap();
+    indexer::run_incremental_embed(&y.conn, &MockEmbedder::default(), 100, None).unwrap();
 
     let text = y.search(None, 5, 0, &[], false, Some("src/a.rs")).unwrap();
     // Source file should not appear in results
@@ -2813,7 +2701,6 @@ fn yomu_config_from_env_with_empty_lookup_uses_defaults() {
     let cfg = YomuConfig::from_env_with(|_| None);
     assert!(!cfg.embed_disabled);
     assert!(!cfg.rerank_enabled);
-    assert_eq!(cfg.embed_budget, DEFAULT_EMBED_BUDGET);
 }
 
 // T-CFG002: YOMU_EMBED=0 sets embed_disabled
@@ -2856,16 +2743,6 @@ fn yomu_config_yomu_rerank_non_one_keeps_reranker_off() {
     assert!(!cfg.rerank_enabled);
 }
 
-// T-CFG006: YOMU_EMBED_BUDGET valid value flows through
-#[test]
-fn yomu_config_yomu_embed_budget_valid_value_applied() {
-    let cfg = YomuConfig::from_env_with(|k| match k {
-        "YOMU_EMBED_BUDGET" => Some("10".into()),
-        _ => None,
-    });
-    assert_eq!(cfg.embed_budget, 10);
-}
-
 // T-CFG007: Default impl equals from_env_with empty lookup
 #[test]
 fn yomu_config_default_matches_empty_lookup() {
@@ -2873,7 +2750,6 @@ fn yomu_config_default_matches_empty_lookup() {
     let empty = YomuConfig::from_env_with(|_| None);
     assert_eq!(default.embed_disabled, empty.embed_disabled);
     assert_eq!(default.rerank_enabled, empty.rerank_enabled);
-    assert_eq!(default.embed_budget, empty.embed_budget);
 }
 
 // --- Issue #192 Phase 2.2a: InvalidInputKind + YomuError methods ---

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -239,6 +239,41 @@ fn search_does_not_auto_embed_chunked_only() {
     );
 }
 
+// T-184: search_hints_incomplete_embeddings_when_partially_embedded
+#[test]
+fn search_hints_incomplete_embeddings_when_partially_embedded() {
+    let (y, _dir) = test_yomu_with_files_and_embedder(
+        &[
+            ("src/A.tsx", "export function A() { return <div/>; }"),
+            ("src/B.tsx", "export function B() { return <div/>; }"),
+            ("src/C.tsx", "export function C() { return <div/>; }"),
+        ],
+        Arc::new(MockEmbedder::default()),
+    );
+    indexer::run_chunk_only_index(&y.conn, y.root.as_path(), false).unwrap();
+    // Embed only one chunk so embedded_chunks < embeddable_chunks (partial state).
+    indexer::run_incremental_embed(&y.conn, &MockEmbedder::default(), 1, None).unwrap();
+
+    let stats = {
+        let c = y.conn.lock().unwrap();
+        storage::get_stats(&c).unwrap()
+    };
+    assert!(
+        stats.embedded_chunks > 0 && stats.embedded_chunks < stats.embeddable_chunks,
+        "expected partial embedding, got {}/{}",
+        stats.embedded_chunks,
+        stats.embeddable_chunks
+    );
+
+    let text = y
+        .search(Some("component"), 10, 0, &[], false, None)
+        .unwrap();
+    assert!(
+        text.contains("embeddings incomplete"),
+        "expected incomplete-embeddings hint, got: {text}"
+    );
+}
+
 // T-183: search_shows_coverage_on_no_results
 #[test]
 fn search_shows_coverage_on_no_results() {

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -351,33 +351,16 @@ fn search_format_json() {
     }
 }
 
-#[cfg(unix)]
 // T-506: search_format_json_includes_index_and_degraded_notes
 #[test]
 fn search_format_json_includes_index_and_degraded_notes() {
-    use std::os::unix::fs::PermissionsExt;
-
     let dir = setup_project();
-    let src = dir.path().join("src");
-    let bad_path = src.join("Unreadable.tsx");
     let hf_home = dir.path().join("empty-hf-home");
     fs::create_dir_all(&hf_home).unwrap();
-    fs::write(
-        &bad_path,
-        "export function Unreadable() { return <div />; }\n",
-    )
-    .unwrap();
-    fs::set_permissions(&bad_path, fs::Permissions::from_mode(0o000)).unwrap();
 
-    let db_path = dir.path().join(".yomu").join("index.db");
-    let conn = rusqlite::Connection::open(db_path).unwrap();
-    conn.execute(
-        "UPDATE index_meta SET value = datetime('now', '-2 minutes') WHERE key = 'last_indexed_at'",
-        [],
-    )
-    .unwrap();
-    drop(conn);
-
+    // setup_project chunk-indexes but does not embed, and the model is disabled
+    // via an empty HF_HOME. Search is read-only, so it surfaces both an index
+    // hint (no embeddings) and a degraded note (model unavailable).
     let output = yomu_cmd()
         .args(["search", "button", "--json"])
         .current_dir(dir.path())
@@ -385,8 +368,6 @@ fn search_format_json_includes_index_and_degraded_notes() {
         .env("HF_HOME", &hf_home)
         .output()
         .unwrap();
-
-    fs::set_permissions(&bad_path, fs::Permissions::from_mode(0o644)).unwrap();
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
@@ -401,8 +382,8 @@ fn search_format_json_includes_index_and_degraded_notes() {
     assert!(
         notes
             .iter()
-            .any(|n| n == "1 files had errors during re-indexing"),
-        "should include re-index note: {stdout}"
+            .any(|n| n.as_str().is_some_and(|s| s.contains("yomu embed"))),
+        "should include index hint: {stdout}"
     );
     assert!(
         notes.iter().any(|n| n


### PR DESCRIPTION
## 概要

`yomu search` / `search --from` / `impact --semantic` を read-only 化。検索が裏で自動 index/embed しなくなり、index 構築は `yomu index` (chunk) → `yomu embed` (embedding) の明示実行に分離した。

## 背景

従来は search が `ensure_indexed` で staleness 判定 → 自動で chunk/embed していた。検索のたびに embedding (MLX forward) が走って重く、挙動が暗黙的だった。

## 変更 (6 ファイル, +63 / -367)

| ファイル | 変更 |
| --- | --- |
| `tools.rs` | 3 経路の `ensure_indexed` 除去、`index_hint` ヘルパー追加、dead code (`ensure_indexed` 一族 / `IndexState` / `embed_budget`) 削除 |
| `embedder.rs` / `storage.rs` | dead code (`embedding_available` / `DEFAULT_EMBED_BUDGET` / `parse_budget_value` / `is_index_fresh`) 削除、`YOMU_EMBED_BUDGET` env 廃止 |
| `main.rs` | search ヘルプに「build the index first」を追加 |
| `tools/tests.rs` / `cli_integration.rs` | テストを新挙動に追従、削除関数のテストを削除 |

## 未 index 時の挙動

結果の notes に index ヒント (`run yomu index` / `yomu embed`) を表示 (`search --from` の既存パターンに統一)。

## テスト / 品質

全テスト green (lib 600 / cli_integration 56 / 他 25)、`clippy --all-targets` クリーン。

## OUTCOME.md の変更 (gitignored のため転記)

```
Behavior:
- 概念名のみで yomu search を 1 回呼び出し…
+ 事前に yomu index + yomu embed でインデックスを構築した上で、概念名のみで yomu search を 1 回呼び出し…

Indicator Time:
- index は 3,535 ファイルで ~2.5s | コールドスタートが初回検索を阻害しない
+ yomu index は 3,535 ファイルで ~2.5s | 一度のインデックス構築で以降の検索が阻害されない

Constraints (追加):
+ クエリコマンド (search / impact) は read-only。インデックス構築は yomu index (chunk) + yomu embed (embedding) の明示実行で行い、検索時に自動構築しない。
```

## 運用上の含意

yomu を呼ぶエージェント / CI / スキルは、検索前に `yomu index` + `yomu embed` を実行する前提になる。

## 後続

index = embed 統合 (embed 必須化、`yomu embed` を index に吸収) を別 PR で予定。ADR + issue 化済み。