### PR TITLE
feat(brief): 双方向 closure と breadth-first cap で seed-less recall を改善

### DIFF
--- a/src/brief.rs
+++ b/src/brief.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use crate::injection_check::InjectionCheck;
 use crate::storage::{
     Chunk, ChunkType, SourceKind, StorageError, get_chunks_for_files, get_edges_among_files,
-    get_import_counts, get_transitive_dependencies_multi,
+    get_import_counts, get_transitive_dependencies_multi, get_transitive_dependents,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -31,12 +31,16 @@ pub struct TaskBrief {
     pub depth: u32,
     pub max_chunks: u32,
     pub max_bytes: u32,
+    /// Keep test files (`source_kind = 'test'`) in the closure. Default false:
+    /// brief is for working on the code under test, not the tests themselves.
+    pub include_tests: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ChunkInclusionReason {
     Seed,
     Forward(u32),
+    Impact(u32),
     Sibling,
     ModDecl,
 }
@@ -46,6 +50,7 @@ impl fmt::Display for ChunkInclusionReason {
         match self {
             Self::Seed => f.write_str("seed"),
             Self::Forward(n) => write!(f, "forward-{n}"),
+            Self::Impact(n) => write!(f, "impact-{n}"),
             Self::Sibling => f.write_str("sibling"),
             Self::ModDecl => f.write_str("mod-decl"),
         }
@@ -80,27 +85,61 @@ fn collect_seed_paths(task: &TaskBrief) -> Vec<String> {
         .collect()
 }
 
+/// Bidirectional closure (FR-C): the seed's forward imports unioned with its
+/// backward impact (callers). Returns the minimum distance per file and the set
+/// of forward-reachable files so the caller can label backward-only files as
+/// Impact. A file reachable both ways keeps its smaller distance and the forward
+/// label. When a seed has no callers the backward query returns nothing, so the
+/// result degrades to a forward-only closure.
 fn collect_closure(
     conn: &Connection,
     seeds: &[String],
     depth: u32,
-) -> Result<HashMap<String, u32>, StorageError> {
-    // Single recursive query over all seeds; `MIN(depth)` inside the query
-    // already collapses per-seed distances, so no Rust-side merge is needed.
+) -> Result<(HashMap<String, u32>, HashSet<String>), StorageError> {
     let seed_refs: Vec<&str> = seeds.iter().map(String::as_str).collect();
-    let deps = get_transitive_dependencies_multi(conn, &seed_refs, depth)?;
-    Ok(deps.into_iter().map(|d| (d.file_path, d.depth)).collect())
+    let mut depth_by_path: HashMap<String, u32> = HashMap::new();
+    let mut forward_paths: HashSet<String> = HashSet::new();
+
+    // Forward: a single recursive query collapses per-seed distances via MIN.
+    for dep in get_transitive_dependencies_multi(conn, &seed_refs, depth)? {
+        forward_paths.insert(dep.file_path.clone());
+        merge_min_depth(&mut depth_by_path, dep.file_path, dep.depth);
+    }
+
+    // Backward: `get_transitive_dependents` is single-target, so fan out over
+    // seeds and merge. Seeds stay at depth 0 (forward injects them); callers
+    // enter at depth >= 1.
+    for seed in &seed_refs {
+        for dep in get_transitive_dependents(conn, seed, depth)? {
+            merge_min_depth(&mut depth_by_path, dep.file_path, dep.depth);
+        }
+    }
+
+    Ok((depth_by_path, forward_paths))
 }
 
-fn determine_reason(depth: u32) -> ChunkInclusionReason {
+fn merge_min_depth(depth_by_path: &mut HashMap<String, u32>, path: String, depth: u32) {
+    depth_by_path
+        .entry(path)
+        .and_modify(|d| *d = (*d).min(depth))
+        .or_insert(depth);
+}
+
+fn determine_reason(depth: u32, is_forward: bool) -> ChunkInclusionReason {
     if depth == 0 {
         ChunkInclusionReason::Seed
-    } else {
+    } else if is_forward {
         ChunkInclusionReason::Forward(depth)
+    } else {
+        ChunkInclusionReason::Impact(depth)
     }
 }
 
-fn build_brief_chunks(chunks: Vec<Chunk>, depth_by_path: &HashMap<String, u32>) -> Vec<BriefChunk> {
+fn build_brief_chunks(
+    chunks: Vec<Chunk>,
+    depth_by_path: &HashMap<String, u32>,
+    forward_paths: &HashSet<String>,
+) -> Vec<BriefChunk> {
     chunks
         .into_iter()
         .map(|c| {
@@ -116,13 +155,14 @@ fn build_brief_chunks(chunks: Vec<Chunk>, depth_by_path: &HashMap<String, u32>) 
                 );
                 0
             });
+            let is_forward = forward_paths.contains(&c.file_path);
             BriefChunk {
                 file_path: c.file_path,
                 start_line: c.start_line,
                 end_line: c.end_line,
                 chunk_type: c.chunk_type,
                 content: c.content,
-                included_reason: determine_reason(depth),
+                included_reason: determine_reason(depth, is_forward),
                 source_kind: c.source_kind,
                 injection_flags: c.injection_flags,
             }
@@ -141,53 +181,71 @@ fn under_cap(chunk_count: usize, total_bytes: usize, max_chunks: u32, max_bytes:
     to_u32_saturating(chunk_count) <= max_chunks && to_u32_saturating(total_bytes) <= max_bytes
 }
 
-fn deletion_priority(
-    chunk: &BriefChunk,
-    depth_by_path: &HashMap<String, u32>,
-    incoming_counts: &HashMap<String, u32>,
-) -> (u32, u32) {
-    let depth = depth_by_path.get(&chunk.file_path).copied().unwrap_or(0);
-    let incoming = incoming_counts.get(&chunk.file_path).copied().unwrap_or(0);
-    (depth, incoming)
-}
-
+/// Selects which chunk indices to drop, breadth-first. Returns the drop set and
+/// the surviving byte total. Groups chunks by file and hands each file one chunk
+/// per round before any file gets a second, so the budget spreads across the
+/// closure and maximizes file coverage (recall@N). Files are visited
+/// closest-first (depth ASC) then by centrality (incoming DESC); within a file,
+/// chunks keep source order.
+///
+/// Guarantee: under a chunk-count-bound budget, every closure file keeps at
+/// least one chunk. Under a byte-bound budget this cannot always hold — a file
+/// whose chunks all exceed the remaining byte budget is dropped, because the
+/// hard `max_bytes` cap forbids including it.
 fn select_drops(
     chunks: &[BriefChunk],
     depth_by_path: &HashMap<String, u32>,
     incoming_counts: &HashMap<String, u32>,
     max_chunks: u32,
     max_bytes: u32,
-    total_bytes: usize,
 ) -> (HashSet<usize>, usize) {
-    let mut order: Vec<(usize, u32, u32)> = chunks
-        .iter()
-        .enumerate()
-        .map(|(i, c)| {
-            let (d, e) = deletion_priority(c, depth_by_path, incoming_counts);
-            (i, d, e)
-        })
-        .collect();
-    order.sort_by(|a, b| b.1.cmp(&a.1).then(a.2.cmp(&b.2)));
-
-    let mut drop_idx: HashSet<usize> = HashSet::new();
-    let mut count = chunks.len();
-    let mut bytes = total_bytes;
-    for (idx, _, _) in order {
-        if under_cap(count, bytes, max_chunks, max_bytes) {
-            break;
-        }
-        drop_idx.insert(idx);
-        count -= 1;
-        bytes -= chunks[idx].content.len();
+    let mut by_file: HashMap<&str, Vec<usize>> = HashMap::new();
+    for (i, c) in chunks.iter().enumerate() {
+        by_file.entry(c.file_path.as_str()).or_default().push(i);
     }
+    for idxs in by_file.values_mut() {
+        idxs.sort_by_key(|&i| chunks[i].start_line);
+    }
+    let mut files: Vec<&str> = by_file.keys().copied().collect();
+    files.sort_by(|a, b| {
+        let depth = |p: &str| depth_by_path.get(p).copied().unwrap_or(0);
+        let incoming = |p: &str| incoming_counts.get(p).copied().unwrap_or(0);
+        depth(a)
+            .cmp(&depth(b))
+            .then(incoming(b).cmp(&incoming(a)))
+            .then(a.cmp(b))
+    });
+
+    let max_round = by_file.values().map(Vec::len).max().unwrap_or(0);
+    let mut keep: HashSet<usize> = HashSet::new();
+    let mut bytes: usize = 0;
+    'rounds: for round in 0..max_round {
+        for file in &files {
+            let Some(&idx) = by_file[*file].get(round) else {
+                continue;
+            };
+            if to_u32_saturating(keep.len() + 1) > max_chunks {
+                break 'rounds;
+            }
+            let len = chunks[idx].content.len();
+            if to_u32_saturating(bytes + len) > max_bytes {
+                continue; // over the byte budget; skip (see the byte-bound caveat above)
+            }
+            keep.insert(idx);
+            bytes += len;
+        }
+    }
+
+    let drop_idx: HashSet<usize> = (0..chunks.len()).filter(|i| !keep.contains(i)).collect();
     (drop_idx, bytes)
 }
 
-/// Applies BR-001 cap deletion order: drop chunks first by
-/// `(seed_distance DESC, incoming_edge_count ASC)`. Pure: takes pre-computed
-/// `depth_by_path`, `incoming_counts`, and `total_bytes` so callers can test
-/// deterministically without DB access and the byte sum is computed once.
-/// Returns the surviving chunks paired with their total byte count.
+/// Caps the chunk set to the budget via breadth-first retention (BR-001
+/// revised, see [`select_drops`]). Pure: takes pre-computed `depth_by_path`,
+/// `incoming_counts`, and `total_bytes` so callers can test deterministically
+/// without DB access and the early under-budget check reuses the precomputed
+/// byte sum instead of recomputing it. Returns the surviving chunks paired with
+/// their total byte count.
 pub fn apply_cap(
     chunks: Vec<BriefChunk>,
     depth_by_path: &HashMap<String, u32>,
@@ -205,7 +263,6 @@ pub fn apply_cap(
         incoming_counts,
         max_chunks,
         max_bytes,
-        total_bytes,
     );
     let kept = chunks
         .into_iter()
@@ -377,11 +434,17 @@ pub fn expand_plan(conn: &Connection, task: &TaskBrief) -> Result<BriefOutput, S
             total_bytes: 0,
         });
     }
-    let depth_by_path = collect_closure(conn, &seeds, task.depth)?;
+    let (depth_by_path, forward_paths) = collect_closure(conn, &seeds, task.depth)?;
 
     let paths: Vec<&str> = depth_by_path.keys().map(String::as_str).collect();
     let chunks = get_chunks_for_files(conn, &paths)?;
-    let brief_chunks = build_brief_chunks(chunks, &depth_by_path);
+    let mut brief_chunks = build_brief_chunks(chunks, &depth_by_path, &forward_paths);
+    // Drop test files from the closure unless the caller opted in. A test file
+    // reached via a `mod tests;` edge (or a test seed) is noise for a task about
+    // the code under test.
+    if !task.include_tests {
+        brief_chunks.retain(|c| c.source_kind != Some(SourceKind::Test));
+    }
     // Single byte sum reused by the cap check and the final totals.
     let total_bytes: usize = brief_chunks.iter().map(|c| c.content.len()).sum();
 

--- a/src/brief/tests.rs
+++ b/src/brief/tests.rs
@@ -50,6 +50,7 @@ fn task_with_seeds(seeds: Vec<Seed>, depth: u32) -> TaskBrief {
         depth,
         max_chunks: 80,
         max_bytes: 80_000,
+        include_tests: false,
     }
 }
 
@@ -170,6 +171,88 @@ fn apply_cap_drops_to_fit_byte_budget() {
         remaining, 8,
         "remaining bytes must equal the surviving chunks' total"
     );
+}
+
+// Two files-per-chunk fixture shared by the breadth-first cap tests: 3 files
+// (a depth 0, b/c depth 1) with 2 chunks each, distinct incoming counts so the
+// (depth ASC, incoming DESC) visit order is deterministic.
+fn breadth_first_fixture() -> (Vec<BriefChunk>, HashMap<String, u32>, HashMap<String, u32>) {
+    let chunks = vec![
+        make_brief_chunk("src/a.rs", "a1"),
+        make_brief_chunk("src/a.rs", "a2"),
+        make_brief_chunk("src/b.rs", "b1"),
+        make_brief_chunk("src/b.rs", "b2"),
+        make_brief_chunk("src/c.rs", "c1"),
+        make_brief_chunk("src/c.rs", "c2"),
+    ];
+    let depth_by_path: HashMap<String, u32> = [
+        ("src/a.rs".to_owned(), 0),
+        ("src/b.rs".to_owned(), 1),
+        ("src/c.rs".to_owned(), 1),
+    ]
+    .into_iter()
+    .collect();
+    let incoming_counts: HashMap<String, u32> = [
+        ("src/a.rs".to_owned(), 10),
+        ("src/b.rs".to_owned(), 5),
+        ("src/c.rs".to_owned(), 2),
+    ]
+    .into_iter()
+    .collect();
+    (chunks, depth_by_path, incoming_counts)
+}
+
+// T-605: apply_cap_breadth_first_keeps_one_chunk_per_file
+// Spec FR-D (BR-001 revised): over budget, retention is breadth-first. Every
+// closure file keeps at least one chunk before any file keeps a second, so the
+// budget maximizes file coverage (recall@N) instead of zeroing out whole files
+// at the closure's edge (the failure that capped seed-less recall at 67%).
+#[test]
+fn apply_cap_breadth_first_keeps_one_chunk_per_file() {
+    let (chunks, depth_by_path, incoming_counts) = breadth_first_fixture();
+
+    // Budget of 3 chunks over 3 files: breadth-first must place one chunk in
+    // each file, not spend all 3 on the two shallowest files (the old order
+    // would drop both src/c.rs chunks and lose the file entirely).
+    let (kept, _remaining) = apply_cap(chunks, &depth_by_path, &incoming_counts, 3, u32::MAX, 12);
+
+    let kept_files: HashSet<&str> = kept.iter().map(|c| c.file_path.as_str()).collect();
+    assert_eq!(
+        kept_files.len(),
+        3,
+        "every closure file must keep at least one chunk, got files: {kept_files:?}"
+    );
+    assert_eq!(kept.len(), 3, "budget of 3 chunks must be fully used");
+}
+
+// T-609: apply_cap_breadth_first_keeps_all_files_when_budget_exceeds_file_count
+// Spec FR-D (BR-001 revised): under a chunk-count-bound budget every closure
+// file keeps >= 1 chunk *before* any file keeps a second. With a budget larger
+// than the file count, the extra slot goes to the highest-priority file's
+// second chunk, never by starving a lower-priority file of its first. T-605
+// covers the budget == file-count boundary; this covers budget > file-count,
+// locking the contract the seed-less recall result rests on (#128).
+#[test]
+fn apply_cap_breadth_first_keeps_all_files_when_budget_exceeds_file_count() {
+    let (chunks, depth_by_path, incoming_counts) = breadth_first_fixture();
+
+    // Budget of 4 chunks over 3 files (2 chunks each), byte budget unbounded so
+    // chunk count is the only constraint. Round 0 places a1,b1,c1; the 4th slot
+    // is a2 (highest priority). A depth-first fill (a1,a2,b1,b2) would drop
+    // src/c.rs entirely.
+    let (kept, _remaining) = apply_cap(chunks, &depth_by_path, &incoming_counts, 4, u32::MAX, 12);
+
+    let kept_files: HashSet<&str> = kept.iter().map(|c| c.file_path.as_str()).collect();
+    assert_eq!(
+        kept_files.len(),
+        3,
+        "every closure file must keep a chunk before any file doubles, got: {kept_files:?}"
+    );
+    assert!(
+        kept_files.contains("src/c.rs"),
+        "lowest-priority file must not be starved of its first chunk"
+    );
+    assert_eq!(kept.len(), 4, "budget of 4 chunks must be fully used");
 }
 
 // T-605: render_json_emits_spec_shape
@@ -379,6 +462,52 @@ fn expand_plan_returns_seed_and_forward_chunks() {
     );
 }
 
