### PR TITLE
refactor(yomu): query.rs から keyword/rank モジュールを抽出 (#137)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: File size gate
         run: |
           threshold=400
-          allowlist="src/brief.rs src/indexer/chunker/ts.rs src/query.rs src/storage/search.rs src/tools/format.rs"
+          allowlist="src/brief.rs src/indexer/chunker/ts.rs src/storage/search.rs src/tools/format.rs"
           fail=0
           # 1. New or regrown source files over the ceiling fail (tests excluded).
           while IFS= read -r f; do

--- a/src/query.rs
+++ b/src/query.rs
@@ -2,10 +2,15 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 use crate::query_log::StageHit;
-use crate::storage::{self, ChunkType, Db, MatchSource, SearchResult, StorageError};
-use crate::text::split_identifier;
+use crate::storage::{self, Db, MatchSource, SearchResult, StorageError};
 use rurico::embed::{Embed, EmbedError};
 use rurico::reranker::Rerank;
+
+mod keywords;
+mod rank;
+
+pub use keywords::{extract_keywords, extract_type_hints};
+pub use rank::{RerankContext, rerank};
 
 #[derive(Debug, thiserror::Error)]
 pub enum QueryError {
@@ -46,286 +51,6 @@ fn capture_stage(results: &[SearchResult]) -> Vec<StageHit> {
             })
         })
         .collect()
