### PR TITLE
fix(brief): test seed の degraded note 誤帰属を解消し TS type-only 閉包を検証 (#236, #127)

### DIFF
--- a/src/brief.rs
+++ b/src/brief.rs
@@ -439,11 +439,16 @@ pub fn expand_plan(conn: &Connection, task: &TaskBrief) -> Result<BriefOutput, S
     let paths: Vec<&str> = depth_by_path.keys().map(String::as_str).collect();
     let chunks = get_chunks_for_files(conn, &paths)?;
     let mut brief_chunks = build_brief_chunks(chunks, &depth_by_path, &forward_paths);
-    // Drop test files from the closure unless the caller opted in. A test file
-    // reached via a `mod tests;` edge (or a test seed) is noise for a task about
-    // the code under test.
+    // Drop test files reached transitively (e.g. via a `mod tests;` edge): they
+    // are noise for a task about the code under test. An explicitly named seed
+    // is the exception — the caller asked for that file, so keep it even when it
+    // is a test. Dropping it would empty the closure and the CLI would then
+    // misreport the cause as an FTS fallback (#236).
     if !task.include_tests {
-        brief_chunks.retain(|c| c.source_kind != Some(SourceKind::Test));
+        let seed_set: HashSet<&str> = seeds.iter().map(String::as_str).collect();
+        brief_chunks.retain(|c| {
+            c.source_kind != Some(SourceKind::Test) || seed_set.contains(c.file_path.as_str())
+        });
     }
     // Single byte sum reused by the cap check and the final totals.
     let total_bytes: usize = brief_chunks.iter().map(|c| c.content.len()).sum();

--- a/src/brief/tests.rs
+++ b/src/brief/tests.rs
@@ -55,6 +55,16 @@ fn task_with_seeds(seeds: Vec<Seed>, depth: u32) -> TaskBrief {
 }
 
 fn insert_test_chunk(conn: &Connection, file_path: &str, name: &'static str, start: u32) {
+    insert_kind_chunk(conn, file_path, name, start, None);
+}
+
+fn insert_kind_chunk(
+    conn: &Connection,
+    file_path: &str,
+    name: &'static str,
+    start: u32,
+    source_kind: Option<SourceKind>,
+) {
     insert_chunk(
         conn,
         file_path,
@@ -65,7 +75,7 @@ fn insert_test_chunk(conn: &Connection, file_path: &str, name: &'static str, sta
             start_line: start,
             end_line: start + 2,
             parent_index: None,
-            source_kind: None,
+            source_kind,
             injection_flags: None,
         },
         "h",
@@ -711,4 +721,35 @@ fn expand_plan_queries_import_counts_when_over_cap() {
     );
     assert_eq!(output.total_chunks, 1);
     assert!(!output.degraded, "a satisfiable seed must not degrade");
+}
+
+// T-615: expand_plan_keeps_explicit_test_seed [#236]
+// A test file named directly as the seed must survive the default test filter.
+// Dropping it (as the pre-fix filter did) empties the closure, and the CLI then
+// misreports the empty result as an FTS fallback. Transitively-reached test
+// files are still dropped (T-217 integration).
+#[test]
+fn expand_plan_keeps_explicit_test_seed() {
+    let (conn, _dir) = test_db();
+    insert_kind_chunk(
+        &conn,
+        "src/feature/tests.rs",
+        "computes_sum",
+        1,
+        Some(SourceKind::Test),
+    );
+
+    let task = task_with_seeds(vec![seed_file("src/feature/tests.rs")], 1);
+    let output = expand_plan(&conn, &task).unwrap();
+
+    assert_eq!(
+        output.chunks.len(),
+        1,
+        "explicit test seed must survive the default test filter"
+    );
+    assert_eq!(output.chunks[0].file_path, "src/feature/tests.rs");
+    assert!(
+        !output.degraded,
+        "a satisfiable explicit seed must not degrade"
+    );
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1086,6 +1086,49 @@ fn setup_ts_alias_project() -> TempDir {
     dir
 }
 
+/// Like `setup_ts_alias_project` but the seed reaches its target through a
+/// `import type { ... }` specifier instead of a value import, exercising the
+/// `RefKind::TypeOnly` edge under the same baseUrl path alias.
+fn setup_ts_type_only_project() -> TempDir {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir_all(src.join("components")).unwrap();
+    fs::write(
+        dir.path().join("tsconfig.json"),
+        "{ \"compilerOptions\": { \"baseUrl\": \"src\", \"paths\": { \"@/*\": [\"*\"] } } }\n",
+    )
+    .unwrap();
+    fs::write(
+        src.join("components/widget.tsx"),
+        "import type { Theme } from \"@/types\";\n\
+         export function Widget(t: Theme) { return t.name; }\n",
+    )
+    .unwrap();
+    fs::write(
+        src.join("types.ts"),
+        "export interface Theme { name: string; }\n",
+    )
+    .unwrap();
+    Command::new("git")
+        .args(["init"])
+        .current_dir(dir.path())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .unwrap();
+    let out = yomu_cmd()
+        .arg("index")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "index failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    dir
+}
+
 // T-613: brief_resolves_tsconfig_baseurl_path_alias [#127 Phase 2]
 // The seed imports `@/util/format`; tsconfig maps `@/*` to `*` under
 // `baseUrl: "src"`, so the forward closure must include `src/util/format.ts`.
@@ -1115,6 +1158,33 @@ fn brief_resolves_tsconfig_baseurl_path_alias() {
         stdout.contains("src/util/format.ts"),
         "forward closure must resolve baseUrl path alias `@/util/format` → \
          src/util/format.ts, got: {stdout}"
+    );
+}
+
+// T-614: brief_resolves_type_only_path_alias [#127 Phase 2]
+// The seed reaches `src/types.ts` only through `import type { Theme } from
+// "@/types"`. A type-only specifier must still emit a forward edge
+// (`RefKind::TypeOnly`), so the same baseUrl path alias must land the target in
+// the closure. Probes the last unverified TS gap from #127.
+#[test]
+fn brief_resolves_type_only_path_alias() {
+    let dir = setup_ts_type_only_project();
+    let output = yomu_cmd()
+        .args(["brief", "theme", "--seed-file", "src/components/widget.tsx"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "brief failed: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("src/types.ts"),
+        "type-only import `@/types` must resolve into forward closure → \
+         src/types.ts, got: {stdout}"
     );
 }
 
@@ -1820,6 +1890,80 @@ fn brief_include_tests_flag_keeps_test_chunks() {
     assert!(
         files.iter().any(|f| f.ends_with("feature/tests.rs")),
         "--include-tests must keep the inline test module, got: {files:?}"
+    );
+}
+
+// A test file reached by nothing (no `mod` declaration) and importing nothing
+// resolvable: its bidirectional closure is the seed alone, all test-kind. This
+// is the only shape that empties under the default test filter now that the
+// closure is bidirectional — an inline `mod tests;` file always pulls its src
+// parent in backward.
+fn setup_orphan_test_seed_project() -> TempDir {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir_all(src.join("widget")).unwrap();
+    fs::write(src.join("lib.rs"), "pub fn noop() {}\n").unwrap();
+    fs::write(
+        src.join("widget/tests.rs"),
+        "#[test]\nfn solo() {\n    assert!(true);\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"orphan_test_e2e\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    Command::new("git")
+        .args(["init"])
+        .current_dir(dir.path())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .unwrap();
+    let out = yomu_cmd()
+        .arg("index")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "index failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    dir
+}
+
+// T-616: brief_explicit_test_seed_keeps_seed_without_misattribution [#236]
+// Seeding directly on a test file whose whole closure is test-kind, without
+// --include-tests. The seed must survive (the caller named it), so the closure
+// is non-empty and the CLI does not emit the degraded note — that note means
+// "FTS-only seed selection" and would misreport the cause of an empty result.
+#[test]
+fn brief_explicit_test_seed_keeps_seed_without_misattribution() {
+    let dir = setup_orphan_test_seed_project();
+    let out = yomu_cmd()
+        .args([
+            "brief",
+            "fix the failing solo assertion",
+            "--seed-file",
+            "src/widget/tests.rs",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "brief failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("src/widget/tests.rs"),
+        "explicit test seed must survive the default test filter, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("FTS-only seed selection"),
+        "a non-empty closure must not emit the FTS-fallback degraded note (#236), got: {stdout}"
     );
 }
 


### PR DESCRIPTION
## 概要

brief の小さい改善2件。

- #236 (fix): 明示 test seed を test-filter 例外にし、closure が空になって degraded note (FTS fallback の意) が原因を誤帰属する問題を解消。
- #127 (検証): TS type-only path-alias を T-614 で実証。#234 の baseUrl fix 後、`import type { T } from "@/x"` が forward closure に入る。resolver / indexer / closure の全経路は実装済み。

## 変更

- `expand_plan`: include_tests=false でも seed path の chunk は retain (src/brief.rs)
- T-614 (type-only closure) / T-615 (unit: seed 保持) / T-616 (integration: 誤帰属なし)

## 検証

- lib 614 / cli_integration 60 green、clippy クリーン
- fix のみ stash して T-615 / T-616 が FAILED → red→green を実証

## 既知の残件 (follow-up 候補)

- #236 の root (degraded フラグが FTS fallback と空 closure を多重表現) は本 PR では未解消。`--seed-file <index 外>` 等の空 closure では依然 FTS note が出る (実機確認)。完全な root 解消は案 a (原因別 note) を別 issue で追跡したい。
- #127 multi-target paths (`["src/*","lib/*"]`, resolver.rs:174 の `.first()`) は #234 が defer 済み。#127 は narrowed scope (type-only + path-alias) としては close 可能。

Closes #236
Refs #127