### PR TITLE
feat(recall): Gate1 seeded recall hard-block を追加 (#128 Phase 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+          # Gate1 (tests/brief_recall.rs) measures recall against the pinned
+          # vendor/ submodules; without them it fails the FR-017 setup check.
+          submodules: recursive
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
@@ -71,6 +74,9 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+          # Coverage runs the full suite incl. Gate1, which needs the vendor/
+          # submodules present (see the test job).
+          submodules: recursive
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -96,6 +96,16 @@ pub fn measure(
     }
 }
 
+/// Returns `true` when the mean seeded recall meets the committed `floor`.
+///
+/// FR-009: the seeded gate (Gate1) fails when `mean` is below `floor`. The floor
+/// is an inclusive minimum, so `mean == floor` passes. Keeping the comparison in
+/// one pure function lets the threshold be unit-tested without a live index, and
+/// the integration gate wires a measured mean to the committed constant.
+pub fn gate_passes(mean: f64, floor: f64) -> bool {
+    mean >= floor
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -164,6 +174,19 @@ mod tests {
             "vacuous cap-fit reports 1.0 (verify.rs parity), got {}",
             r.cap_fit
         );
+    }
+
+    // T-009: gate_passes_is_false_below_floor_true_at_or_above
+    #[test]
+    fn gate_passes_is_false_below_floor_true_at_or_above() {
+        // FR-009: the seeded gate fails when mean recall is below the committed floor.
+        assert!(
+            !gate_passes(0.74, 0.80),
+            "mean below floor must fail the gate"
+        );
+        // The floor is an inclusive minimum: equal or above passes.
+        assert!(gate_passes(0.80, 0.80), "mean equal to floor must pass");
+        assert!(gate_passes(0.95, 0.80), "mean above floor must pass");
     }
 
     // cap-fit invariant: a must-include file present in `output` but absent from

--- a/src/recall/corpus.rs
+++ b/src/recall/corpus.rs
@@ -114,12 +114,26 @@ pub fn canary_violations(
         .collect()
 }
 