-}
-
-const STOP_WORDS: &[&str] = &["the", "a", "an", "in", "for", "of", "with", "and", "or"];
-
-// Words ending in -ing that are not gerunds (stripping -ing produces a non-word).
-const ING_DENY: &[&str] = &[
-    "string",
-    "bring",
-    "thing",
-    "nothing",
-    "something",
-    "everything",
-    "ring",
-    "king",
-    "spring",
-    "swing",
-    "sing",
-    "sting",
-    "wing",
-];
-
-// Words ending in -s that are not plurals (stripping -s produces a non-word).
-const S_DENY: &[&str] = &[
-    "class", "this", "alias", "canvas", "focus", "status", "bus", "process", "address", "access",
-    "express", "progress",
-];
-
-fn stem_keyword(kw: &str) -> Option<&str> {
-    let stem = if kw.len() > 5 && kw.ends_with("ing") && !ING_DENY.contains(&kw) {
-        Some(&kw[..kw.len() - 3])
-    } else if kw.len() > 3 && kw.ends_with('s') && !kw.ends_with("ss") && !S_DENY.contains(&kw) {
-        Some(&kw[..kw.len() - 1])
-    } else {
-        None
-    };
-    stem.filter(|s| s.len() >= 2)
-}
-
-pub fn extract_keywords(query: &str) -> Vec<String> {
-    let mut base: Vec<String> = Vec::new();
-    let mut seen: HashSet<String> = HashSet::new();
-    for token in query.split_whitespace() {
-        let lower = token.to_lowercase();
-        if lower.chars().count() >= 2
-            && !STOP_WORDS.contains(&lower.as_str())
-            && seen.insert(lower.clone())
-        {
-            base.push(lower);
-        }
-        for part in split_identifier(token) {
-            let part_lower = part.to_lowercase();
-            if part_lower.chars().count() >= 2
-                && !STOP_WORDS.contains(&part_lower.as_str())
-                && seen.insert(part_lower.clone())
-            {
-                base.push(part_lower);
-            }
-        }
-    }
-
-    let stems: Vec<String> = base
-        .iter()
-        .filter_map(|kw| stem_keyword(kw))
-        .filter(|s| !seen.contains(*s))
-        .map(str::to_owned)
-        .collect();
-    let mut all = base;
-    for s in stems {
-        seen.insert(s.clone());
-        all.push(s);
-    }
-    all
-}
-
-pub fn extract_type_hints(query: &str) -> Vec<ChunkType> {
-    let mut hints = Vec::new();
-    for token in query.split_whitespace() {
-        let token = token.to_lowercase();
-        let hint = match token.as_str() {
-            "hook" | "hooks" => Some(ChunkType::Hook),
-            "component" | "components" => Some(ChunkType::Component),
-            "type" | "types" | "interface" => Some(ChunkType::TypeDef),
-            "css" | "style" | "styles" => Some(ChunkType::CssRule),
-            "test" | "tests" | "spec" => Some(ChunkType::TestCase),
-            _ => None,
-        };
-        if let Some(h) = hint
-            && !hints.contains(&h)
-        {
-            hints.push(h);
-        }
-    }
-    hints
-}
-
-fn keyword_hit_ratio(
-    result: &storage::SearchResult,
-    keywords: &[String],
-    idfs: &[f32],
-    check_content: bool,
-) -> f32 {
-    if keywords.is_empty() {
-        return 0.0;
-    }
-    let name_lower = result.chunk.name.as_deref().unwrap_or("").to_lowercase();
-    let path_lower = result.chunk.file_path.to_lowercase();
-    let content_lower;
-    let content_ref = if check_content {
-        content_lower = result.chunk.content.to_lowercase();
-        Some(content_lower.as_str())
-    } else {
-        None
-    };
-
-    let total_idf: f32 = idfs.iter().sum();
-    if total_idf < 1e-6 {
-        let hits = keywords
-            .iter()
-            .filter(|kw| {
-                name_lower.contains(kw.as_str())
-                    || path_lower.contains(kw.as_str())
-                    || content_ref.is_some_and(|c| c.contains(kw.as_str()))
-            })
-            .count();
-        return hits as f32 / keywords.len() as f32;
-    }
-
-    let hit_idf: f32 = keywords
-        .iter()
-        .zip(idfs)
-        .filter(|(kw, _)| {
-            name_lower.contains(kw.as_str())
-                || path_lower.contains(kw.as_str())
-                || content_ref.is_some_and(|c| c.contains(kw.as_str()))
-        })
-        .map(|(_, idf)| idf)
-        .sum();
-    hit_idf / total_idf
-}
-
-const MAX_RESULTS_PER_FILE: usize = 2;
-
-fn cross_encoder_rerank(results: &mut [SearchResult], query: &str, reranker: &dyn Rerank) {
-    if results.is_empty() {
-        return;
-    }
-    let pairs: Vec<(&str, &str)> = results
-        .iter()
-        .map(|r| (query, r.chunk.content.as_str()))
-        .collect();
-    match reranker.score_batch(&pairs) {
-        Ok(scores) => {
-            for (result, score) in results.iter_mut().zip(scores) {
-                result.score = score;
-            }
-            results.sort_by(|a, b| b.score.total_cmp(&a.score));
-        }
-        Err(e) => {
-            tracing::warn!(error = %e, "cross-encoder reranking failed, keeping heuristic order");
-        }
-    }
-}
-
-fn cap_per_file(results: &mut Vec<storage::SearchResult>, max: usize) {
-    let mut counts: HashMap<String, usize> = HashMap::new();
-    results.retain(|r| {
-        let count = counts.entry(r.chunk.file_path.clone()).or_insert(0);
-        *count += 1;
-        *count <= max
-    });
-}
-
-const TYPE_HINT_BONUS: f32 = 0.03;
-const IMPORT_RANK_BONUS: f32 = 0.03;
-const TEST_PATH_PENALTY: f32 = 0.05;
-const SEMANTIC_KEYWORD_OVERLAP_BONUS: f32 = 0.05;
-
-fn is_test_path(path: &str) -> bool {
-    path.contains("__tests__")
-        || path.contains("__mocks__")
-        || path.contains("__fixtures__")
-        || path.contains(".test.")
-        || path.contains(".spec.")
-        || path.contains(".stories.")
-        || path.contains("/test/")
-        || path.starts_with("test/")
-        || path.contains("/examples/")
-        || path.starts_with("examples/")
-        || path.contains("/fixtures/")
-        || path.contains("/e2e/")
-}
-
-/// Confidence weight for semantic search scores.
-/// Reaches 1.0 at 9% embedding coverage — below this, text-match scores
-/// are boosted relative to vector scores to compensate for sparse embeddings.
-/// At 0% coverage: 0.4 (semantic results still shown but heavily discounted).
-fn semantic_confidence(embed_coverage: f32) -> f32 {
-    (embed_coverage.sqrt() * 2.0 + 0.4).min(1.0)
-}
-
-pub struct RerankContext<'a> {
-    pub type_hints: &'a [storage::ChunkType],
-    pub keywords: &'a [String],
-    pub keyword_idfs: &'a [f32],
-    pub embed_coverage: f32,
-}
-
-impl Default for RerankContext<'_> {
-    fn default() -> Self {
-        Self {
-            type_hints: &[],
-            keywords: &[],
-            keyword_idfs: &[],
-            embed_coverage: 1.0,
-        }
-    }
-}
-
-pub fn rerank(
-    results: &mut [storage::SearchResult],
-    ctx: &RerankContext<'_>,
-    import_counts: &HashMap<String, u32>,
-) {
-    if results.is_empty() {
-        return;
-    }
-
-    let confidence = semantic_confidence(ctx.embed_coverage);
-
-    let mut counts: Vec<u32> = import_counts.values().copied().filter(|&c| c > 0).collect();
-    counts.sort_unstable();
-    let top_25_threshold = if counts.is_empty() {
-        0
-    } else {
-        counts[counts.len().saturating_sub(counts.len() / 4 + 1)]
-    };
-
-    let query_wants_tests = ctx.type_hints.contains(&storage::ChunkType::TestCase);
-
-    for result in results.iter_mut() {
-        let base = match result.match_source {
-            storage::MatchSource::Semantic => 1.0 / (1.0 + result.distance) * confidence,
-            storage::MatchSource::Fts => result.score,
-        };
-
-        let overlap_bonus =
-            if result.match_source == storage::MatchSource::Semantic && !ctx.keywords.is_empty() {
-                SEMANTIC_KEYWORD_OVERLAP_BONUS
-                    * keyword_hit_ratio(result, ctx.keywords, ctx.keyword_idfs, true)
-            } else {
-                0.0
-            };
-
-        let type_bonus =
-            if !ctx.type_hints.is_empty() && ctx.type_hints.contains(&result.chunk.chunk_type) {
-                TYPE_HINT_BONUS
-            } else {
-                0.0
-            };
-
-        let ic = import_counts
-            .get(&result.chunk.file_path)
-            .copied()
-            .unwrap_or(0);
-        let import_bonus = if top_25_threshold > 0 && ic >= top_25_threshold {
-            IMPORT_RANK_BONUS
-        } else {
-            0.0
-        };
-
-        let test_penalty = if is_test_path(&result.chunk.file_path) && !query_wants_tests {
-            TEST_PATH_PENALTY
-        } else {
-            0.0
-        };
-
-        result.score = base + overlap_bonus + type_bonus + import_bonus - test_penalty;
-    }
-
-    results.sort_by(|a, b| b.score.total_cmp(&a.score));
 }
 
 const MAX_FROM_SUB_EMBEDDINGS: usize = 20;
