### PR TITLE
ci(yomu): ファイルサイズ/関数サイズ再肥大ゲートを追加 (#255)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,45 @@ jobs:
           # vendor/ submodules; without them it fails the FR-017 setup check.
           submodules: recursive
 
+      # File-size ratchet gate (#255): block re-bloat of the yomu crate's src/
+      # past the THRESHOLDS file ceiling (sibling crates/ are out of scope).
+      # Runs before the build for fast feedback and lives in this required job
+      # so it blocks merge. Pre-existing oversized files are grandfathered in
+      # `allowlist`; once a file is split below the ceiling the gate forces its
+      # removal from the list, so the ratchet cannot silently rot — analogous
+      # to the self-expiring `#[expect(clippy::too_many_lines)]` in src/main.rs.
+      - name: File size gate
+        run: |
+          threshold=400
+          allowlist="src/brief.rs src/indexer/chunker/ts.rs src/query.rs src/storage/search.rs src/tools/format.rs"
+          fail=0
+          # 1. New or regrown source files over the ceiling fail (tests excluded).
+          while IFS= read -r f; do
+            # Skip split-out test modules. Inline `#[cfg(test)]` still counts;
+            # split a long inline test module to tests.rs (THRESHOLDS exempts tests).
+            case "$f" in */tests.rs) continue ;; esac
+            case " $allowlist " in *" $f "*) continue ;; esac
+            n=$(wc -l < "$f" | tr -d ' ')
+            if [ "$n" -gt "$threshold" ]; then
+              echo "::error file=$f::$f is $n lines (> $threshold). Split it (#255 / THRESHOLDS)."
+              fail=1
+            fi
+          done < <(git ls-files 'src/**/*.rs' 'src/*.rs')
+          # 2. Allowlist entries now within the ceiling (or gone) must be removed.
+          for f in $allowlist; do
+            if [ ! -f "$f" ]; then
+              echo "::error::$f is allowlisted in the file-size gate but no longer exists; remove it."
+              fail=1
+              continue
+            fi
+            n=$(wc -l < "$f" | tr -d ' ')
+            if [ "$n" -le "$threshold" ]; then
+              echo "::error file=$f::$f is now $n lines (<= $threshold); remove it from the file-size gate allowlist."
+              fail=1
+            fi
+          done
+          exit $fail
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,10 @@ enum_glob_use = "deny"
 str_to_string = "deny"
 # arguments
 needless_pass_by_value = "deny"
+# function size: hugeness backstop at clippy's 100-line default. The
+# THRESHOLDS fn<=30 target is stricter and not enforced here. Pairs with the
+# file-size gate in .github/workflows/ci.yml (#255).
+too_many_lines = "deny"
 
 [profile.release]
 opt-level = 3

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,10 @@ fn main() -> ExitCode {
     run(env::args_os())
 }
 
+// #137: `run` is an oversized subcommand dispatch. Grandfathered until the
+// cli/ handler split shrinks it; `expect` (not `allow`) makes clippy flag the
+// stale attribute once it drops under the 100-line ceiling, forcing removal.
+#[expect(clippy::too_many_lines)]
 fn run<I, T>(args: I) -> ExitCode
 where
     I: IntoIterator<Item = T>,


### PR DESCRIPTION
## What & Why

RC-009 (#137) で `tools.rs` (1052→390) / `main.rs` (742→366) を THRESHOLD 以下に縮小した成果を ratchet gate で固定し、再肥大を能動検知する。Rust 側に fn 行数 / file サイズを止める gate が無く、中核ファイルが ≤400 を超えても検知されなかった (#255) 穴を塞ぐ。

## Changes

- **file-size gate** (`.github/workflows/ci.yml`, `test` job): yomu crate の `src/` で 400 行超を fail。既存超過 5 ファイル (`query.rs` 558 / `tools/format.rs` 520 / `brief.rs` 516 / `storage/search.rs` 500 / `indexer/chunker/ts.rs` 421) は `allowlist` で grandfather。分割で 400 以下になったら allowlist からの除去を強制する自浄 ratchet。checkout 直後・必須 `test` job 内に配置し、branch protection 変更なしで merge をブロック。
- **fn-size gate** (`Cargo.toml` + `src/main.rs`): clippy `too_many_lines = "deny"`。唯一の既存違反 `run()` を `#[expect(clippy::too_many_lines)]` で grandfather。cli/ 分割で 100 行未満に縮めば `unfulfilled_lint_expectations` で属性除去を強制（file allowlist と対称な自浄）。

## Scope

- **Not included**: 5 ファイルの実分割は #137 の領域。本 PR は gate のみで、後続の各分割 PR が allowlist を 1 件ずつ縮める。sibling crate `crates/recall-bench` は対象外（gate コメントに明記）。

## Design Decisions

- **ratchet (allowlist) 先行 vs 5 ファイル先行分割**: allowlist 方式で gate を先行導入。新規リグロースを即ブロックでき、`brief.rs` / `storage/search.rs` が既に 400 超だった = リグロースは実証済みのため固定を優先。
- **`#[expect]` vs `#[allow]`**: `expect` は縮小時に期待が外れ clippy が警告 → stale 属性の自動除去を強制。plain `cargo check` では誤発火しないことを実測確認済み。
- **in-job 配置 vs 別 ubuntu job**: 別 job は速く安いが必須チェック化に branch protection 更新が要る。必須 `test` job 内なら変更なしで即 merge ブロック = gate のアウトカム（確実な阻止）に資する。

## How to Test

1. CI の `test` job → `File size gate` step が green（既存 5 allowlist で exit 0）。
2. リグロース検知: 任意の `src/**/*.rs` を 401 行に増やす → `::error ... is 401 lines (> 400)` で fail。
3. 自浄: allowlist のファイルを 400 以下にしつつ allowlist から外さない → `remove it from the file-size gate allowlist` で fail。
4. `cargo clippy --all-targets --all-features -p yomu -- -D warnings` → exit 0（`#[expect]` が `run()` を抑制）。

検証済み: `cargo fmt --check` / `clippy -D warnings` / `actionlint` / gate 4 シナリオ（`bash -eo pipefail`）すべて green。718 tests pass。`/audit` で high 級指摘（無言 fail-open・off-by-one）は実測反証（fail-closed / fmt gate が末尾改行を強制）。

## Related

- Closes #255
- 親: #137 (RC-009、5 ファイル分割)