+/// The ground-truth corpus bundled with the crate (`tests/fixtures/brief/gt.yaml`).
+const BUNDLED_GT_YAML: &str = include_str!("../../tests/fixtures/brief/gt.yaml");
+
+/// Loads and validates the bundled ground-truth corpus.
+///
+/// Convenience over [`load_from_str`] for the two production call sites — the
+/// Gate1 seeded-recall gate and the `yomu recall` CLI — that measure against the
+/// same bundled corpus.
+///
+/// # Errors
+/// Propagates [`load_from_str`]. The bundled corpus is also covered by a load
+/// test, so an error here signals the fixture was edited into an invalid state.
+pub fn load_bundled() -> Result<GtCorpus, GtLoadError> {
+    load_from_str(BUNDLED_GT_YAML)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::{HashMap, HashSet};
-
-    const BUNDLED_GT_YAML: &str = include_str!("../../tests/fixtures/brief/gt.yaml");
 
     fn wf(path: &str, weight: u32) -> WeightedFile {
         WeightedFile {
@@ -264,8 +278,7 @@ entries:
     // T-005: bundled_gt_corpus_loads_with_ten_weighted_entries
     #[test]
     fn bundled_gt_corpus_loads_with_ten_weighted_entries() {
-        let corpus = load_from_str(BUNDLED_GT_YAML)
-            .expect("bundled gt.yaml loads and passes weight validation");
+        let corpus = load_bundled().expect("bundled gt.yaml loads and passes weight validation");
         assert!(
             corpus.entries.len() >= 10,
             "FR-005: corpus must carry >= 10 domain-diverse entries, got {}",

--- a/tests/brief_recall.rs
+++ b/tests/brief_recall.rs
@@ -1,0 +1,333 @@
+//! Gate1: seeded recall hard-block over the vendored ground-truth corpus
+//! (#128 Phase 3, FR-007/008/009/010/017).
+//!
+//! For each pinned submodule the gate copies `src/` into a tempdir, indexes it
+//! with the spawned `yomu` binary (built with the `test-support` stub embedder,
+//! so no model is needed), runs seeded `brief` for every GT entry, and asserts
+//! the mean seeded recall stays at or above the floor committed in
+//! `fixtures/brief/baseline.json`. The seeded path is graph-only (import/impact
+//! closure, no vector search), so the stub index suffices and the gate is
+//! deterministic — empirically verified bit-identical across processes and
+//! re-indexes (#128, NFR-001).
+//!
+//! Run with `--features test-support` so the spawned binary uses the stub
+//! embedder. The gate carries no `#[ignore]` and runs in the default profile
+//! (FR-008 / T-010).
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use rusqlite::Connection;
+use serde::Deserialize;
+use tempfile::{TempDir, tempdir};
+
+use yomu::brief::{ChunkInclusionReason, Seed, SeedKind, TaskBrief, expand_plan};
+use yomu::recall::corpus::{GtEntry, canary_violations, load_bundled};
+use yomu::recall::{gate_passes, measure};
+use yomu::storage::open_db;
+
+/// Production `brief` defaults (src/main.rs); recall is measured at these so the
+/// floor reflects the values agents actually run with.
+const DEPTH: u32 = 3;
+const MAX_CHUNKS: u32 = 80;
+const MAX_BYTES: u32 = 80_000;
+
+/// The committed Gate1 baseline (`fixtures/brief/baseline.json`).
+#[derive(Debug, Deserialize)]
+struct Baseline {
+    /// Minimum acceptable mean seeded recall (FR-010). The gate fails below it.
+    seeded_floor: f64,
+    /// Embedder identity behind the floor measurement (stub for the seeded gate).
+    model_hash: String,
+}
+
+fn load_baseline() -> Baseline {
+    let text = include_str!("fixtures/brief/baseline.json");
+    serde_json::from_str(text).expect("baseline.json parses")
+}
+
+fn vendor_dir(repo: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("vendor")
+        .join(repo)
+}
+
+/// Recursively copies a directory tree (regular files and subdirectories).
+fn copy_tree(from: &Path, to: &Path) {
+    fs::create_dir_all(to).expect("create dest dir");
+    for entry in fs::read_dir(from).expect("read source dir") {
+        let entry = entry.expect("dir entry");
+        let kind = entry.file_type().expect("file type");
+        let dst = to.join(entry.file_name());
+        if kind.is_dir() {
+            copy_tree(&entry.path(), &dst);
+        } else if kind.is_file() {
+            fs::copy(entry.path(), &dst).expect("copy file");
+        }
+    }
+}
+
+/// Copies `vendor/<repo>/src` into a fresh tempdir, indexes it with the spawned
+/// stub-embedder binary, and opens the resulting db. GT seeds are crate-relative
+/// (`src/...`), so only `src/` is copied; a minimal Cargo.toml gives the indexer
+/// a project root (mirrors the cli_integration setup). The vendored checkout is
+/// never written to (BR-005, hermetic).
+fn index_repo(repo: &str) -> (TempDir, Connection) {
+    let dir = tempdir().expect("tempdir");
+    copy_tree(&vendor_dir(repo).join("src"), &dir.path().join("src"));
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        format!("[package]\nname = \"{repo}_gt\"\nversion = \"0.0.0\"\n"),
+    )
+    .expect("write Cargo.toml");
+    Command::new("git")
+        .args(["init"])
+        .current_dir(dir.path())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .expect("git init");
+    let out = Command::new(env!("CARGO_BIN_EXE_yomu"))
+        .arg("index")
+        .current_dir(dir.path())
+        .output()
+        .expect("spawn yomu index");
+    assert!(
+        out.status.success(),
+        "index {repo} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let conn = open_db(&dir.path().join(".yomu/index.db")).expect("open indexed db");
+    (dir, conn)
+}
+
+fn task_for(
+    entry: &GtEntry,
+    depth: u32,
+    max_chunks: u32,
+    max_bytes: u32,
+    include_tests: bool,
+) -> TaskBrief {
+    TaskBrief {
+        task: entry.task.clone(),
+        seeds: entry
+            .seed
+            .iter()
+            .map(|p| Seed {
+                kind: SeedKind::File,
+                value: p.clone(),
+            })
+            .collect(),
+        depth,
+        max_chunks,
+        max_bytes,
+        include_tests,
+    }
+}
+
+/// Seeded recall for one entry at the production brief defaults.
+fn entry_recall(conn: &Connection, entry: &GtEntry) -> f64 {
+    let task = task_for(entry, DEPTH, MAX_CHUNKS, MAX_BYTES, false);
+    let out = expand_plan(conn, &task).expect("expand_plan");
+    let output: HashSet<String> = out.chunks.iter().map(|c| c.file_path.clone()).collect();
+    let reachable: HashSet<String> = out.reachable_files.iter().cloned().collect();
+    measure(&entry.must_include, &output, &reachable).recall
+}
+
+/// The seed's 1-hop forward closure: files reasoned Seed or Forward by a depth-1
+/// brief with the cap maxed out, so a truncating cap cannot hide a forward
+/// member (toothless canary). Mirrors `collect_closure(seed, 1).forward_paths`,
+/// the BR-002 canary's reachability source.
+fn forward_1hop(conn: &Connection, entry: &GtEntry) -> HashSet<String> {
+    let task = task_for(entry, 1, u32::MAX, u32::MAX, true);
+    let out = expand_plan(conn, &task).expect("expand_plan depth=1");
+    out.chunks
+        .iter()
+        .filter(|c| {
+            matches!(
+                c.included_reason,
+                ChunkInclusionReason::Seed | ChunkInclusionReason::Forward(_)
+            )
+        })
+        .map(|c| c.file_path.clone())
+        .collect()
+}
+
+/// Setup failure when a vendored submodule is missing or off its pinned rev.
+#[derive(Debug)]
+struct SetupError {
+    repo: String,
+    expected_rev: String,
+    detail: String,
+}
+
+impl fmt::Display for SetupError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "submodule {} setup error (expected rev {}): {}",
+            self.repo, self.expected_rev, self.detail
+        )
+    }
+}
+
+/// FR-017: fail when a submodule is absent or its HEAD differs from the pinned
+/// rev. Pure over the observed HEAD so both paths are deterministically testable
+/// (T-011).
+fn check_rev(repo: &str, expected_rev: &str, actual_head: Option<&str>) -> Result<(), SetupError> {
+    match actual_head {
+        None => Err(SetupError {
+            repo: repo.to_owned(),
+            expected_rev: expected_rev.to_owned(),
+            detail: "submodule absent or HEAD unreadable".to_owned(),
+        }),
+        Some(head) if head == expected_rev => Ok(()),
+        Some(head) => Err(SetupError {
+            repo: repo.to_owned(),
+            expected_rev: expected_rev.to_owned(),
+            detail: format!("HEAD is {head}"),
+        }),
+    }
+}
+
+/// Reads `vendor/<repo>` HEAD, or None when the submodule is absent/unreadable.
+fn read_head(repo: &str) -> Option<String> {
+    let out = Command::new("git")
+        .args([
+            "-C",
+            vendor_dir(repo).to_str().expect("utf8 path"),
+            "rev-parse",
+            "HEAD",
+        ])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_owned())
+}
+
+/// Groups corpus entries by repo (sorted), asserting one pinned rev per repo.
+fn entries_by_repo(entries: Vec<GtEntry>) -> BTreeMap<String, (String, Vec<GtEntry>)> {
+    let mut by_repo: BTreeMap<String, (String, Vec<GtEntry>)> = BTreeMap::new();
+    for entry in entries {
+        let slot = by_repo
+            .entry(entry.repo.clone())
+            .or_insert_with(|| (entry.rev.clone(), Vec::new()));
+        assert_eq!(
+            slot.0, entry.rev,
+            "all GT entries for repo {} must share one pinned rev",
+            entry.repo
+        );
+        slot.1.push(entry);
+    }
+    by_repo
+}
+
+// T-008 / T-006b / T-017 / NFR-001 + FR-009 wiring. The seeded recall over the
+// vendored corpus must meet the committed floor, the corpus must pass the BR-002
+// canary through the real index, recall must be deterministic, and baseline.json
+// must record a floor consistent with this run. One test shares the index across
+// these checks because indexing dominates the cost (NFR-002); nextest runs each
+// test in its own process, so a shared fixture is not available.
+#[test]
+fn gate1_seeded_recall_meets_floor() {
+    let baseline = load_baseline();
+    let by_repo = entries_by_repo(load_bundled().expect("bundled corpus").entries);
+
+    let mut recalls: Vec<f64> = Vec::new();
+    let mut forward: HashMap<String, HashSet<String>> = HashMap::new();
+    let mut all_entries: Vec<GtEntry> = Vec::new();
+
+    for (repo, (expected_rev, entries)) in &by_repo {
+        check_rev(repo, expected_rev, read_head(repo).as_deref()).unwrap_or_else(|e| panic!("{e}")); // FR-017
+        let (_dir, conn) = index_repo(repo);
+        for entry in entries {
+            let recall = entry_recall(&conn, entry);
+            // NFR-001: same input, same recall (re-measure on the same index).
+            assert_eq!(
+                recall,
+                entry_recall(&conn, entry),
+                "recall for {} must be deterministic",
+                entry.id
+            );
+            assert!(
+                (0.0..=1.0).contains(&recall),
+                "recall for {} must be in [0,1], got {recall}",
+                entry.id
+            );
+            eprintln!("RECALL {} = {recall:.4}", entry.id);
+            recalls.push(recall);
+            forward.insert(entry.id.clone(), forward_1hop(&conn, entry));
+            all_entries.push(entry.clone());
+        }
+    }
+
+    // T-006b: every GT entry has a must-include outside its 1-hop forward closure,
+    // verified through the real index, so recall is not vacuously high.
+    let violations = canary_violations(&all_entries, &forward);
+    assert!(
+        violations.is_empty(),
+        "BR-002 canary flagged tautological entries: {violations:?}"
+    );
+
+    // T-008: mean seeded recall is computed over the full corpus.
+    assert!(!recalls.is_empty(), "corpus produced no measurements");
+    let mean = recalls.iter().sum::<f64>() / recalls.len() as f64;
+    eprintln!(
+        "MEAN_SEEDED_RECALL = {mean:.6} over {} entries (floor {:.6})",
+        recalls.len(),
+        baseline.seeded_floor
+    );
+
+    // T-017: the committed floor is a valid recall and not above this run's mean
+    // (it was measured from a run like this one). model_hash is recorded.
+    assert!(
+        (0.0..=1.0).contains(&baseline.seeded_floor),
+        "seeded_floor must be in [0,1], got {}",
+        baseline.seeded_floor
+    );
+    assert!(
+        !baseline.model_hash.is_empty(),
+        "baseline must record the embedder identity"
+    );
+
+    // FR-009: the gate fails when mean seeded recall drops below the floor.
+    assert!(
+        gate_passes(mean, baseline.seeded_floor),
+        "mean seeded recall {mean:.6} is below the committed floor {:.6}",
+        baseline.seeded_floor
+    );
+}
+
+// T-011: FR-017 setup check rejects a wrong rev and an absent submodule, and
+// accepts a matching HEAD. Pure, no submodule required.
+#[test]
+fn check_rev_rejects_mismatch_and_absence() {
+    let rurico_rev = "1d6650a86ffd5c377fd4b50e171edfc89e39c3f0";
+    let err = check_rev(
+        "rurico",
+        rurico_rev,
+        Some("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+    )
+    .expect_err("a mismatched HEAD must fail");
+    assert_eq!(err.repo, "rurico");
+    assert_eq!(err.expected_rev, rurico_rev);
+    let msg = err.to_string();
+    assert!(
+        msg.contains("rurico") && msg.contains(rurico_rev),
+        "error message names repo and expected rev, got: {msg}"
+    );
+
+    assert!(
+        check_rev("amici", "ae8c0682c4c5f663644f4cd9f9cbcf6b392904da", None).is_err(),
+        "an absent submodule must fail"
+    );
+    assert!(
+        check_rev("rurico", rurico_rev, Some(rurico_rev)).is_ok(),
+        "a HEAD matching the pinned rev must pass"
+    );
+}

--- a/tests/fixtures/brief/baseline.json
+++ b/tests/fixtures/brief/baseline.json
@@ -1,0 +1,7 @@
+{
+  "seeded_floor": 0.90,
+  "measured_mean": 0.95,
+  "model_hash": "stub-test-support",
+  "gate1_index_seconds": 3,
+  "_note": "Gate1 committed threshold (#128 Phase 3). measured_mean is the mean seeded recall observed by tests/brief_recall.rs over vendor/rurico@1d6650a and vendor/amici@ae8c068 with the stub embedder (deterministic: the seeded brief path is graph-only, verified bit-identical across processes and re-indexes). seeded_floor is set below measured_mean with headroom so a single entry shifting one recall notch (mean 0.925) does not fail the gate, while a closure-mechanism collapse (the #235 failure mode) does. Ratchet seeded_floor up as recall improves. model_hash records the embedder identity (stub) rather than a semantic model hash; the real-model hash belongs to the Gate2 seed-less baseline (Phase 5). Two entries currently measure 0.75 because src/bin/eval_harness.rs imports the lib via the package-name path (use amici::...), which the resolver does not resolve to an internal edge, so the binary is absent from the closure (brief limitation, tracked in #242)."
+}


### PR DESCRIPTION
## 概要

`yomu brief` の recall regression を CI で hard-block する Gate1 (#128 Phase 3 / AC-3)。pinned submodule (rurico@1d6650a / amici@ae8c068) を tempdir に copy し stub embedder で index、GT 10 件を seeded brief (depth=3, default cap) で測定、mean seeded recall を baseline.json の seeded_floor と比較する。実測 mean = 0.95 (8x1.0 + 2x0.75)、seeded_floor = 0.90。

## 変更

- `recall::gate_passes` (FR-009, pure 閾値比較) + T-009
- `recall::corpus::load_bundled` (BUNDLED_GT_YAML を module スコープ昇格)
- `tests/brief_recall.rs` (Gate1: index helper + measure + canary T-006b + check_rev FR-017)
- `tests/fixtures/brief/baseline.json` (seeded_floor=0.90)
- `.github/workflows/ci.yml` (test / coverage job に submodules: recursive)

## 決定性 (NFR-001)

同一 index・4 プロセス、かつ 2 つの独立 fresh `yomu index` build の seeded brief 出力が bit-identical。select_drops の total-order path sort と graph-only な seeded path による。hard-gate が flaky にならないことを経験的に確認。

## floor = 0.90 の根拠

実測 0.95 から headroom 0.05。#235 型の closure collapse は捕捉しつつ、単一 entry の recall notch 低下は許容する regression floor。改善時は ratchet up。

## 既知の限界 (別 issue)

`src/bin/*.rs` が lib を `use <pkg>::...` で import すると resolver が内部 edge 化せず closure から欠落する (amici の 2 entry が recall 0.75 の原因)。#242 で追跡。

Refs #128