@@ -502,12 +227,12 @@ fn search_pipeline(
     };
     rerank(&mut results, &ctx, &import_counts);
     if let Some(ranker) = reranker {
-        cross_encoder_rerank(&mut results, query, ranker);
+        rank::cross_encoder_rerank(&mut results, query, ranker);
     }
     if let Some(s) = stages.as_mut() {
         s.reranked_results = capture_stage(&results);
     }
-    cap_per_file(&mut results, MAX_RESULTS_PER_FILE);
+    rank::cap_per_file(&mut results, rank::MAX_RESULTS_PER_FILE);
     if offset > 0 {
         let skip = (offset as usize).min(results.len());
         results.drain(..skip);

--- a/src/query/keywords.rs
+++ b/src/query/keywords.rs
@@ -1,0 +1,97 @@
+use std::collections::HashSet;
+
+use crate::storage::ChunkType;
+use crate::text::split_identifier;
+
+const STOP_WORDS: &[&str] = &["the", "a", "an", "in", "for", "of", "with", "and", "or"];
+
+// Words ending in -ing that are not gerunds (stripping -ing produces a non-word).
+const ING_DENY: &[&str] = &[
+    "string",
+    "bring",
+    "thing",
+    "nothing",
+    "something",
+    "everything",
+    "ring",
+    "king",
+    "spring",
+    "swing",
+    "sing",
+    "sting",
+    "wing",
+];
+
+// Words ending in -s that are not plurals (stripping -s produces a non-word).
+const S_DENY: &[&str] = &[
+    "class", "this", "alias", "canvas", "focus", "status", "bus", "process", "address", "access",
+    "express", "progress",
+];
+
+fn stem_keyword(kw: &str) -> Option<&str> {
+    let stem = if kw.len() > 5 && kw.ends_with("ing") && !ING_DENY.contains(&kw) {
+        Some(&kw[..kw.len() - 3])
+    } else if kw.len() > 3 && kw.ends_with('s') && !kw.ends_with("ss") && !S_DENY.contains(&kw) {
+        Some(&kw[..kw.len() - 1])
+    } else {
+        None
+    };
+    stem.filter(|s| s.len() >= 2)
+}
+
+pub fn extract_keywords(query: &str) -> Vec<String> {
+    let mut base: Vec<String> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for token in query.split_whitespace() {
+        let lower = token.to_lowercase();
+        if lower.chars().count() >= 2
+            && !STOP_WORDS.contains(&lower.as_str())
+            && seen.insert(lower.clone())
+        {
+            base.push(lower);
+        }
+        for part in split_identifier(token) {
+            let part_lower = part.to_lowercase();
+            if part_lower.chars().count() >= 2
+                && !STOP_WORDS.contains(&part_lower.as_str())
+                && seen.insert(part_lower.clone())
+            {
+                base.push(part_lower);
+            }
+        }
+    }
+
+    let stems: Vec<String> = base
+        .iter()
+        .filter_map(|kw| stem_keyword(kw))
+        .filter(|s| !seen.contains(*s))
+        .map(str::to_owned)
+        .collect();
+    let mut all = base;
+    for s in stems {
+        seen.insert(s.clone());
+        all.push(s);
+    }
+    all
+}
+
+pub fn extract_type_hints(query: &str) -> Vec<ChunkType> {
+    let mut hints = Vec::new();
+    for token in query.split_whitespace() {
+        let token = token.to_lowercase();
+        let hint = match token.as_str() {
+            "hook" | "hooks" => Some(ChunkType::Hook),
+            "component" | "components" => Some(ChunkType::Component),
+            "type" | "types" | "interface" => Some(ChunkType::TypeDef),
+            "css" | "style" | "styles" => Some(ChunkType::CssRule),
+            "test" | "tests" | "spec" => Some(ChunkType::TestCase),
+            _ => None,
+        };
+        if let Some(h) = hint
+            && !hints.contains(&h)
+        {
+            hints.push(h);
+        }
+    }
+    hints
+}

--- a/src/query/rank.rs
+++ b/src/query/rank.rs
@@ -1,0 +1,195 @@
+use std::collections::HashMap;
+
+use crate::storage::{self, SearchResult};
+use rurico::reranker::Rerank;
+
+pub(super) fn keyword_hit_ratio(
+    result: &storage::SearchResult,
+    keywords: &[String],
+    idfs: &[f32],
+    check_content: bool,
+) -> f32 {
+    if keywords.is_empty() {
+        return 0.0;
+    }
+    let name_lower = result.chunk.name.as_deref().unwrap_or("").to_lowercase();
+    let path_lower = result.chunk.file_path.to_lowercase();
+    let content_lower;
+    let content_ref = if check_content {
+        content_lower = result.chunk.content.to_lowercase();
+        Some(content_lower.as_str())
+    } else {
+        None
+    };
+
+    let total_idf: f32 = idfs.iter().sum();
+    if total_idf < 1e-6 {
+        let hits = keywords
+            .iter()
+            .filter(|kw| {
+                name_lower.contains(kw.as_str())
+                    || path_lower.contains(kw.as_str())
+                    || content_ref.is_some_and(|c| c.contains(kw.as_str()))
+            })
+            .count();
+        return hits as f32 / keywords.len() as f32;
+    }
+
+    let hit_idf: f32 = keywords
+        .iter()
+        .zip(idfs)
+        .filter(|(kw, _)| {
+            name_lower.contains(kw.as_str())
+                || path_lower.contains(kw.as_str())
+                || content_ref.is_some_and(|c| c.contains(kw.as_str()))
+        })
+        .map(|(_, idf)| idf)
+        .sum();
+    hit_idf / total_idf
+}
+
+pub(super) const MAX_RESULTS_PER_FILE: usize = 2;
+
+pub(super) fn cross_encoder_rerank(
+    results: &mut [SearchResult],
+    query: &str,
+    reranker: &dyn Rerank,
+) {
+    if results.is_empty() {
+        return;
+    }
+    let pairs: Vec<(&str, &str)> = results
+        .iter()
+        .map(|r| (query, r.chunk.content.as_str()))
+        .collect();
+    match reranker.score_batch(&pairs) {
+        Ok(scores) => {
+            for (result, score) in results.iter_mut().zip(scores) {
+                result.score = score;
+            }
+            results.sort_by(|a, b| b.score.total_cmp(&a.score));
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "cross-encoder reranking failed, keeping heuristic order");
+        }
+    }
+}
+
+pub(super) fn cap_per_file(results: &mut Vec<storage::SearchResult>, max: usize) {
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    results.retain(|r| {
+        let count = counts.entry(r.chunk.file_path.clone()).or_insert(0);
+        *count += 1;
+        *count <= max
+    });
+}
+
+pub(super) const TYPE_HINT_BONUS: f32 = 0.03;
+pub(super) const IMPORT_RANK_BONUS: f32 = 0.03;
+const TEST_PATH_PENALTY: f32 = 0.05;
+const SEMANTIC_KEYWORD_OVERLAP_BONUS: f32 = 0.05;
+
+pub(super) fn is_test_path(path: &str) -> bool {
+    path.contains("__tests__")
+        || path.contains("__mocks__")
+        || path.contains("__fixtures__")
+        || path.contains(".test.")
+        || path.contains(".spec.")
+        || path.contains(".stories.")
+        || path.contains("/test/")
+        || path.starts_with("test/")
+        || path.contains("/examples/")
+        || path.starts_with("examples/")
+        || path.contains("/fixtures/")
+        || path.contains("/e2e/")
+}
+
+/// Confidence weight for semantic search scores.
+/// Reaches 1.0 at 9% embedding coverage — below this, text-match scores
+/// are boosted relative to vector scores to compensate for sparse embeddings.
+/// At 0% coverage: 0.4 (semantic results still shown but heavily discounted).
+pub(super) fn semantic_confidence(embed_coverage: f32) -> f32 {
+    (embed_coverage.sqrt() * 2.0 + 0.4).min(1.0)
+}
+
+pub struct RerankContext<'a> {
+    pub type_hints: &'a [storage::ChunkType],
+    pub keywords: &'a [String],
+    pub keyword_idfs: &'a [f32],
+    pub embed_coverage: f32,
+}
+
+impl Default for RerankContext<'_> {
+    fn default() -> Self {
+        Self {
+            type_hints: &[],
+            keywords: &[],
+            keyword_idfs: &[],
+            embed_coverage: 1.0,
+        }
+    }
+}
+
+pub fn rerank(
+    results: &mut [storage::SearchResult],
+    ctx: &RerankContext<'_>,
+    import_counts: &HashMap<String, u32>,
+) {
+    if results.is_empty() {
+        return;
+    }
+
+    let confidence = semantic_confidence(ctx.embed_coverage);
+
+    let mut counts: Vec<u32> = import_counts.values().copied().filter(|&c| c > 0).collect();
+    counts.sort_unstable();
+    let top_25_threshold = if counts.is_empty() {
+        0
+    } else {
+        counts[counts.len().saturating_sub(counts.len() / 4 + 1)]
+    };
+
+    let query_wants_tests = ctx.type_hints.contains(&storage::ChunkType::TestCase);
+
+    for result in results.iter_mut() {
+        let base = match result.match_source {
+            storage::MatchSource::Semantic => 1.0 / (1.0 + result.distance) * confidence,
+            storage::MatchSource::Fts => result.score,
+        };
+
+        let overlap_bonus =
+            if result.match_source == storage::MatchSource::Semantic && !ctx.keywords.is_empty() {
+                SEMANTIC_KEYWORD_OVERLAP_BONUS
+                    * keyword_hit_ratio(result, ctx.keywords, ctx.keyword_idfs, true)
+            } else {
+                0.0
+            };
+
+        let type_bonus =
+            if !ctx.type_hints.is_empty() && ctx.type_hints.contains(&result.chunk.chunk_type) {
+                TYPE_HINT_BONUS
+            } else {
+                0.0
+            };
+
+        let ic = import_counts
+            .get(&result.chunk.file_path)
+            .copied()
+            .unwrap_or(0);
+        let import_bonus = if top_25_threshold > 0 && ic >= top_25_threshold {
+            IMPORT_RANK_BONUS
+        } else {
+            0.0
+        };
+
+        let test_penalty = if is_test_path(&result.chunk.file_path) && !query_wants_tests {
+            TEST_PATH_PENALTY
+        } else {
+            0.0
+        };
+
+        result.score = base + overlap_bonus + type_bonus + import_bonus - test_penalty;
+    }
+
+    results.sort_by(|a, b| b.score.total_cmp(&a.score));
+}

