### PR TITLE
feat(recall): recall/cap-fit 測定コアと expand_plan の pre-cap reachable surface (#128 Phase 1)

### DIFF
--- a/src/brief.rs
+++ b/src/brief.rs
@@ -75,6 +75,11 @@ pub struct BriefOutput {
     pub degraded: bool,
     pub total_chunks: u32,
     pub total_bytes: u32,
+    /// Distinct files reachable in the closure after the test filter and before
+    /// the cap. Surfaced for recall measurement (FR-002): cap-fit's denominator
+    /// is the must-include weight reachable here, isolating the cap's effect
+    /// from the closure's coverage. Not serialized in the CLI output.
+    pub reachable_files: Vec<String>,
 }
 
 fn collect_seed_paths(task: &TaskBrief) -> Vec<String> {
@@ -432,6 +437,7 @@ pub fn expand_plan(conn: &Connection, task: &TaskBrief) -> Result<BriefOutput, S
             degraded: true,
             total_chunks: 0,
             total_bytes: 0,
+            reachable_files: Vec::new(),
         });
     }
     let (depth_by_path, forward_paths) = collect_closure(conn, &seeds, task.depth)?;
@@ -450,6 +456,19 @@ pub fn expand_plan(conn: &Connection, task: &TaskBrief) -> Result<BriefOutput, S
             c.source_kind != Some(SourceKind::Test) || seed_set.contains(c.file_path.as_str())
         });
     }
+
+    // Distinct files reachable after the test filter and before the cap, in
+    // chunk (source) order. Captured here so cap-fit (FR-002) can divide by the
+    // must-include weight the closure actually reached, not what the cap kept.
+    let reachable_files: Vec<String> = {
+        let mut seen = HashSet::new();
+        brief_chunks
+            .iter()
+            .filter(|c| seen.insert(c.file_path.as_str()))
+            .map(|c| c.file_path.clone())
+            .collect()
+    };
+
     // Single byte sum reused by the cap check and the final totals.
     let total_bytes: usize = brief_chunks.iter().map(|c| c.content.len()).sum();
 
@@ -489,6 +508,7 @@ pub fn expand_plan(conn: &Connection, task: &TaskBrief) -> Result<BriefOutput, S
         degraded: false,
         total_chunks,
         total_bytes,
+        reachable_files,
     })
 }
 

--- a/src/brief/tests.rs
+++ b/src/brief/tests.rs
@@ -282,6 +282,7 @@ fn render_json_emits_spec_shape() {
         degraded: true,
         total_chunks: 1,
         total_bytes: 11,
+        reachable_files: Vec::new(),
     };
 
     let rendered = render_json(&output);
@@ -317,6 +318,7 @@ fn render_json_includes_seed_and_modkinds() {
         degraded: false,
         total_chunks: 3,
         total_bytes: 0,
+        reachable_files: Vec::new(),
     };
     let parsed: serde_json::Value = serde_json::from_str(&render_json(&output)).unwrap();
     assert_eq!(parsed["chunks"][0]["included_reason"], "seed");
@@ -345,6 +347,7 @@ fn render_plain_outputs_separator_and_header() {
         degraded: false,
         total_chunks: 2,
         total_bytes: 0,
+        reachable_files: Vec::new(),
     };
 
     let rendered = render_plain(&output);
@@ -362,6 +365,7 @@ fn render_plain_returns_empty_string_for_empty_output() {
         degraded: false,
         total_chunks: 0,
         total_bytes: 0,
+        reachable_files: Vec::new(),
     };
     assert_eq!(render_plain(&output), "");
 }
