### PR TITLE
brief の TS forward closure で tsconfig baseUrl path alias を解決する

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -146,11 +146,21 @@ pub fn load_aliases(root: &Path) -> Vec<PathAlias> {
         }
     };
 
-    let paths = match json
-        .get("compilerOptions")
-        .and_then(|co| co.get("paths"))
-        .and_then(|p| p.as_object())
-    {
+    let compiler_options = match json.get("compilerOptions") {
+        Some(co) => co,
+        None => return vec![],
+    };
+
+    // TypeScript resolves `paths` targets relative to `baseUrl` (which defaults
+    // to "." when omitted). Without folding `baseUrl` in, an alias like
+    // `{ "baseUrl": "src", "paths": { "@/*": ["*"] } }` resolves to the repo root
+    // instead of `src/`, dropping the target from the forward closure.
+    let base_url = compiler_options
+        .get("baseUrl")
+        .and_then(|b| b.as_str())
+        .unwrap_or(".");
+
+    let paths = match compiler_options.get("paths").and_then(|p| p.as_object()) {
         Some(p) => p,
         None => return vec![],
     };
@@ -158,17 +168,33 @@ pub fn load_aliases(root: &Path) -> Vec<PathAlias> {
     paths
         .iter()
         .filter_map(|(key, value)| {
-            // key: "@/*", value: ["src/*"]
+            // key: "@/*", value: ["*"] (relative to baseUrl) or ["src/*"]
             let prefix = key.strip_suffix('*')?;
             let target_arr = value.as_array()?;
             let target_str = target_arr.first()?.as_str()?;
-            let target = target_str.strip_suffix('*')?;
+            let raw_target = target_str.strip_suffix('*')?;
             Some(PathAlias {
                 prefix: prefix.to_owned(),
-                target: target.to_owned(),
+                target: compose_alias_target(base_url, raw_target),
             })
         })
         .collect()
+}
+
+/// Prefix a tsconfig `paths` target with `base_url` (TypeScript resolves `paths`
+/// relative to `baseUrl`, which defaults to "."). `path_target` is the portion
+/// of a `paths` value before the `*` wildcard and is appended verbatim so its
+/// tail is preserved: `"src/"` for a path-segment wildcard (`src/*`),
+/// `"generated/lib-"` for a filename-prefix wildcard (`generated/lib-*`).
+/// Re-normalizing the tail would break the latter.
+fn compose_alias_target(base_url: &str, path_target: &str) -> String {
+    let base = base_url.trim_start_matches("./").trim_end_matches('/');
+    let prefix = if base.is_empty() || base == "." {
+        String::new()
+    } else {
+        format!("{base}/")
+    };
+    format!("{prefix}{path_target}")
 }
 
 #[cfg(test)]
@@ -297,6 +323,65 @@ mod tests {
                 target: "src/".to_owned(),
             }]
         );
+    }
+
+    // T-347: load_aliases_with_baseurl
+    // tsconfig `paths` targets are relative to `baseUrl`; `{ baseUrl: "src",
+    // paths: { "@/*": ["*"] } }` must yield the same `src/` target as the
+    // root-relative `["src/*"]` form.
+    #[test]
+    fn load_aliases_with_baseurl() {
+        let tmp = tempdir().unwrap();
+        let tsconfig = r#"{
+            "compilerOptions": {
+                "baseUrl": "src",
+                "paths": {
+                    "@/*": ["*"]
+                }
+            }
+        }"#;
+        fs::write(tmp.path().join("tsconfig.json"), tsconfig).unwrap();
+
+        let aliases = load_aliases(tmp.path());
+        assert_eq!(
+            aliases,
+            vec![PathAlias {
+                prefix: "@/".to_owned(),
+                target: "src/".to_owned(),
+            }]
+        );
+    }
+
+    // T-348: compose_alias_target_variants
+    #[test]
+    fn compose_alias_target_variants() {
+        // baseUrl pushed, empty path target
+        assert_eq!(compose_alias_target("src", ""), "src/");
+        // leading "./" on baseUrl is normalized away
+        assert_eq!(compose_alias_target("./src", ""), "src/");
+        // baseUrl "." is skipped; the path target stands alone
+        assert_eq!(compose_alias_target(".", "src/"), "src/");
+        // both empty → repo root (empty prefix)
+        assert_eq!(compose_alias_target(".", ""), "");
+        // filename-prefix wildcard (e.g. `generated/lib-*`): the target tail is
+        // preserved verbatim with no forced trailing "/"
+        assert_eq!(
+            compose_alias_target(".", "generated/lib-"),
+            "generated/lib-"
+        );
+        assert_eq!(
+            compose_alias_target("src", "generated/lib-"),
+            "src/generated/lib-"
+        );
+    }
+
+    // T-349: load_aliases_no_compiler_options
+    // A tsconfig without `compilerOptions` yields no aliases (no panic).
+    #[test]
+    fn load_aliases_no_compiler_options() {
+        let tmp = tempdir().unwrap();
+        fs::write(tmp.path().join("tsconfig.json"), "{}").unwrap();
+        assert!(load_aliases(tmp.path()).is_empty());
     }
 
     // T-332: load_aliases_no_tsconfig

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1041,6 +1041,82 @@ fn brief_integration_json_output_includes_chunks() {
     );
 }
 