--- a/src/query/tests.rs
+++ b/src/query/tests.rs
@@ -6,6 +6,10 @@ use rurico::embed::{Embedder, FailingEmbedder, MockEmbedder, ModelId};
 use rurico::reranker::{MockReranker, RankedResult, Rerank, RerankerError};
 use tempfile::tempdir;
 
+use super::rank::{
+    IMPORT_RANK_BONUS, MAX_RESULTS_PER_FILE, TYPE_HINT_BONUS, is_test_path, keyword_hit_ratio,
+    semantic_confidence,
+};
 use super::*;
 use crate::storage;
 


### PR DESCRIPTION
## What & Why

RC-009 (#137) の file 分割。`src/query.rs` が 558 行で THRESHOLDS (≤400) と #255 file-size gate を超過していたため、概念ベースで 3 ファイルに分割して query.rs を 283 行に縮小し、gate allowlist から除去する。挙動は完全保存（コード移動のみ、ロジック変更なし）。

## Changes

- **`src/query/keywords.rs`** (97): keyword 抽出 — `extract_keywords` / `extract_type_hints` (pub) + `stem_keyword` / stop-word・deny consts (private)
- **`src/query/rank.rs`** (195): ranking — `rerank` / `RerankContext` (pub) + helper 8 件 (`keyword_hit_ratio` / `cap_per_file` / `cross_encoder_rerank` / `is_test_path` / `semantic_confidence` / `MAX_RESULTS_PER_FILE` / `TYPE_HINT_BONUS` / `IMPORT_RANK_BONUS`) を **`pub(super)`** (LANG.md 最小可視性)
- **`src/query.rs`** (283): 型 (`QueryError` / `SearchStages` / `SearchOutcome`) + orchestration (`search` / `search_pipeline` / `search_from_file` / `capture_stage`)。`pub use` で公開 API を再エクスポート → 呼び出し側 (`tools/*`) 不変
- **`src/query/tests.rs`**: 内部 helper を `use super::rank::{}` で明示 import (既存 `tools/tests.rs`・`indexer/tests.rs` 慣習)
- **`.github/workflows/ci.yml`**: file-size gate allowlist から `src/query.rs` を除去 (ratchet 自浄)

## Design Decisions

- **概念境界 (keywords / rank / orchestration)**: 既存の `tools/`・`storage/`・`indexer/` と同じ `sub.rs` + `sub/child.rs` パターンに揃える。`keyword_hit_ratio` は rank に配置 — rerank 専用の scoring helper で、keywords.rs へ移すと `storage::SearchResult` 依存が増えるため (audit で確認)
- **可視性**: 内部 helper は `pub(super)` (LANG.md「Minimum required. Prefer pub(super)」)。tests は query の子孫なので `super::rank::` で到達。`rerank` / `RerankContext` は分割前から pub のため維持
- **両モジュール抽出 vs rank のみ**: rank のみだと query.rs 373 行 (margin 27)。両抽出で 283 行 (margin 117) + 概念の明確化

## How to Test

1. `cargo nextest run --profile ci --features test-support -p yomu` → **718 passed** (分割前と同一、4 skipped)
2. `cargo clippy --all-targets --all-features -p yomu -- -D warnings` → exit 0 (tests が `pub(super)` helper にアクセス可)
3. file-size gate: `src/query.rs` 283 ≤ 400 かつ allowlist から除去済み → step green
4. diff-cover: query.rs 100% / keywords.rs 100% / rank.rs 97% (≥95% floor)

レビュー観点: **equivalence (移動が verbatim か)** と **可視性**。`git diff` の query.rs 削除分が keywords.rs / rank.rs にそのまま移っていること、`pub use` 再エクスポートで外部呼び出しが不変であることを確認してください。rank.rs の未カバー 3 箇所 (13 / 59 / 72-73 = 早期 return ガード 2 + reranker エラーアーム) は**分割前から未カバー**で、本 PR では covered 化しません (別 issue 候補)。

検証済み: 718 tests pass / clippy / fmt / diff-cover 97%。`/audit` で「クリーンな分割 (equivalence verbatim)」を確認、唯一の指摘 (helper の可視性過剰昇格) は `pub(super)` 化で解消済み。

## Related

- Refs #137 (RC-009 file 分割。残り: `tools/format.rs` 520 / `brief.rs` 516 / `storage/search.rs` 500 / `indexer/chunker/ts.rs` 421 を後続 PR で分割し allowlist を縮める)