@@ -383,6 +387,7 @@ fn render_plain_prepends_degraded_note() {
         degraded: true,
         total_chunks: 1,
         total_bytes: 11,
+        reachable_files: Vec::new(),
     };
     let rendered = render_plain(&output);
     assert!(
@@ -403,6 +408,7 @@ fn render_plain_empty_degraded_returns_only_note() {
         degraded: true,
         total_chunks: 0,
         total_bytes: 0,
+        reachable_files: Vec::new(),
     };
     assert_eq!(
         render_plain(&output),
@@ -574,6 +580,7 @@ fn render_json_emits_per_chunk_injection_flags() {
         degraded: false,
         total_chunks: 1,
         total_bytes: 11,
+        reachable_files: Vec::new(),
     };
 
     let rendered = render_json(&output);
@@ -610,6 +617,7 @@ fn render_json_emits_per_chunk_source_kind() {
         degraded: false,
         total_chunks: 1,
         total_bytes: 11,
+        reachable_files: Vec::new(),
     };
 
     let rendered = render_json(&output);
@@ -638,6 +646,7 @@ fn render_json_skips_source_kind_when_none() {
         degraded: false,
         total_chunks: 1,
         total_bytes: 11,
+        reachable_files: Vec::new(),
     };
 
     let rendered = render_json(&output);
@@ -655,6 +664,7 @@ fn render_json_emits_injection_check_even_with_empty_chunks() {
         degraded: false,
         total_chunks: 0,
         total_bytes: 0,
+        reachable_files: Vec::new(),
     };
 
     let rendered = render_json(&output);
@@ -751,5 +761,66 @@ fn expand_plan_keeps_explicit_test_seed() {
     assert!(
         !output.degraded,
         "a satisfiable explicit seed must not degrade"
+    );
+}
+
+// T-002: expand_plan_surfaces_pre_cap_reachable_files [#128 FR-002]
+// The reachable set is the closure after the test filter and before the cap:
+// a forward-reached test file is excluded (retain), and the set does not shrink
+// when the cap does. cap-fit divides by this, isolating the cap from the filter.
+#[test]
+fn expand_plan_surfaces_pre_cap_reachable_files() {
+    let (conn, _dir) = test_db();
+    for (path, name) in [
+        ("src/a.rs", "a"),
+        ("src/b.rs", "b"),
+        ("src/c.rs", "c"),
+        ("src/d.rs", "d"),
+    ] {
+        insert_test_chunk(&conn, path, name, 1);
+    }
+    insert_kind_chunk(&conn, "src/d/tests.rs", "t", 1, Some(SourceKind::Test));
+    let edge = |source: &str, target: &str| Reference {
+        source_file: source.into(),
+        target_file: target.into(),
+        symbol_name: None,
+        ref_kind: RefKind::Named,
+    };
+    replace_file_references(&conn, "src/a.rs", &[edge("src/a.rs", "src/b.rs")]).unwrap();
+    replace_file_references(&conn, "src/b.rs", &[edge("src/b.rs", "src/c.rs")]).unwrap();
+    replace_file_references(&conn, "src/c.rs", &[edge("src/c.rs", "src/d.rs")]).unwrap();
+    replace_file_references(&conn, "src/d.rs", &[edge("src/d.rs", "src/d/tests.rs")]).unwrap();
+
+    let reachable = |max_chunks: u32| -> Vec<String> {
+        let task = TaskBrief {
+            task: "find".to_owned(),
+            seeds: vec![seed_file("src/a.rs")],
+            depth: 5,
+            max_chunks,
+            max_bytes: 80_000,
+            include_tests: false,
+        };
+        let mut r = expand_plan(&conn, &task).unwrap().reachable_files;
+        r.sort();
+        r
+    };
+
+    let expected = vec![
+        "src/a.rs".to_owned(),
+        "src/b.rs".to_owned(),
+        "src/c.rs".to_owned(),
+        "src/d.rs".to_owned(),
+    ];
+    // Forward-reached test file (src/d/tests.rs) is excluded by the test filter.
+    assert_eq!(
+        reachable(80),
+        expected,
+        "reachable set excludes the forward-reached test file"
+    );
+    // Pre-cap: shrinking the cap to 2 must not shrink the reachable set.
+    assert_eq!(
+        reachable(2),
+        expected,
+        "reachable set is captured pre-cap, independent of max_chunks"
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod injection_check;
 pub mod io;
 pub mod query;
 pub mod query_log;
+pub mod recall;
 pub mod resolver;
 pub mod rust_resolver;
 pub mod storage;

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -1,0 +1,181 @@
+//! Recall / cap-fit measurement for `brief` output against a ground-truth corpus.
+//!
+//! Pure (no I/O). Mirrors the degraded-on-vacuous contract of [`crate::verify`]
+//! (`verify.rs` `compute_rates`): when a denominator is structurally zero the
+//! rate is vacuous (1.0) and `degraded` is set so a gate fails loud instead of
+//! passing on a meaningless metric.
+
+use std::collections::HashSet;
+
+/// A must-include file paired with its domain-assigned importance weight.
+///
+/// Weight ranks how much dropping the file would hurt the brief's completeness
+/// (1 = supporting, higher = central). Used only by the weighted cap-fit metric;
+/// plain recall ignores it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WeightedFile {
+    pub path: String,
+    pub weight: u32,
+}
+
+/// Recall and cap-fit for one ground-truth entry.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RecallReport {
+    /// Unweighted must-include hit rate: present / total.
+    pub recall: f64,
+    /// Weighted ratio of must-include kept by the cap, among those the closure
+    /// reached pre-cap. Isolates the cap's effect from the closure's coverage.
+    pub cap_fit: f64,
+    /// True when a denominator was zero (vacuous metric, see module docs).
+    pub degraded: bool,
+}
+
+fn count_u32(n: usize) -> u32 {
+    u32::try_from(n).unwrap_or(u32::MAX)
+}
+
+/// Computes [`RecallReport`] for one GT entry.
+///
+/// - `recall` = `|must_include ∩ output| / |must_include|`.
+/// - `cap_fit` = `Σ weight(must_include ∩ output ∩ reachable) / Σ weight(must_include ∩ reachable)`,
+///   where `reachable` is the pre-cap closure set. Both sides require membership
+///   in `reachable`, so cap-fit stays in `[0, 1]` even if a caller passes an
+///   `output` not contained in `reachable`; it measures the cap alone, not the
+///   closure's recall.
+/// - `degraded` = true when either denominator is zero.
+pub fn measure(
+    must_include: &[WeightedFile],
+    output: &HashSet<String>,
+    reachable: &HashSet<String>,
+) -> RecallReport {
+    let total = count_u32(must_include.len());
+    let hit = count_u32(
+        must_include
+            .iter()
+            .filter(|f| output.contains(&f.path))
+            .count(),
+    );
+    let reachable_weight: u32 = must_include
+        .iter()
+        .filter(|f| reachable.contains(&f.path))
+        .map(|f| f.weight)
+        .sum();
+    // Numerator is constrained to `reachable` too, so a file in `output` but not
+    // in `reachable` cannot inflate cap-fit past 1.0. In practice `output` is a
+    // post-cap subset of `reachable`, but `measure` is pure and must not trust
+    // its caller to preserve that.
+    let surviving_weight: u32 = must_include
+        .iter()
+        .filter(|f| output.contains(&f.path) && reachable.contains(&f.path))
+        .map(|f| f.weight)
+        .sum();
+
+    // Vacuous denominators report 1.0 and flag degraded, so a gate fails loud
+    // instead of passing on an empty corpus (verify.rs `compute_rates` parity).
+    let recall_degraded = total == 0;
+    let cap_fit_degraded = reachable_weight == 0;
+    let recall = if recall_degraded {
+        1.0
+    } else {
+        f64::from(hit) / f64::from(total)
+    };
+    let cap_fit = if cap_fit_degraded {
+        1.0
+    } else {
+        f64::from(surviving_weight) / f64::from(reachable_weight)
+    };
+
+    RecallReport {
+        recall,
+        cap_fit,
+        degraded: recall_degraded || cap_fit_degraded,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wf(path: &str, weight: u32) -> WeightedFile {
+        WeightedFile {
+            path: path.to_owned(),
+            weight,
+        }
+    }
+
+    fn set(paths: &[&str]) -> HashSet<String> {
+        paths.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    // T-001: measure_recall_is_hit_over_total
+    #[test]
+    fn measure_recall_is_hit_over_total() {
+        let must = [wf("a", 1), wf("b", 1), wf("c", 1), wf("d", 1)];
+        let output = set(&["a", "b", "c"]);
+        let reachable = set(&["a", "b", "c", "d"]);
+        let r = measure(&must, &output, &reachable);
+        assert!(
+            (r.recall - 0.75).abs() < f64::EPSILON,
+            "3 of 4 must-include present → recall 0.75, got {}",
+            r.recall
+        );
+        assert!(!r.degraded, "non-zero denominators must not degrade");
+    }
+
+    // T-003: measure_cap_fit_is_weighted_survival_over_reachable
+    #[test]
+    fn measure_cap_fit_is_weighted_survival_over_reachable() {
+        // Pre-cap reachable must-include weight = 4+3+2+1 = 10; cap keeps a+b = 7.
+        let must = [wf("a", 4), wf("b", 3), wf("c", 2), wf("d", 1)];
+        let output = set(&["a", "b"]);
+        let reachable = set(&["a", "b", "c", "d"]);
+        let r = measure(&must, &output, &reachable);
+        assert!(
+            (r.cap_fit - 0.7).abs() < f64::EPSILON,
+            "surviving weight 7 / reachable weight 10 → cap_fit 0.7, got {}",
+            r.cap_fit
+        );
+        // recall is unweighted and independent: 2 of 4 present = 0.5.
+        assert!(
+            (r.recall - 0.5).abs() < f64::EPSILON,
+            "recall must stay unweighted (0.5), independent of cap_fit, got {}",
+            r.recall
+        );
+    }
+
+    // T-004: measure_zero_reachable_weight_degrades
+    #[test]
+    fn measure_zero_reachable_weight_degrades() {
+        // No must-include file is reachable pre-cap → cap-fit denominator 0.
+        let must = [wf("a", 1)];
+        let output = set(&[]);
+        let reachable = set(&[]);
+        let r = measure(&must, &output, &reachable);
+        assert!(
+            r.degraded,
+            "zero reachable must-include weight must set degraded (vacuous cap-fit)"
+        );
+        assert!(
+            (r.cap_fit - 1.0).abs() < f64::EPSILON,
+            "vacuous cap-fit reports 1.0 (verify.rs parity), got {}",
+            r.cap_fit
+        );
+    }
+
+    // cap-fit invariant: a must-include file present in `output` but absent from
+    // `reachable` must not inflate cap-fit past 1.0 (guards FR-003 against a
+    // caller whose output is not a subset of reachable).
+    #[test]
+    fn measure_cap_fit_stays_within_one_when_output_escapes_reachable() {
+        let must = [wf("a", 1), wf("b", 1)];
+        // `b` is in output but was never reached pre-cap: it must not be credited.
+        let output = set(&["a", "b"]);
+        let reachable = set(&["a"]);
+        let r = measure(&must, &output, &reachable);
+        assert!(
+            (r.cap_fit - 1.0).abs() < f64::EPSILON,
+            "numerator constrained to reachable → cap_fit 1.0 (not 2.0), got {}",
+            r.cap_fit
+        );
+    }
+}


### PR DESCRIPTION
## 概要

#128 Phase 3 (brief recall 完全性 KPI / GT corpus / CI gate) の Phase 1 (AC-1)。brief recall を客観測定する pure な metric コアを追加する。SOW/Spec は split-gate 設計 (critic-design + reviewer-spec を 2 周通過) に基づく。

## 変更

- `src/recall.rs` (new): pure `measure()` が recall (must-include hit 率) と weighted cap-fit を算出。
  - recall = `|must_include ∩ output| / |must_include|`
  - cap-fit = `Σ weight(must_include ∩ output ∩ reachable) / Σ weight(must_include ∩ reachable)`。cap が重要 file を落とした度合いを closure 被覆から分離。
  - 分母 0 で `degraded=true` (`verify.rs` の `compute_rates` degraded-on-vacuous parity)。DB/embedder 非依存。
- `src/brief.rs`: `BriefOutput` に `reachable_files` を追加し `expand_plan` が test-filter 後・cap 前の reachable file 集合を surface (FR-002)。closure/cap アルゴリズムは不変の read-only 追加。cap-fit 分母を「cap が落とした分」でなく「closure が到達した分」にするため。

## テスト

- T-001 (recall 0.75) / T-002 (reachable は test file 除外・cap 非依存) / T-003 (cap-fit 0.7、recall と独立) / T-004 (zero reachable weight → degraded)
- cap-fit 不変条件 guard: `output ⊄ reachable` で `cap_fit` が 1.0 を超えない
- 704 tests pass / clippy `-D warnings` / fmt クリーン。RGRC (stub→Red→Green) で検証。

## レビュー反映

Codex review の P2 (cap-fit numerator が `reachable` 非制約 → `cap_fit > 1.0` になりうる) を適用し、numerator を `output ∩ reachable` に制約。pure fn として caller を信頼しない防御。

## 残作業 (#128 Phase 3 の続き)

Phase 2 (rurico/amici submodule + GT corpus ≥10 + loader + BR-002 canary) / 3 (Gate1 seeded hard-block) / 4 (`yomu recall` CLI) / 5 (Gate2 recall.yml PR comment + cron)。

Refs #128