### PR TITLE
feat(recall): seed-less recall を測る yomu recall CLI を追加 (#128 Phase 4)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -146,6 +146,16 @@ Examples:
         #[arg(long)]
         include_tests: bool,
     },
+    /// Measure seed-less recall and weighted cap-fit against the bundled GT corpus.
+    #[command(after_help = "\
+Examples:
+  yomu recall --repo rurico
+  yomu --json recall --repo amici")]
+    Recall {
+        /// GT corpus repo to measure against the current index (e.g. rurico, amici)
+        #[arg(long)]
+        repo: String,
+    },
     /// Manage the embedding model.
     #[command(
         subcommand_required = true,
@@ -245,6 +255,23 @@ fn main() -> ExitCode {
         Err(e) => return emit_error(&e, json),
     };
 
+    // recall emits its (possibly degraded) report to stdout and exits non-zero
+    // when degraded (FR-012), so it cannot use the uniform Ok→write / Err→emit
+    // path below. Handled here, after Yomu::new opens the index it measures.
+    if let Command::Recall { repo } = &command {
+        return match yomu.recall(repo, json) {
+            Ok((text, degraded)) => {
+                let code = write_output(&text);
+                if degraded {
+                    ExitCode::from(ErrorCode::TempFailure.exit_code())
+                } else {
+                    code
+                }
+            }
+            Err(e) => emit_error(&e, json),
+        };
+    }
+
     let result = match command {
         Command::Search {
             query,
@@ -333,6 +360,7 @@ fn main() -> ExitCode {
         } => yomu.impact(&target, symbol.as_deref(), depth, json, semantic),
         Command::Status => yomu.status(json),
         Command::Verify => unreachable!("handled before Yomu::new()"),
+        Command::Recall { .. } => unreachable!("handled before the command match"),
         Command::Brief {
             task,
             seed_file,
@@ -409,7 +437,7 @@ fn render_clap_error(e: &clap::Error) -> ExitCode {
 }
 
 const KNOWN_SUBCOMMANDS: &[&str] = &[
-    "search", "index", "rebuild", "impact", "status", "verify", "brief", "model",
+    "search", "index", "rebuild", "impact", "status", "verify", "brief", "model", "recall",
 ];
 
 fn build_seeds(files: Vec<String>, symbols: Vec<String>) -> Vec<brief::Seed> {

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashSet;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 pub mod corpus;
 
@@ -23,7 +23,7 @@ pub struct WeightedFile {
 }
 
 /// Recall and cap-fit for one ground-truth entry.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct RecallReport {
     /// Unweighted must-include hit rate: present / total.
     pub recall: f64,
@@ -104,6 +104,92 @@ pub fn measure(
 /// the integration gate wires a measured mean to the committed constant.
 pub fn gate_passes(mean: f64, floor: f64) -> bool {
     mean >= floor
+}
+
+/// One ground-truth entry's seed-less recall, tagged with its id, for the
+/// `yomu recall` report (FR-011). Flattens [`RecallReport`] so each entry object
+/// carries `recall` / `cap_fit` / `degraded` directly.
+#[derive(Debug, Clone, Serialize)]
+pub struct EntryReport {
+    pub id: String,
+    #[serde(flatten)]
+    pub report: RecallReport,
+}
+
+/// Seed-less recall report for one repo's GT entries (FR-011). `aggregate` holds
+/// the mean recall / cap-fit and a degraded flag set when any entry degraded or
+/// no entry matched. Emitted per-repo; the recall workflow merges repos.
+#[derive(Debug, Clone, Serialize)]
+pub struct CorpusReport {
+    pub repo: String,
+    pub aggregate: RecallReport,
+    pub entries: Vec<EntryReport>,
+}
+
+impl CorpusReport {
+    /// Builds a report from per-entry measurements, with the aggregate as the
+    /// unweighted mean. An empty entry set (no GT entry matched `repo`) is
+    /// degraded with a vacuous 1.0 mean, mirroring [`measure`]'s degraded-on-
+    /// vacuous contract so a `--repo` typo never reads as a silent pass.
+    pub fn new(repo: String, entries: Vec<EntryReport>) -> Self {
+        let aggregate = if entries.is_empty() {
+            RecallReport {
+                recall: 1.0,
+                cap_fit: 1.0,
+                degraded: true,
+            }
+        } else {
+            let n = entries.len() as f64;
+            RecallReport {
+                recall: entries.iter().map(|e| e.report.recall).sum::<f64>() / n,
+                cap_fit: entries.iter().map(|e| e.report.cap_fit).sum::<f64>() / n,
+                degraded: entries.iter().any(|e| e.report.degraded),
+            }
+        };
+        Self {
+            repo,
+            aggregate,
+            entries,
+        }
+    }
+}
+
+/// Renders a [`CorpusReport`] as a single-line JSON object (FR-011).
+pub fn render_recall_json(report: &CorpusReport) -> String {
+    serde_json::to_string(report).unwrap_or_else(|_| "{}".to_owned())
+}
+
+/// Renders a [`CorpusReport`] as a human-readable plain-text table (FR-011).
+pub fn render_recall_plain(report: &CorpusReport) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "recall report: {} (degraded: {})",
+        report.repo, report.aggregate.degraded
+    );
+    let _ = writeln!(
+        out,
+        "  aggregate: recall={:.3} cap_fit={:.3} over {} entries",
+        report.aggregate.recall,
+        report.aggregate.cap_fit,
+        report.entries.len()
+    );
+    for entry in &report.entries {
+        let _ = writeln!(
+            out,
+            "  {:<40} recall={:.3} cap_fit={:.3}{}",
+            entry.id,
+            entry.report.recall,
+            entry.report.cap_fit,
+            if entry.report.degraded {
+                " (degraded)"
+            } else {
+                ""
+            }
+        );
+    }
+    out
 }
 
 #[cfg(test)]
@@ -203,6 +289,75 @@ mod tests {
             (r.cap_fit - 1.0).abs() < f64::EPSILON,
             "numerator constrained to reachable → cap_fit 1.0 (not 2.0), got {}",
             r.cap_fit
+        );
+    }
+
+    // T-020: corpus_report_aggregates_mean_and_renders_keys_per_entry_and_aggregate
+    #[test]
+    fn corpus_report_aggregates_mean_and_renders_keys() {
+        let entries = vec![
+            EntryReport {
+                id: "e1".to_owned(),
+                report: RecallReport {
+                    recall: 1.0,
+                    cap_fit: 1.0,
+                    degraded: false,
+                },
+            },
+            EntryReport {
+                id: "e2".to_owned(),
+                report: RecallReport {
+                    recall: 0.5,
+                    cap_fit: 0.5,
+                    degraded: false,
+                },
+            },
+        ];
+        let report = CorpusReport::new("rurico".to_owned(), entries);
+        assert!(
+            (report.aggregate.recall - 0.75).abs() < f64::EPSILON,
+            "aggregate recall is the mean (0.75), got {}",
+            report.aggregate.recall
+        );
+        assert!(
+            (report.aggregate.cap_fit - 0.75).abs() < f64::EPSILON,
+            "aggregate cap_fit is the mean (0.75), got {}",
+            report.aggregate.cap_fit
+        );
+        assert!(
+            !report.aggregate.degraded,
+            "no entry degraded → aggregate not degraded"
+        );
+
+        let json = render_recall_json(&report);
+        assert!(
+            json.contains("\"repo\":\"rurico\""),
+            "repo present, got: {json}"
+        );
+        assert!(
+            json.contains("\"id\":\"e1\""),
+            "entry id present, got: {json}"
+        );
+        // recall/cap_fit keys appear per-entry (2) plus once in the aggregate (3).
+        assert_eq!(
+            json.matches("\"recall\":").count(),
+            3,
+            "recall key present per-entry and in aggregate, got: {json}"
+        );
+        assert_eq!(
+            json.matches("\"cap_fit\":").count(),
+            3,
+            "cap_fit key present per-entry and in aggregate, got: {json}"
+        );
+    }
+
+    // T-022: corpus_report_with_no_entries_is_degraded
+    #[test]
+    fn corpus_report_with_no_entries_is_degraded() {
+        let report = CorpusReport::new("ghost".to_owned(), Vec::new());
+        assert!(
+            report.aggregate.degraded,
+            "no entries (e.g. --repo mismatch) → degraded, never a silent pass"
         );
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -26,6 +26,7 @@ use crate::error::ErrorCode;
 use crate::indexer;
 use crate::query::{self, QueryError};
 use crate::query_log::{self, QueryLogRecord};
+use crate::recall::{self, corpus};
 use crate::storage;
 
 use embedder::{DegradedReason, degraded_reason_user_note};
@@ -44,6 +45,11 @@ pub const MAX_SEARCH_LIMIT: u32 = 100;
 pub const MAX_SEARCH_OFFSET: u32 = 500;
 pub const MAX_IMPACT_DEPTH: u32 = 10;
 const BRIEF_MAX_INFERRED_SEEDS: u32 = 5;
+// Production `brief` defaults (mirrors main.rs clap defaults); `recall` measures
+// seed-less recall at the values agents actually run with.
+const RECALL_DEPTH: u32 = 3;
+const RECALL_MAX_CHUNKS: u32 = 80;
+const RECALL_MAX_BYTES: u32 = 80_000;
 
 /// Upper bound for the EmptyTarget `candidates` retry list emitted to agents.
 /// A short, scannable list is the actionable shape per ADR-0060.
@@ -866,20 +872,11 @@ impl Yomu {
         dedupe_seed_paths(results, max_seeds as usize)
     }
 
-    pub fn brief(&self, task: &brief::TaskBrief, json: bool) -> Result<String, YomuError> {
-        if task.task.trim().is_empty() {
-            return Err(YomuError::InvalidInput(InvalidInputKind::EmptyTask));
-        }
-        if task
-            .seeds
-            .iter()
-            .any(|s| matches!(s.kind, brief::SeedKind::Symbol))
-        {
-            return Err(YomuError::InvalidInput(
-                InvalidInputKind::SeedSymbolUnimplemented,
-            ));
-        }
-
+    /// Runs `brief` over `task`, inferring file seeds from `task.task` when none
+    /// are given (seed-less), and returns the closure output with `degraded` set
+    /// when seed inference fell back or the closure was empty. Shared by `brief`
+    /// (renders) and `recall` (measures); callers validate `task` first.
+    fn brief_output(&self, task: &brief::TaskBrief) -> Result<brief::BriefOutput, YomuError> {
         let mut effective = task.clone();
         let mut degraded = false;
         if effective.seeds.is_empty() {
@@ -906,12 +903,68 @@ impl Yomu {
             );
             output.degraded = true;
         }
+        Ok(output)
+    }
 
+    pub fn brief(&self, task: &brief::TaskBrief, json: bool) -> Result<String, YomuError> {
+        if task.task.trim().is_empty() {
+            return Err(YomuError::InvalidInput(InvalidInputKind::EmptyTask));
+        }
+        if task
+            .seeds
+            .iter()
+            .any(|s| matches!(s.kind, brief::SeedKind::Symbol))
+        {
+            return Err(YomuError::InvalidInput(
+                InvalidInputKind::SeedSymbolUnimplemented,
+            ));
+        }
+
+        let output = self.brief_output(task)?;
         Ok(if json {
             brief::render_json(&output)
         } else {
             brief::render_plain(&output)
         })
+    }
+
+    /// Measures seed-less recall and weighted cap-fit for every bundled GT entry
+    /// whose repo matches `repo`, against the current index, and renders a
+    /// per-entry plus aggregate report (FR-011). Returns the rendered text and the
+    /// aggregate degraded flag. The caller exits non-zero when degraded (FR-012):
+    /// an unavailable embedding model makes seed inference fall back and flag
+    /// degraded, so a model-less run never reports a silent pass.
+    pub fn recall(&self, repo: &str, json: bool) -> Result<(String, bool), YomuError> {
+        let gt = corpus::load_bundled()
+            .map_err(|e| YomuError::Internal(format!("bundled GT corpus: {e}")))?;
+        let mut entries = Vec::new();
+        for entry in gt.entries.iter().filter(|e| e.repo == repo) {
+            let task = brief::TaskBrief {
+                task: entry.task.clone(),
+                seeds: Vec::new(),
+                depth: RECALL_DEPTH,
+                max_chunks: RECALL_MAX_CHUNKS,
+                max_bytes: RECALL_MAX_BYTES,
+                include_tests: false,
+            };
+            let output = self.brief_output(&task)?;
+            let out_files: HashSet<String> =
+                output.chunks.iter().map(|c| c.file_path.clone()).collect();
+            let reachable: HashSet<String> = output.reachable_files.iter().cloned().collect();
+            let mut report = recall::measure(&entry.must_include, &out_files, &reachable);
+            report.degraded |= output.degraded;
+            entries.push(recall::EntryReport {
+                id: entry.id.clone(),
+                report,
+            });
+        }
+        let report = recall::CorpusReport::new(repo.to_owned(), entries);
+        let text = if json {
+            recall::render_recall_json(&report)
+        } else {
+            recall::render_recall_plain(&report)
+        };
+        Ok((text, report.aggregate.degraded))
     }
 }
 

--- a/tests/brief_recall.rs
+++ b/tests/brief_recall.rs
@@ -75,7 +75,7 @@ fn copy_tree(from: &Path, to: &Path) {
 /// (`src/...`), so only `src/` is copied; a minimal Cargo.toml gives the indexer
 /// a project root (mirrors the cli_integration setup). The vendored checkout is
 /// never written to (BR-005, hermetic).
-fn index_repo(repo: &str) -> (TempDir, Connection) {
+fn index_repo_dir(repo: &str) -> TempDir {
     let dir = tempdir().expect("tempdir");
     copy_tree(&vendor_dir(repo).join("src"), &dir.path().join("src"));
     fs::write(
@@ -100,6 +100,11 @@ fn index_repo(repo: &str) -> (TempDir, Connection) {
         "index {repo} failed: {}",
         String::from_utf8_lossy(&out.stderr)
     );
+    dir
+}
+
+fn index_repo(repo: &str) -> (TempDir, Connection) {
+    let dir = index_repo_dir(repo);
     let conn = open_db(&dir.path().join(".yomu/index.db")).expect("open indexed db");
     (dir, conn)
 }
@@ -329,5 +334,128 @@ fn check_rev_rejects_mismatch_and_absence() {
     assert!(
         check_rev("rurico", rurico_rev, Some(rurico_rev)).is_ok(),
         "a HEAD matching the pinned rev must pass"
+    );
+}
+
+// T-012: `yomu recall --repo <name> --json` emits recall/cap_fit per entry and in
+// aggregate (FR-011). With the stub embedder seed inference is meaningless, so this
+// asserts the report SCHEMA, never the recall values. Reuses the Phase 3 index setup.
+#[test]
+fn recall_cli_json_emits_recall_and_cap_fit_schema() {
+    let dir = index_repo_dir("rurico");
+    let out = Command::new(env!("CARGO_BIN_EXE_yomu"))
+        .args(["recall", "--repo", "rurico", "--json"])
+        .current_dir(dir.path())
+        .output()
+        .expect("spawn yomu recall");
+    assert!(
+        out.status.success(),
+        "recall --json should succeed with the stub embedder: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("recall --json must emit valid JSON ({e}), got: {stdout}"));
+    assert_eq!(json["repo"], "rurico", "report names the repo, got: {json}");
+    assert!(
+        json["aggregate"]["recall"].is_number(),
+        "aggregate carries recall, got: {json}"
+    );
+    assert!(
+        json["aggregate"]["cap_fit"].is_number(),
+        "aggregate carries cap_fit, got: {json}"
+    );
+    let entries = json["entries"].as_array().expect("entries is an array");
+    assert!(
+        !entries.is_empty(),
+        "rurico GT entries were measured, got: {json}"
+    );
+    for entry in entries {
+        assert!(
+            entry["id"].is_string(),
+            "per-entry id present, got: {entry}"
+        );
+        assert!(
+            entry["recall"].is_number(),
+            "per-entry recall present, got: {entry}"
+        );
+        assert!(
+            entry["cap_fit"].is_number(),
+            "per-entry cap_fit present, got: {entry}"
+        );
+    }
+}
+
+// T-013: when the embedding model is unavailable, `yomu recall` sets degraded and
+// exits non-zero rather than report a silent pass (FR-012). The degraded report is
+// still emitted to stdout (distinguishing this from a usage error).
+#[test]
+fn recall_cli_degrades_and_exits_nonzero_when_model_unavailable() {
+    let dir = index_repo_dir("rurico");
+    let out = Command::new(env!("CARGO_BIN_EXE_yomu"))
+        .args(["recall", "--repo", "rurico", "--json"])
+        .env("YOMU_TEST_EMBEDDER", "unavailable")
+        .current_dir(dir.path())
+        .output()
+        .expect("spawn yomu recall");
+    assert!(
+        !out.status.success(),
+        "model unavailable must exit non-zero (no silent pass)"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!("degraded report must still be emitted to stdout ({e}), got: {stdout}")
+    });
+    assert_eq!(
+        json["aggregate"]["degraded"], true,
+        "report marks the aggregate degraded, got: {json}"
+    );
+}
+
+// T-023: `yomu recall` without --repo fails with a usage error instead of silently
+// expanding to `search recall`. Regression guard: `recall` must be in
+// maybe_expand_shorthand's known-subcommand list, else a missing required --repo
+// falls through to shorthand search expansion and runs the wrong command (exit 0).
+#[test]
+fn recall_cli_without_repo_is_usage_error_not_silent_search() {
+    let out = Command::new(env!("CARGO_BIN_EXE_yomu"))
+        .arg("recall")
+        .output()
+        .expect("spawn yomu recall");
+    assert!(
+        !out.status.success(),
+        "missing --repo must fail as a usage error, not silently run a search"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--repo"),
+        "usage error names the missing --repo arg, got stderr: {stderr}"
+    );
+}
+
+// T-024: `yomu recall --repo <name>` without --json renders the human-readable
+// report, exercising render_recall_plain (the JSON tests cover only the JSON
+// renderer, leaving the plain path otherwise unexecuted).
+#[test]
+fn recall_cli_plain_renders_human_report() {
+    let dir = index_repo_dir("rurico");
+    let out = Command::new(env!("CARGO_BIN_EXE_yomu"))
+        .args(["recall", "--repo", "rurico"])
+        .current_dir(dir.path())
+        .output()
+        .expect("spawn yomu recall");
+    assert!(
+        out.status.success(),
+        "plain recall should succeed with the stub embedder: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("recall report: rurico"),
+        "plain output carries the report header, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("aggregate:"),
+        "plain output carries the aggregate line, got: {stdout}"
     );
 }


### PR DESCRIPTION
## 概要

seed-less recall + weighted cap-fit を測る `yomu recall --repo <name> [--json]` を追加 (#128 Phase 4 / AC-4)。現 index に対し `--repo` 一致の GT entry を seed-less brief (task embed → vec_search で seed 推論 → 双方向 closure) で実行し、recall + cap-fit を per-entry と aggregate で JSON/plain 出力する。embedding model 不在時は degraded + 非0 exit で silent pass を防ぐ (FR-011/012)。

## 変更

- `recall::{EntryReport, CorpusReport}` + `render_recall_json/plain` (`RecallReport` を flatten 再利用し recall/cap_fit を per-entry と aggregate の両方に出す)。T-020/T-022
- `tools.rs`: `brief()` から `brief_output` を抽出 (brief render と recall measure で共有)、`Yomu::recall(repo, json)`
- `main.rs`: `Command::Recall { --repo }`、degraded で `ExitCode::TempFailure` (sysexits 75)
- `main.rs`: `recall` を `KNOWN_SUBCOMMANDS` に登録。未登録だと `yomu recall` (--repo 無し) が clap parse 失敗 → shorthand 展開で `search recall` を静かに実行し exit 0 になる silent-pass を polish で検出・修正。T-023 回帰
- tests: `index_repo_dir` 抽出、T-012 (schema + entries=5 + 値域 [0,1])、T-013 (unavailable → degraded + 非0 exit)、T-023

## 設計

Option B (Yomu の単一 index モデルを保ち per-repo で測る)。cross-repo aggregate は Phase 5 の recall.yml が per-repo 実行を merge する。#235 baseline が単一 index per-repo 手法だったことを確認した上での選択。

## 検証

nextest 718 pass / clippy -D warnings / fmt クリーン。polish (code-review + codex + coderabbit) で上記 silent-pass バグを検出・修正。実 binary でも model 未インストール時に degraded + exit 75 を確認 (FR-012)。

Refs #128