+// Minimal TS project exercising a tsconfig `baseUrl` + `paths` alias: the seed
+// imports `@/util/format`, which maps to `src/util/format.ts` only when the
+// resolver factors `baseUrl` into the alias target.
+fn setup_ts_alias_project() -> TempDir {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir_all(src.join("components")).unwrap();
+    fs::create_dir_all(src.join("util")).unwrap();
+    fs::write(
+        dir.path().join("tsconfig.json"),
+        "{ \"compilerOptions\": { \"baseUrl\": \"src\", \"paths\": { \"@/*\": [\"*\"] } } }\n",
+    )
+    .unwrap();
+    fs::write(
+        src.join("components/widget.tsx"),
+        "import { formatLabel } from \"@/util/format\";\n\
+         export function Widget() { return formatLabel(\"x\"); }\n",
+    )
+    .unwrap();
+    fs::write(
+        src.join("util/format.ts"),
+        "export function formatLabel(s: string): string { return s.toUpperCase(); }\n",
+    )
+    .unwrap();
+    Command::new("git")
+        .args(["init"])
+        .current_dir(dir.path())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .unwrap();
+    let out = yomu_cmd()
+        .arg("index")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "index failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    dir
+}
+
+// T-613: brief_resolves_tsconfig_baseurl_path_alias [#127 Phase 2]
+// The seed imports `@/util/format`; tsconfig maps `@/*` to `*` under
+// `baseUrl: "src"`, so the forward closure must include `src/util/format.ts`.
+// Before the baseUrl fix the alias target resolved to the repo root and the
+// file was dropped from the closure.
+#[test]
+fn brief_resolves_tsconfig_baseurl_path_alias() {
+    let dir = setup_ts_alias_project();
+    let output = yomu_cmd()
+        .args([
+            "brief",
+            "widget",
+            "--seed-file",
+            "src/components/widget.tsx",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "brief failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("src/util/format.ts"),
+        "forward closure must resolve baseUrl path alias `@/util/format` → \
+         src/util/format.ts, got: {stdout}"
+    );
+}
+
 // --- ADR-0066 Group 2 exit code + JSON error envelope ---
 
 /// Returns the last line in stderr that begins with `{`, parsed as JSON.


### PR DESCRIPTION
## 概要

`yomu brief` の TS forward closure で tsconfig path alias (`@/*`) が `baseUrl` を無視して解決され、alias 先ファイルが閉包から欠落する不具合を修正する (#127 brief Phase 2 の一部)。

## 背景

probe で確定: brief の TS forward closure は相対 import・type-only import では動作するが、慣用形 `{ "baseUrl": "src", "paths": { "@/*": ["*"] } }` で alias 先が repo root に解決され欠落していた。`load_aliases` が `compilerOptions.baseUrl` を読んでいなかったのが原因(`["*"]` → strip → target `""` → root 直下を探索)。

## 変更

- `load_aliases` が `compilerOptions.baseUrl` を読み、`compose_alias_target` で alias target に合成する(baseUrl 省略時は `.`)。
- `compose_alias_target` は baseUrl を前置し path target の末尾を verbatim 維持する。path-segment wildcard (`src/*` → `src/`) も filename-prefix wildcard (`generated/lib-*` → `generated/lib-`) も正しく解決する。
- TS path-alias の GT integration test (T-613)。
- `load_aliases` の baseUrl ケース + `compose_alias_target` 全分岐 (prefix-wildcard 含む) の unit test (T-347 / T-348 / T-349)。
- baseUrl なし + `["src/*"]` の既存挙動は不変(回帰テスト pass)。

## テスト

- 599 lib + 54 integration green (`cargo nextest run --features test-support`)
- diff-coverage 100%

## スコープ外 (別 issue #233)

baseUrl-only 非相対 import / multi-target paths / 絶対パス baseUrl。niche な tsconfig 構成のため遭遇頻度を見てから着手 (YAGNI)。

## 関連

- #127 (brief Phase 2, 親)
- #233 (残ギャップ follow-up)