+// T-604: expand_plan_includes_backward_dependents
+// Spec FR-C: the closure is bidirectional (import union impact). Seeding on a
+// file that another imports must pull in the caller, labeled Impact, so an
+// agent sees who is affected by a change to the seed.
+#[test]
+fn expand_plan_includes_backward_dependents() {
+    let (conn, _dir) = test_db();
+    insert_test_chunk(&conn, "src/a.rs", "a", 1);
+    insert_test_chunk(&conn, "src/b.rs", "b", 1);
+    // a imports b, so b's backward closure (impact) reaches a.
+    replace_file_references(
+        &conn,
+        "src/a.rs",
+        &[Reference {
+            source_file: "src/a.rs".into(),
+            target_file: "src/b.rs".into(),
+            symbol_name: None,
+            ref_kind: RefKind::Named,
+        }],
+    )
+    .unwrap();
+
+    // Seed on b: forward closure is just b, backward closure adds a.
+    let task = task_with_seeds(vec![seed_file("src/b.rs")], 1);
+    let output = expand_plan(&conn, &task).unwrap();
+
+    let by_path: HashMap<&str, &BriefChunk> = output
+        .chunks
+        .iter()
+        .map(|c| (c.file_path.as_str(), c))
+        .collect();
+    assert!(
+        by_path.contains_key("src/a.rs"),
+        "backward dependent src/a.rs must be in the closure, got: {:?}",
+        by_path.keys().collect::<Vec<_>>()
+    );
+    assert_eq!(
+        by_path["src/b.rs"].included_reason,
+        ChunkInclusionReason::Seed
+    );
+    assert_eq!(
+        by_path["src/a.rs"].included_reason,
+        ChunkInclusionReason::Impact(1)
+    );
+}
+
 // T-603: expand_plan_is_deterministic [Spec T-008]
 #[test]
 fn expand_plan_is_deterministic() {
@@ -570,6 +699,7 @@ fn expand_plan_queries_import_counts_when_over_cap() {
         depth: 1,
         max_chunks: 1,
         max_bytes: 80_000,
+        include_tests: false,
     };
 
     let output = expand_plan(&conn, &task).unwrap();

--- a/src/indexer/source_kind.rs
+++ b/src/indexer/source_kind.rs
@@ -58,6 +58,10 @@ fn is_test_filename(name: &str) -> bool {
     if RS_GO_PY_EXTS.contains(&ext) && stem.ends_with("_test") {
         return true;
     }
+    // Rust inline test module: `#[cfg(test)] mod tests;` split into `tests.rs`.
+    if ext == "rs" && stem == "tests" {
+        return true;
+    }
     false
 }
 
@@ -172,6 +176,68 @@ mod tests {
                 classify(input),
                 SourceKind::Vendor,
                 "expected SourceKind::Vendor (precedence over test) for input {input:?}"
+            );
+        }
+    }
+
+    // T-205: inline_test_module_filename_returns_test
+    //
+    // Perspective: Equivalence. Rust's `#[cfg(test)] mod tests;` split into a
+    // `tests.rs` file is the most common inline-test convention. The classifier
+    // must tag it Test so brief and search can exclude it.
+    //
+    // FR: FR-A1-1
+    #[test]
+    fn inline_test_module_filename_returns_test() {
+        let cases = ["src/tools/tests.rs", "src/storage/tests.rs", "tests.rs"];
+        for input in cases {
+            assert_eq!(
+                classify(input),
+                SourceKind::Test,
+                "expected SourceKind::Test for Rust inline test module {input:?}"
+            );
+        }
+    }
+
+    // T-206/T-207: tests_stem_is_rust_specific
+    //
+    // Perspective: Branch (negative). The new `tests.rs` branch is gated on the
+    // `rs` extension. Go (`_test.go`) and Python (`tests/` dir or `test_*.py`)
+    // must not be caught by a `tests` stem, or the classifier would over-trigger
+    // on legitimate non-test module names.
+    //
+    // FR: FR-A1-2
+    #[test]
+    fn tests_stem_is_rust_specific() {
+        let cases = ["src/foo/tests.go", "src/foo/tests.py"];
+        for input in cases {
+            assert_eq!(
+                classify(input),
+                SourceKind::Src,
+                "expected SourceKind::Src (tests stem is rs-only) for input {input:?}"
+            );
+        }
+    }
+
+    // T-208: non_tests_rust_filename_returns_src
+    //
+    // Perspective: Boundary. A `.rs` file whose stem is not exactly `tests`
+    // stays Src even when a sibling `tests.rs` exists. Guards the branch against
+    // widening beyond the exact stem (e.g. `_tests` plural must not match).
+    //
+    // FR: FR-A1-1
+    #[test]
+    fn non_tests_rust_filename_returns_src() {
+        let cases = [
+            "src/tools.rs",
+            "src/tools/format.rs",
+            "src/integration_tests.rs",
+        ];
+        for input in cases {
+            assert_eq!(
+                classify(input),
+                SourceKind::Src,
+                "expected SourceKind::Src for non-tests rust file {input:?}"
             );
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,6 +142,9 @@ Examples:
         /// Maximum bytes in output (1000..=10000000)
         #[arg(long, default_value_t = 80_000, value_parser = clap::value_parser!(u32).range(1000..=10_000_000))]
         max_bytes: u32,
+        /// Include test files in the closure (default: test files are excluded)
+        #[arg(long)]
+        include_tests: bool,
     },
     /// Manage the embedding model.
     #[command(
@@ -337,6 +340,7 @@ fn main() -> ExitCode {
             depth,
             max_chunks,
             max_bytes,
+            include_tests,
         } => {
             let task_brief = brief::TaskBrief {
                 task,
@@ -344,6 +348,7 @@ fn main() -> ExitCode {
                 depth,
                 max_chunks,
                 max_bytes,
+                include_tests,
             };
             yomu.brief(&task_brief, json)
         }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -45,8 +45,10 @@ pub fn file_exists_in_index(conn: &Connection, file_path: &str) -> Result<bool, 
 pub fn get_stats(conn: &Connection) -> Result<IndexStatus, StorageError> {
     let total_chunks: u32 = conn.query_row("SELECT COUNT(*) FROM chunks", [], |row| row.get(0))?;
 
+    // Test chunks are chunked and FTS-indexed but not embedded, so they are not
+    // embeddable. `IS NOT` keeps NULL source_kind (legacy rows) embeddable.
     let embeddable_chunks: u32 = conn.query_row(
-        "SELECT COUNT(*) FROM chunks WHERE chunk_type != 'inner_fn'",
+        "SELECT COUNT(*) FROM chunks WHERE chunk_type != 'inner_fn' AND source_kind IS NOT 'test'",
         [],
         |row| row.get(0),
     )?;

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -61,12 +61,15 @@ pub fn get_unembedded_chunks_for_file(
     conn: &Connection,
     file_path: &str,
 ) -> Result<Vec<UnembeddedChunk>, StorageError> {
+    // `c.source_kind IS NOT 'test'` skips test chunks from the embed worklist
+    // (test code is FTS-searchable but not embedded). `IS NOT` is NULL-safe, so
+    // legacy rows with NULL source_kind stay embeddable.
     let mut stmt = conn.prepare_cached(
         "SELECT c.id, c.content, c.chunk_type, c.name, p.name
          FROM chunks c
          LEFT JOIN chunks p ON c.parent_chunk_id = p.id
          LEFT JOIN embedded_chunk_ids e ON c.id = e.chunk_id
-         WHERE c.file_path = ?1 AND e.chunk_id IS NULL AND c.chunk_type != 'inner_fn'",
+         WHERE c.file_path = ?1 AND e.chunk_id IS NULL AND c.chunk_type != 'inner_fn' AND c.source_kind IS NOT 'test'",
     )?;
     let rows = stmt.query_map([file_path], |row| {
         Ok(UnembeddedChunk {

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -47,7 +47,7 @@ pub fn open_db(path: &Path) -> Result<Connection, StorageError> {
     Ok(conn)
 }
 
-const SCHEMA_VERSION: u32 = 10;
+const SCHEMA_VERSION: u32 = 11;
 
 const DDL_FTS_CHUNKS: &str = "CREATE VIRTUAL TABLE IF NOT EXISTS fts_chunks USING fts5(name, content, file_path, tokenize='trigram')";
 
@@ -293,6 +293,35 @@ fn migrate(conn: &Connection, from: u32, path: &Path) -> Result<(), StorageError
         conn.execute_batch(DDL_FTS_CHUNKS)?;
         conn.execute_batch(DDL_FTS_CHUNKS_VOCAB)?;
         notify_schema_change("yomu", "chunks v10", 0, "yomu index");
+    }
+
+    // v10 → v11: the brief-recall change reclassifies Rust inline `tests.rs`
+    // modules as `source_kind='test'` (previously `'src'`) and stops embedding
+    // test chunks. Existing v10 rows keep the old tag plus stale test
+    // embeddings, and `check_file` skips unchanged files by content hash, so
+    // neither is corrected on the next index without a rebuild. Drop + recreate
+    // the same dependent set as v10 so `yomu index` reclassifies and re-embeds
+    // uniformly; clearing embedded_chunk_ids also restores the
+    // embedded <= embeddable invariant get_stats / embed_pending rely on.
+    if from < 11 {
+        let _span = tracing::info_span!("migration_v11", path = %path.display()).entered();
+        conn.execute_batch(
+            "DROP TABLE IF EXISTS chunks; \
+             DROP TABLE IF EXISTS embedded_chunk_ids; \
+             DROP TABLE IF EXISTS vec_chunks; \
+             DROP TABLE IF EXISTS fts_chunks_vocab; \
+             DROP TABLE IF EXISTS fts_chunks;",
+        )?;
+        // Wipe file_references: dropping chunks invalidates the source_file /
+        // target_file rows (F-005). The next reindex repopulates per surviving
+        // file via replace_file_references.
+        conn.execute_batch("DELETE FROM file_references")?;
+        conn.execute_batch(DDL)?;
+        conn.execute_batch(&ddl_vec_chunks())?;
+        conn.execute_batch(DDL_EMBEDDED_CHUNK_IDS)?;
+        conn.execute_batch(DDL_FTS_CHUNKS)?;
+        conn.execute_batch(DDL_FTS_CHUNKS_VOCAB)?;
+        notify_schema_change("yomu", "chunks v11", 0, "yomu index");
     }
 
     Ok(())

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -2261,9 +2261,9 @@ fn fts_chunks_vocab_exists_on_new_db() {
     assert!(exists, "fts_chunks_vocab table should exist after open_db");
 }
 
-// T-167: migration_v3_to_v10_creates_vocab_and_drops_chunks
+// T-167: migration_v3_to_v11_creates_vocab_and_drops_chunks
 #[test]
-fn migration_v3_to_v10_creates_vocab_and_drops_chunks() {
+fn migration_v3_to_v11_creates_vocab_and_drops_chunks() {
     let dir = tempdir().unwrap();
     let db_path = dir.path().join("test.db");
     let conn = open_db(&db_path).unwrap();
@@ -2300,7 +2300,7 @@ fn migration_v3_to_v10_creates_vocab_and_drops_chunks() {
             |row| row.get(0),
         )
         .unwrap();
-    assert_eq!(version, "10", "schema_version should be 10 after migration");
+    assert_eq!(version, "11", "schema_version should be 11 after migration");
 
     let exists: bool = conn
         .query_row(
@@ -2680,6 +2680,71 @@ fn get_stats_returns_embeddable_and_total_chunks() {
 
     assert_eq!(stats.total_chunks, 3);
     assert_eq!(stats.embeddable_chunks, 2);
+}
+
+// T-214: get_stats_embeddable_excludes_test_chunks
+// Spec FR-A2: embeddable_chunks counts only non-test, non-inner_fn chunks so a
+// full index reaches `embedded == embeddable` (test chunks are not embedded),
+// keeping the degraded signal from firing on intentionally skipped test chunks.
+#[test]
+fn get_stats_embeddable_excludes_test_chunks() {
+    let (conn, _dir) = test_db();
+    let chunks = vec![
+        NewChunk {
+            chunk_type: &ChunkType::Component,
+            name: Some("App"),
+            content: "function App() {}",
+            start_line: 1,
+            end_line: 3,
+            parent_index: None,
+            source_kind: Some(SourceKind::Src),
+            injection_flags: None,
+        },
+        NewChunk {
+            chunk_type: &ChunkType::Component,
+            name: Some("AppTest"),
+            content: "function AppTest() {}",
+            start_line: 10,
+            end_line: 12,
+            parent_index: None,
+            source_kind: Some(SourceKind::Test),
+            injection_flags: None,
+        },
+    ];
+    replace_file_chunks_only(&conn, "src/app.rs", &chunks, "h1", "", &[], None).unwrap();
+
+    let stats = get_stats(&conn).unwrap();
+    assert_eq!(stats.total_chunks, 2, "both chunks counted in total");
+    assert_eq!(
+        stats.embeddable_chunks, 1,
+        "test chunk excluded from embeddable; only the src chunk counts"
+    );
+}
+
+// T-215: get_unembedded_chunks_for_file_excludes_test_source
+// Spec FR-A2: the embed worklist skips chunks whose source_kind is 'test', so
+// test files consume no embedding work even when present in the file list.
+#[test]
+fn get_unembedded_chunks_for_file_excludes_test_source() {
+    let (conn, _dir) = test_db();
+    let chunks = vec![NewChunk {
+        chunk_type: &ChunkType::Component,
+        name: Some("it_works"),
+        content: "function it_works() {}",
+        start_line: 1,
+        end_line: 3,
+        parent_index: None,
+        source_kind: Some(SourceKind::Test),
+        injection_flags: None,
+    }];
+    replace_file_chunks_only(&conn, "src/feature/tests.rs", &chunks, "h1", "", &[], None).unwrap();
+
+    let rows = get_unembedded_chunks_for_file(&conn, "src/feature/tests.rs").unwrap();
+    assert!(
+        rows.is_empty(),
+        "test-source chunks must be excluded from the embed worklist, got {} rows",
+        rows.len()
+    );
 }
 
 // T-017: embed_percentage_uses_embeddable_chunks
@@ -3126,9 +3191,9 @@ fn fts_stores_file_path() {
     );
 }
 
-// T-557: migration_v6_to_v10_drops_chunks_for_reindex
+// T-557: migration_v6_to_v11_drops_chunks_for_reindex
 #[test]
-fn migration_v6_to_v10_drops_chunks_for_reindex() {
+fn migration_v6_to_v11_drops_chunks_for_reindex() {
     let dir = tempdir().unwrap();
     let db_path = dir.path().join("test.db");
     let conn = open_db(&db_path).unwrap();
@@ -3167,7 +3232,7 @@ fn migration_v6_to_v10_drops_chunks_for_reindex() {
             |row| row.get(0),
         )
         .unwrap();
-    assert_eq!(version, "10", "schema_version should be 10 after migration");
+    assert_eq!(version, "11", "schema_version should be 11 after migration");
 
     let chunks_count: i64 = conn
         .query_row("SELECT COUNT(*) FROM chunks", [], |row| row.get(0))
@@ -4213,11 +4278,11 @@ fn schema_v10_chunks_table_includes_new_columns() {
     assert_eq!(injection_flags.unwrap().1, "TEXT");
 }
 
-// T-008: opening_v8_store_drops_chunks_and_bumps_schema_version_to_10
-// Spec FR-002, BR-002: v8 → v10 migration drops chunks and recreates them.
+// T-008: opening_v8_store_drops_chunks_and_bumps_schema_version_to_11
+// Spec FR-002, BR-002: v8 → v11 migration drops chunks and recreates them.
 // V8_CHUNKS_DDL is the v8 schema inlined verbatim (no source_kind / injection_flags).
 #[test]
-fn opening_v8_store_drops_chunks_and_bumps_schema_version_to_10() {
+fn opening_v8_store_drops_chunks_and_bumps_schema_version_to_11() {
     const V8_CHUNKS_DDL: &str = "
         CREATE TABLE chunks (
             id INTEGER PRIMARY KEY,
@@ -4260,7 +4325,7 @@ fn opening_v8_store_drops_chunks_and_bumps_schema_version_to_10() {
     let chunks_count: i64 = conn
         .query_row("SELECT COUNT(*) FROM chunks", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(chunks_count, 0, "v8 → v10 migration must drop all chunks");
+    assert_eq!(chunks_count, 0, "v8 → v11 migration must drop all chunks");
 
     let version: String = conn
         .query_row(
@@ -4269,7 +4334,72 @@ fn opening_v8_store_drops_chunks_and_bumps_schema_version_to_10() {
             |row| row.get(0),
         )
         .unwrap();
-    assert_eq!(version, "10");
+    assert_eq!(version, "11");
+}
+
+// T-219: opening_v10_store_drops_chunks_and_bumps_schema_version_to_11
+// A1/A2 redefine source_kind for Rust inline `tests.rs` modules (now Test, not
+// Src) and stop embedding test chunks. Existing v10 rows keep the old
+// classification plus stale test embeddings, and check_file skips unchanged
+// files by hash, so a rebuild is required. The v10 -> v11 migration drops chunks
+// (and dependents) to force reclassification on the next `yomu index`.
+#[test]
+fn opening_v10_store_drops_chunks_and_bumps_schema_version_to_11() {
+    const V10_CHUNKS_DDL: &str = "
+        CREATE TABLE chunks (
+            id INTEGER PRIMARY KEY,
+            file_path TEXT NOT NULL,
+            chunk_type TEXT NOT NULL,
+            name TEXT,
+            content TEXT NOT NULL,
+            start_line INTEGER NOT NULL,
+            end_line INTEGER NOT NULL,
+            file_hash TEXT NOT NULL,
+            parent_chunk_id INTEGER REFERENCES chunks(id),
+            source_kind TEXT,
+            injection_flags TEXT
+        );
+        CREATE TABLE index_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+    ";
+
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("v10.db");
+
+    {
+        let raw = Connection::open(&db_path).unwrap();
+        raw.execute_batch(V10_CHUNKS_DDL).unwrap();
+        // A Rust inline test module mis-tagged 'src' under the pre-A1 classifier.
+        raw.execute(
+            "INSERT INTO chunks (file_path, chunk_type, name, content, start_line, end_line, file_hash, parent_chunk_id, source_kind) \
+             VALUES ('src/foo/tests.rs', 'function', 'it_works', 'fn it_works() {}', 1, 1, 'h1', NULL, 'src')",
+            [],
+        )
+        .unwrap();
+        raw.execute(
+            "INSERT INTO index_meta (key, value) VALUES ('schema_version', '10')",
+            [],
+        )
+        .unwrap();
+    }
+
+    let conn = open_db(&db_path).unwrap();
+
+    let chunks_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM chunks", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(chunks_count, 0, "v10 -> v11 migration must drop all chunks");
+
+    let version: String = conn
+        .query_row(
+            "SELECT value FROM index_meta WHERE key = 'schema_version'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(version, "11");
 }
 
 // T-009: opening_v8_store_drops_stale_file_references
@@ -4376,7 +4506,7 @@ fn opening_v9_store_drops_stale_file_references() {
 
 // ── PR#3 Phase 2: schema v10 bump (FR-307a, FR-307b, FR-307c) ──
 
-// T-307: opening_v9_store_drops_chunks_and_bumps_schema_version_to_10
+// T-307: opening_v9_store_drops_chunks_and_bumps_schema_version_to_11
 //
 // Perspective: State (v9 → v10 transition) + Hazard (pre-existing v9 chunk
 // rows must be wiped to close the codex P1 contract loop where NULL-column
@@ -4387,7 +4517,7 @@ fn opening_v9_store_drops_stale_file_references() {
 // so the user is told to run `yomu index` again.
 #[traced_test]
 #[test]
-fn opening_v9_store_drops_chunks_and_bumps_schema_version_to_10() {
+fn opening_v9_store_drops_chunks_and_bumps_schema_version_to_11() {
     let dir = tempdir().unwrap();
     let db_path = dir.path().join("v9.db");
 
@@ -4428,8 +4558,8 @@ fn opening_v9_store_drops_chunks_and_bumps_schema_version_to_10() {
         )
         .unwrap();
     assert_eq!(
-        version, "10",
-        "schema_version must be bumped to 10 after v9 → v10 migration"
+        version, "11",
+        "schema_version must be bumped to 11 after migration to the current version"
     );
 
     let chunks_count: i64 = conn
@@ -4444,16 +4574,21 @@ fn opening_v9_store_drops_chunks_and_bumps_schema_version_to_10() {
         logs_contain("chunks v10"),
         "v9 → v10 migration must emit notify_schema_change(\"yomu\", \"chunks v10\", ...)"
     );
+    // A v9 DB now crosses two steps: the v10 → v11 block must also run.
+    assert!(
+        logs_contain("chunks v11"),
+        "v10 → v11 migration must also run for a v9 DB and emit \"chunks v11\""
+    );
 }
 
-// T-308: fresh_db_initializes_at_schema_version_10
+// T-308: fresh_db_initializes_at_schema_version_11
 //
 // Perspective: Equivalence (fresh-DB init path) + Boundary (no prior
 // schema_version row → migrate from 0 lands at SCHEMA_VERSION).
-// Spec FR-307a: SCHEMA_VERSION const SHALL be 10. A fresh DB SHALL be
-// initialized at v10 with the 9 chunks columns present.
+// Spec FR-307a: SCHEMA_VERSION const SHALL be 11. A fresh DB SHALL be
+// initialized at v11 with the 9 chunks columns present.
 #[test]
-fn fresh_db_initializes_at_schema_version_10() {
+fn fresh_db_initializes_at_schema_version_11() {
     let (conn, _dir) = test_db();
 
     let version: String = conn
@@ -4464,8 +4599,8 @@ fn fresh_db_initializes_at_schema_version_10() {
         )
         .unwrap();
     assert_eq!(
-        version, "10",
-        "fresh DB must initialize at schema_version = 10"
+        version, "11",
+        "fresh DB must initialize at schema_version = 11"
     );
 
     let mut stmt = conn.prepare("PRAGMA table_info(chunks)").unwrap();
@@ -4475,7 +4610,7 @@ fn fresh_db_initializes_at_schema_version_10() {
         .collect::<Result<_, _>>()
         .unwrap();
 
-    // FR-307a: chunks at v10 must carry the 9 SELECT columns from FR-303
+    // FR-307a: chunks at v11 must carry the 9 SELECT columns from FR-303
     // (id is the implicit PRIMARY KEY; file_hash exists in DDL but is not
     // part of the FR-303 projection — assert it stays present for full DDL
     // coverage). Total expected = 11 declared columns.

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -2391,6 +2391,7 @@ fn brief_task(seed_file: &str) -> brief::TaskBrief {
         depth: 1,
         max_chunks: 80,
         max_bytes: 80_000,
+        include_tests: false,
     }
 }
 
@@ -2466,6 +2467,7 @@ fn brief_fts_seeds_when_no_embedder_and_keyword_matches() {
         depth: 1,
         max_chunks: 80,
         max_bytes: 80_000,
+        include_tests: false,
     };
 
     let output = yomu.brief(&task, true).unwrap();
@@ -2498,6 +2500,7 @@ fn brief_falls_back_to_degraded_when_no_embedder() {
         depth: 1,
         max_chunks: 80,
         max_bytes: 80_000,
+        include_tests: false,
     };
 
     let output = yomu.brief(&task, true).unwrap();
@@ -2531,6 +2534,7 @@ fn brief_emits_warn_on_seed_inference_embed_query_failure() {
         depth: 1,
         max_chunks: 80,
         max_bytes: 80_000,
+        include_tests: false,
     };
 
     let output = yomu.brief(&task, true).unwrap();

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::Path;
 use std::process::{Command, Stdio};
 
 use tempfile::{TempDir, tempdir};
@@ -1586,6 +1587,239 @@ fn index_exclude_vendor_drops_vendor_source_kind() {
         vendor_count_baseline > 0,
         "regression: baseline `yomu index` (no flag) must produce vendor chunks for the \
          --exclude-vendor flag to be non-vacuous, got {vendor_count_baseline}"
+    );
+}
+
+// Helper for T-209: a project whose test code lives in a Rust inline test
+// module file `src/feature/tests.rs` (the `#[cfg(test)] mod tests;` split-out
+// convention), alongside a plain `src/feature.rs`. NOT pre-indexed.
+fn setup_inline_test_module_project() -> TempDir {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let feature = src.join("feature");
+    fs::create_dir_all(&feature).unwrap();
+    fs::write(src.join("lib.rs"), "pub mod feature;\n").unwrap();
+    fs::write(
+        src.join("feature.rs"),
+        "pub fn sum(a: i32, b: i32) -> i32 { a + b }\n#[cfg(test)]\nmod tests;\n",
+    )
+    .unwrap();
+    fs::write(
+        feature.join("tests.rs"),
+        "#[test]\nfn computes_sum() {\n    assert_eq!(super::sum(2, 3), 5);\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"inline_test_e2e\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    Command::new("git")
+        .args(["init"])
+        .current_dir(dir.path())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .unwrap();
+    dir
+}
+
+// T-209: index_tags_rust_inline_test_module_as_test
+// Spec FR-A1-1/FR-A1-4: after `yomu index`, chunks from a Rust inline test
+// module file (`src/feature/tests.rs`) carry source_kind='test', while the
+// sibling source file (`src/feature.rs`) stays 'src'. End-to-end guard that the
+// classifier fix reaches the persisted column.
+#[test]
+fn index_tags_rust_inline_test_module_as_test() {
+    let dir = setup_inline_test_module_project();
+    let out = yomu_cmd()
+        .arg("index")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "index failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let db_path = dir.path().join(".yomu").join("index.db");
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let test_chunks: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM chunks WHERE file_path LIKE '%feature/tests.rs' AND source_kind = 'test'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let mistagged: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM chunks WHERE file_path LIKE '%feature/tests.rs' AND source_kind != 'test'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let parent_src: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM chunks WHERE file_path LIKE '%/feature.rs' AND source_kind = 'src'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    drop(conn);
+
+    assert!(
+        test_chunks > 0,
+        "inline test module src/feature/tests.rs must yield test chunks, got {test_chunks}"
+    );
+    assert_eq!(
+        mistagged, 0,
+        "no chunk from src/feature/tests.rs may carry a non-test source_kind, got {mistagged}"
+    );
+    assert!(
+        parent_src > 0,
+        "sibling source src/feature.rs must stay source_kind='src', got {parent_src}"
+    );
+}
+
+// T-216: index_does_not_embed_test_chunks
+// Spec FR-A2: after `yomu index`, test files are chunked/FTS-indexed but NOT
+// embedded. No test chunk appears in embedded_chunk_ids, and the embedded count
+// equals the embeddable (non-test, non-inner_fn) count so status is not degraded.
+#[test]
+fn index_does_not_embed_test_chunks() {
+    let dir = setup_inline_test_module_project();
+    let out = yomu_cmd()
+        .arg("index")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "index failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let db_path = dir.path().join(".yomu").join("index.db");
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let embedded_test: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM embedded_chunk_ids e \
+             JOIN chunks c ON e.chunk_id = c.id WHERE c.source_kind = 'test'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let embeddable_expected: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM chunks WHERE source_kind != 'test' AND chunk_type != 'inner_fn'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let embedded_total: i64 = conn
+        .query_row(
+            "SELECT COUNT(DISTINCT chunk_id) FROM embedded_chunk_ids",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    drop(conn);
+
+    assert!(
+        embeddable_expected > 0,
+        "fixture must have embeddable src chunks, got {embeddable_expected}"
+    );
+    assert_eq!(
+        embedded_test, 0,
+        "test chunks must not be embedded, got {embedded_test}"
+    );
+    assert_eq!(
+        embedded_total, embeddable_expected,
+        "embedded count must equal embeddable (non-test, non-inner_fn) count; \
+         embedded={embedded_total} embeddable={embeddable_expected}"
+    );
+}
+
+// Returns the distinct file_path values of a `yomu --json brief` invocation.
+fn brief_files(dir: &Path, extra_args: &[&str]) -> Vec<String> {
+    let mut args = vec![
+        "--json",
+        "brief",
+        "feature sum helper",
+        "--seed-file",
+        "src/feature.rs",
+    ];
+    args.extend_from_slice(extra_args);
+    let out = yomu_cmd().args(&args).current_dir(dir).output().unwrap();
+    assert!(
+        out.status.success(),
+        "brief failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("brief stdout is not JSON: {e}; got: {stdout}"));
+    let mut files: Vec<String> = parsed["chunks"]
+        .as_array()
+        .unwrap_or(&Vec::new())
+        .iter()
+        .filter_map(|c| c["file_path"].as_str().map(str::to_owned))
+        .collect();
+    files.sort();
+    files.dedup();
+    files
+}
+
+// T-217: brief_excludes_test_chunks_from_closure_by_default
+// Spec FR-B: brief drops chunks whose source_kind is 'test' from the forward
+// closure. Seeding on src/feature.rs (which declares `mod tests;`) must yield
+// the src seed without its inline test module.
+#[test]
+fn brief_excludes_test_chunks_from_closure_by_default() {
+    let dir = setup_inline_test_module_project();
+    let idx = yomu_cmd()
+        .arg("index")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        idx.status.success(),
+        "index failed: {}",
+        String::from_utf8_lossy(&idx.stderr)
+    );
+
+    let files = brief_files(dir.path(), &[]);
+    assert!(
+        files.iter().any(|f| f.ends_with("feature.rs")),
+        "src seed src/feature.rs must be present, got: {files:?}"
+    );
+    assert!(
+        !files.iter().any(|f| f.ends_with("feature/tests.rs")),
+        "inline test module must be excluded by default, got: {files:?}"
+    );
+}
+
+// T-218: brief_include_tests_flag_keeps_test_chunks
+// Spec FR-B: `--include-tests` opts back into test code for test-fixing tasks.
+#[test]
+fn brief_include_tests_flag_keeps_test_chunks() {
+    let dir = setup_inline_test_module_project();
+    let idx = yomu_cmd()
+        .arg("index")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        idx.status.success(),
+        "index failed: {}",
+        String::from_utf8_lossy(&idx.stderr)
+    );
+
+    let files = brief_files(dir.path(), &["--include-tests"]);
+    assert!(
+        files.iter().any(|f| f.ends_with("feature/tests.rs")),
+        "--include-tests must keep the inline test module, got: {files:?}"
     );
 }
 


### PR DESCRIPTION
## 概要

seed-less `yomu brief` の recall@N が実質機能していなかった (mean 14%、多くが 100% test ファイルを返す) 問題を、3つの複合失敗モードに対する5 Unit + schema 移行で修正する。同一 repo・同一 6 GT・seed-less で **recall@N 14% → 100% (cap 80)**。

baseline と全成果は #128 に記録 ([結果コメント](https://github.com/thkt/yomu/issues/128#issuecomment-4563596912))。

## 失敗モードと修正 (5 Unit)

| Unit | 失敗モード | 修正 |
| --- | --- | --- |
| **A1** (source_kind) | seed 推論が test に着地 | classify が Rust inline test `src/**/tests.rs` を Src 誤分類していた root を修正 → semantic seed が src に着地 |
| **A2** (embed-skip) | test chunk が embed/検索を汚染 | test chunk を embed しない (`source_kind IS NOT 'test'` を embeddable 会計 + get_unembedded に)。chunk/FTS には残し embed のみ skip |
| **B** (test 除外) | `mod tests;` edge が closure 混入 | brief default で test を closure から除外、`--include-tests` で opt-out (failing test を直すタスク向け) |
| **C** (双方向 closure) | forward-only で caller に到達不能 | collect_closure を forward ∪ backward (`get_transitive_dependents`) の union 化、`ChunkInclusionReason::Impact(n)` で backward をラベル。OUTCOME の「import/impact 双方向 closure」に準拠 |
| **D** (breadth-first cap) | cap が hub seed の budget を独占 | select_drops を round-robin (各 file 1 chunk ずつ) に書換、`deletion_priority` を削除 |

### schema 移行 (v11)

A1/A2 は格納済みの `source_kind` と embedding を変えるため、`SCHEMA_VERSION` を 11 に上げ v10→v11 migration で chunks を drop する (v9/v10 と同一パターン)。既存 index は次回 `yomu index` で再分類・再 embed され、stale な test embedding も一掃される。**これがないと feature は既存ユーザーの index に効かない** (review で検出: 既存 index は content-hash skip で再分類されず、`embedded_chunks` が stale test embedding を数え `embed_pending` が source chunk を skip しうる)。

## 検証

同一 repo・同一 6 GT・seed-less で **recall@N 14% → 100% (cap 80)**。journey: 14 → 67 (A1+A2) → 67 (B+C, cap-masked) → 100 (D)。

**判別測定** (100%@cap80 が小規模 repo の closure 飽和 artifact でないことの確認):

| cap | mean recall@N | 解釈 |
| --- | --- | --- |
| 10 | 94% | 全 6 GT の closure ≥ 26 file ゆえ saturation なし。random baseline (k/N ≈ 32%) の 2.9x |
| 5 | 81% | random baseline (≈ 16%) の 5.1x |

→ D の breadth-first ordering は出力を絞っても must-include を上位ランクしている (本物)。**precision/depth・大規模 repo 検証は次フロンティア** (#128 参照)。

テスト: lib 608 / integration 58 / schema 2 / verification 2、0 failed。clippy clean。統合テストは `--features test-support` (stub embedder)。

## レビュー (/polish)

code-review (5 angle) + Codex + CodeRabbit + critic-audit を実施。Codex の index-移行 2 件 (P1 embedded_chunks 不整合 / P2 tests.rs 未再分類) を schema bump で一括解決。critic-audit が修正 5 claim を全 confirmed。byte-budget の指摘 (F1) は max_bytes が hard cap ゆえ doc over-promise と判明し、doc 精度化 + 契約テスト T-609 を追加。clippy `absolute_paths` を 3 箇所修正。

## Follow-up (別 issue 化予定)

- **F2**: `--seed-file <test path>` (A1 で Test 化) without `--include-tests` で closure が空になると、`degraded=true` にはなる (silent ではない) が render が FTS 用 note を出し原因を誤帰属する。正確な原因 note には notes channel/新 field が要る。LOW。
- precision/depth (1 chunk/file で「再検索不要」十分か) と大規模 repo での recall/precision 検証 (must-include 大・疎 closure)。

Refs #128
