### PR TITLE
test(tools): #257 で残した residual 分岐を追加カバー (fts-empty/reranker/dry-run)

### DIFF
--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -3458,3 +3458,61 @@ fn brief_falls_back_to_fts_when_embedder_unavailable() {
         "embedder failure should degrade to FTS-only seed selection: {json}"
     );
 }
+
+// FTS fallback with a keyword-less task returns no seeds and still degrades
+// (briefing.rs: fts_fallback_seed_paths early return on empty keywords).
+#[test]
+fn brief_fts_fallback_with_no_keywords_still_degrades() {
+    let (y, _dir) = test_yomu_with_files_and_embedder(
+        &[("src/auth.tsx", "export function useAuth() {}")],
+        Arc::new(FailingEmbedder::all_fail("model unavailable")),
+    );
+    indexer::run_chunk_only_index(&y.conn, y.root.as_path(), false).unwrap();
+    let task = brief::TaskBrief {
+        // single-char token yields no extractable keywords (extract_keywords
+        // drops tokens shorter than 2 chars), so the FTS fallback returns early.
+        task: "x".to_owned(),
+        seeds: vec![],
+        depth: 2,
+        max_chunks: 40,
+        max_bytes: 40_000,
+        include_tests: false,
+    };
+    let json = y.brief(&task, true).unwrap();
+    let parsed = parse_json(&json);
+    assert_eq!(
+        parsed["degraded"], true,
+        "keyword-less FTS fallback should still degrade: {json}"
+    );
+}
+
+// rerank enabled with an uncached model surfaces the install note
+// (search.rs: reranker_note Some -> notes.push).
+#[test]
+fn search_notes_reranker_model_absent_when_enabled() {
+    let (mut y, _dir) = test_yomu_with_files_and_embedder(
+        &[("src/A.tsx", "export function A() {}")],
+        Arc::new(MockEmbedder::default()),
+    );
+    indexer::run_chunk_only_index(&y.conn, y.root.as_path(), false).unwrap();
+    y.rerank_enabled = true;
+    let _ = y.reranker.set(ModelLoad::Absent);
+    let text = y.search(Some("function"), 10, 0, &[], false, None).unwrap();
+    assert!(
+        text.contains("reranking requested"),
+        "rerank-enabled with an absent model should surface a note: {text}"
+    );
+}
+
+// An unreadable (invalid UTF-8) file is counted as a dry-run error
+// (indexing.rs: files_errored > 0 -> ", N errors").
+#[test]
+fn dry_run_index_counts_unreadable_files_as_errors() {
+    let (y, dir) = test_yomu_with_files(&[("src/good.tsx", "export function A() {}")]);
+    fs::write(dir.path().join("src/bad.tsx"), [0xFF, 0xFE, 0x00, 0x80]).unwrap();
+    let text = y.dry_run_index(IndexRunOptions::default(), false).unwrap();
+    assert!(
+        text.contains("error"),
+        "an unreadable file should be counted as a dry-run error: {text}"
+    );
+}


### PR DESCRIPTION
## 概要

#257 (RC-009 分割 1/3) の diff-cover 対応で据え置いた residual のうち、error/DB 注入や env 操作が不要な 3 分岐をテストでカバーする。gate を通すためではなく絶対カバレッジの自主的改善。

## 変更

| 行 | 分岐 | 手法 |
| --- | --- | --- |
| `briefing.rs:57` | keyword-less タスクの FTS フォールバック early return | `task="x"` + `FailingEmbedder` |
| `search.rs:79` | rerank 有効 + モデル未キャッシュ時の install note | `rerank_enabled=true` + `reranker=ModelLoad::Absent` |
| `indexing.rs:53` | 読込不能ファイルの dry-run エラー計上 | 不正 UTF-8 → `CheckResult::Error` |

lcov `DA:N,1` で実カバー確認済み。

## 据え置いた residual（設計上テスト困難）

| 行 | 理由 |
| --- | --- |
| `indexing.rs:34,80` (coverage_note) | 部分失敗する embedder double が存在しない |
| `briefing.rs:48` / `search.rs:68` | vec_search / query::search の error 注入が必要 |
| `search.rs:70-71` (log_query) | `unsafe_code = "forbid"` で `set_var` が書けない |
| `briefing.rs:186` (dedupe cap) | `MockEmbedder` が固定ベクトル (`one_hot(0)`) で cap 超を再現できない |

## 注意

`#257` はマージ済みで src 未変更のため、diff-cover はテストファイルのみ（src は "No lines"）を見て PASS する。これは正常で、実カバレッジ向上は `DA` で確認済み。

## 検証

- nextest: 717 passed, 4 skipped
- clippy `--all-features -D warnings`: pass
- fmt --check: pass