### PR TITLE
refactor(yomu): tools/format.rs から markdown renderer を抽出 (#137)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: File size gate
         run: |
           threshold=400
-          allowlist="src/brief.rs src/indexer/chunker/ts.rs src/storage/search.rs src/tools/format.rs"
+          allowlist="src/brief.rs src/indexer/chunker/ts.rs src/storage/search.rs"
           fail=0
           # 1. New or regrown source files over the ceiling fail (tests excluded).
           while IFS= read -r f; do

--- a/src/tools/format.rs
+++ b/src/tools/format.rs
@@ -1,19 +1,22 @@
-//! JSON envelope formatters for success-path routes.
+//! JSON envelope formatters for success-path routes, plus shared
+//! index-coverage helpers (used by both JSON and text output paths).
 //!
 //! `degraded` and `notes` fields are always serialized (no `skip_serializing_if`)
 //! so consumers can read `obj.degraded` without an existence guard
 //! (OUTCOME.md Behavior #4, spec FR-001 / BR-002).
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use serde::Serialize;
 
+use crate::injection_check::InjectionCheck;
 use crate::{indexer, storage};
 
-pub(super) struct EnrichmentContext {
-    pub imports: HashMap<String, String>,
-    pub siblings: HashMap<String, Vec<storage::SiblingInfo>>,
-}
+mod render;
+
+pub(super) use render::{
+    EnrichmentContext, format_impact_all, format_impact_results, format_results_grouped,
+};
 
 pub(super) fn format_coverage(stats: &storage::IndexStatus) -> String {
     format!(
@@ -44,214 +47,6 @@ pub(super) fn format_coverage_note(stats: &storage::IndexStatus) -> Option<Strin
         format!("\n\nEmbedding coverage: {cov}. Run `yomu index` again to finish embedding.")
     })
 }
-
-pub(super) fn format_dependents_by_depth(
-    output: &mut String,
-    dependents: &[storage::Dependent],
-    heading_prefix: &str,
-) {
-    debug_assert!(
-        dependents.windows(2).all(|w| w[0].depth <= w[1].depth),
-        "dependents must be sorted by depth"
-    );
-    let mut current_depth = 0;
-    for dep in dependents {
-        if dep.depth != current_depth {
-            current_depth = dep.depth;
-            output.push_str(&format!("{heading_prefix} Depth {}\n", current_depth));
-        }
-        output.push_str(&format!("- {}\n", dep.file_path));
-    }
-}
-
-fn format_semantic_section(output: &mut String, semantic_related: &[storage::SearchResult]) {
-    output.push_str("\n### Semantic related (embedding search)\n");
-    for r in semantic_related {
-        output.push_str(&format!(
-            "- {} (similarity: {:.2})\n",
-            r.chunk.file_path, r.score
-        ));
-    }
-}
-
-pub(super) fn format_impact_all(
-    target: &str,
-    dependents: &[storage::Dependent],
-    semantic_related: &[storage::SearchResult],
-) -> String {
-    let mut output = format!("## Impact analysis: `{}`\n\n", target);
-
-    if semantic_related.is_empty() {
-        format_dependents_by_depth(&mut output, dependents, "###");
-    } else {
-        output.push_str("### Structural dependents (import graph)\n");
-        format_dependents_by_depth(&mut output, dependents, "####");
-        format_semantic_section(&mut output, semantic_related);
-    }
-
-    output.push_str(&format!(
-        "\nTotal: {} dependent file(s)\n",
-        dependents.len()
-    ));
-    output
-}
-
-pub(super) fn format_impact_results(
-    target: &str,
-    symbol_refs: &[String],
-    all_dependents: &[storage::Dependent],
-    semantic_related: &[storage::SearchResult],
-) -> String {
-    let mut output = format!("## Impact analysis: `{}`\n\n", target);
-
-    if !symbol_refs.is_empty() {
-        output.push_str("### Direct symbol references\n");
-        for f in symbol_refs {
-            output.push_str(&format!("- {}\n", f));
-        }
-    }
-
-    output.push_str("\n### All transitive dependents\n");
-    format_dependents_by_depth(&mut output, all_dependents, "####");
-
-    if !semantic_related.is_empty() {
-        format_semantic_section(&mut output, semantic_related);
-    }
-
-    output.push_str(&format!(
-        "\nTotal: {} dependent file(s)\n",
-        all_dependents.len()
-    ));
-    output
-}
-
-fn format_imports_line(imports: &HashMap<String, String>, file_path: &str) -> Option<String> {
-    let imports_text = imports.get(file_path)?;
-    let items: Vec<&str> = imports_text.split('\n').filter(|s| !s.is_empty()).collect();
-    if items.is_empty() {
-        return None;
-    }
-    Some(format!("Imports: {}\n", items.join(", ")))
-}
-
-fn format_siblings_line(
-    siblings_map: &HashMap<String, Vec<storage::SiblingInfo>>,
-    file_path: &str,
-    result_ranges: &HashSet<(u32, u32)>,
-) -> Option<String> {
-    let siblings = siblings_map.get(file_path)?;
-    let filtered: Vec<String> = siblings
-        .iter()
-        .filter(|s| !result_ranges.contains(&(s.start_line, s.end_line)))
-        .map(|s| {
-            let name = s.name.as_deref().unwrap_or("(unnamed)");
-            format!("{} [{}]", name, s.chunk_type.as_str())
-        })
-        .collect();
-    if filtered.is_empty() {
-        return None;
-    }
-    Some(format!("Siblings: {}\n", filtered.join(", ")))
-}
-
-fn format_file_group(
-    output: &mut String,
-    file_path: &str,
-    chunks: &[(usize, &storage::SearchResult)],
-    ctx: &EnrichmentContext,
-    parent_chunks: &HashMap<i64, storage::Chunk>,
-    result_chunk_ids: &HashSet<i64>,
-) {
-    output.push_str(&format!("## {}\n", file_path));
-
-    if let Some(line) = format_imports_line(&ctx.imports, file_path) {
-        output.push_str(&line);
-    }
-
-    let result_ranges: HashSet<(u32, u32)> = chunks
-        .iter()
-        .map(|(_, r)| (r.chunk.start_line, r.chunk.end_line))
-        .collect();
-    if let Some(line) = format_siblings_line(&ctx.siblings, file_path, &result_ranges) {
-        output.push_str(&line);
-    }
-
-    output.push('\n');
-
-    for (rank, result) in chunks {
-        let chunk = &result.chunk;
-        let name = chunk.name.as_deref().unwrap_or("(unnamed)");
-        output.push_str(&format!(
-            "{}. {} [{}] — {}:{} (similarity: {:.2})\n",
-            rank + 1,
-            name,
-            chunk.chunk_type.as_str(),
-            chunk.start_line,
-            chunk.end_line,
-            result.score,
-        ));
-        output.push_str(&chunk.content);
-        output.push_str("\n\n");
-
-        if let Some(parent_id) = chunk.parent_chunk_id
-            && !result_chunk_ids.contains(&parent_id)
-            && let Some(parent) = parent_chunks.get(&parent_id)
-        {
-            let parent_name = parent.name.as_deref().unwrap_or("(unnamed)");
-            output.push_str(&format!(
-                "  Parent context: {} [{}] — {}:{}\n",
-                parent_name,
-                parent.chunk_type.as_str(),
-                parent.start_line,
-                parent.end_line,
-            ));
-            output.push_str(&parent.content);
-            output.push_str("\n\n");
-        }
-    }
-}
-
-pub(super) fn format_results_grouped(
-    results: &[storage::SearchResult],
-    ctx: &EnrichmentContext,
-    parent_chunks: &HashMap<i64, storage::Chunk>,
-) -> String {
-    let mut groups: HashMap<&str, Vec<(usize, &storage::SearchResult)>> = HashMap::new();
-    for (i, result) in results.iter().enumerate() {
-        groups
-            .entry(&result.chunk.file_path)
-            .or_default()
-            .push((i, result));
-    }
-
-    let mut sorted: Vec<_> = groups.into_iter().collect();
-    sorted.sort_by(|a, b| {
-        let best = |items: &[(usize, &storage::SearchResult)]| {
-            items
-                .iter()
-                .map(|(_, r)| r.score)
-                .fold(f32::NEG_INFINITY, f32::max)
-        };
-        best(&b.1).total_cmp(&best(&a.1))
-    });
-
-    let mut output = String::new();
-    let result_chunk_ids: HashSet<i64> = results.iter().filter_map(|r| r.chunk_id).collect();
-
-    for (file_path, chunks) in &sorted {
-        format_file_group(
-            &mut output,
-            file_path,
-            chunks,
-            ctx,
-            parent_chunks,
-            &result_chunk_ids,
-        );
-    }
-    output
-}
-
-use crate::injection_check::InjectionCheck;
 
 #[derive(Serialize)]
 struct JsonChunk<'a> {

--- a/src/tools/format/render.rs
+++ b/src/tools/format/render.rs
@@ -1,0 +1,296 @@
+//! Human-readable (Markdown) renderers for search and impact results.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::storage;
+
+// The items re-exported by `format.rs` are `pub(crate)`, not `pub(super)`:
+// `render` is a grandchild of `tools`, and `format.rs` re-exports them up to
+// the `tools` level via `pub(super) use`. `pub(super)` / `pub(in crate::tools)`
+// here would scope them to `format` and fail that re-export with E0364.
+// Effective reach stays `tools`-scoped because `mod render` is private.
+
+#[derive(Debug)]
+pub(crate) struct EnrichmentContext {
+    pub imports: HashMap<String, String>,
+    pub siblings: HashMap<String, Vec<storage::SiblingInfo>>,
+}
+
+fn format_dependents_by_depth(
+    output: &mut String,
+    dependents: &[storage::Dependent],
+    heading_prefix: &str,
+) {
+    debug_assert!(
+        dependents.windows(2).all(|w| w[0].depth <= w[1].depth),
+        "dependents must be sorted by depth"
+    );
+    let mut current_depth = 0;
+    for dep in dependents {
+        if dep.depth != current_depth {
+            current_depth = dep.depth;
+            output.push_str(&format!("{heading_prefix} Depth {}\n", current_depth));
+        }
+        output.push_str(&format!("- {}\n", dep.file_path));
+    }
+}
+
+fn format_semantic_section(output: &mut String, semantic_related: &[storage::SearchResult]) {
+    output.push_str("\n### Semantic related (embedding search)\n");
+    for r in semantic_related {
+        output.push_str(&format!(
+            "- {} (similarity: {:.2})\n",
+            r.chunk.file_path, r.score
+        ));
+    }
+}
+
+pub(crate) fn format_impact_all(
+    target: &str,
+    dependents: &[storage::Dependent],
+    semantic_related: &[storage::SearchResult],
+) -> String {
+    let mut output = format!("## Impact analysis: `{}`\n\n", target);
+
+    if semantic_related.is_empty() {
+        format_dependents_by_depth(&mut output, dependents, "###");
+    } else {
+        output.push_str("### Structural dependents (import graph)\n");
+        format_dependents_by_depth(&mut output, dependents, "####");
+        format_semantic_section(&mut output, semantic_related);
+    }
+
+    output.push_str(&format!(
+        "\nTotal: {} dependent file(s)\n",
+        dependents.len()
+    ));
+    output
+}
+
+pub(crate) fn format_impact_results(
+    target: &str,
+    symbol_refs: &[String],
+    all_dependents: &[storage::Dependent],
+    semantic_related: &[storage::SearchResult],
+) -> String {
+    let mut output = format!("## Impact analysis: `{}`\n\n", target);
+
+    if !symbol_refs.is_empty() {
+        output.push_str("### Direct symbol references\n");
+        for f in symbol_refs {
+            output.push_str(&format!("- {}\n", f));
+        }
+    }
+
+    output.push_str("\n### All transitive dependents\n");
+    format_dependents_by_depth(&mut output, all_dependents, "####");
+
+    if !semantic_related.is_empty() {
+        format_semantic_section(&mut output, semantic_related);
+    }
+
+    output.push_str(&format!(
+        "\nTotal: {} dependent file(s)\n",
+        all_dependents.len()
+    ));
+    output
+}
+
+fn format_imports_line(imports: &HashMap<String, String>, file_path: &str) -> Option<String> {
+    let imports_text = imports.get(file_path)?;
+    let items: Vec<&str> = imports_text.split('\n').filter(|s| !s.is_empty()).collect();
+    if items.is_empty() {
+        return None;
+    }
+    Some(format!("Imports: {}\n", items.join(", ")))
+}
+
+fn format_siblings_line(
+    siblings_map: &HashMap<String, Vec<storage::SiblingInfo>>,
+    file_path: &str,
+    result_ranges: &HashSet<(u32, u32)>,
+) -> Option<String> {
+    let siblings = siblings_map.get(file_path)?;
+    let filtered: Vec<String> = siblings
+        .iter()
+        .filter(|s| !result_ranges.contains(&(s.start_line, s.end_line)))
+        .map(|s| {
+            let name = s.name.as_deref().unwrap_or("(unnamed)");
+            format!("{} [{}]", name, s.chunk_type.as_str())
+        })
+        .collect();
+    if filtered.is_empty() {
+        return None;
+    }
+    Some(format!("Siblings: {}\n", filtered.join(", ")))
+}
+
+fn format_file_group(
+    output: &mut String,
+    file_path: &str,
+    chunks: &[(usize, &storage::SearchResult)],
+    ctx: &EnrichmentContext,
+    parent_chunks: &HashMap<i64, storage::Chunk>,
+    result_chunk_ids: &HashSet<i64>,
+) {
+    output.push_str(&format!("## {}\n", file_path));
+
+    if let Some(line) = format_imports_line(&ctx.imports, file_path) {
+        output.push_str(&line);
+    }
+
+    let result_ranges: HashSet<(u32, u32)> = chunks
+        .iter()
+        .map(|(_, r)| (r.chunk.start_line, r.chunk.end_line))
+        .collect();
+    if let Some(line) = format_siblings_line(&ctx.siblings, file_path, &result_ranges) {
+        output.push_str(&line);
+    }
+
+    output.push('\n');
+
+    for (rank, result) in chunks {
+        let chunk = &result.chunk;
+        let name = chunk.name.as_deref().unwrap_or("(unnamed)");
+        output.push_str(&format!(
+            "{}. {} [{}] — {}:{} (similarity: {:.2})\n",
+            rank + 1,
+            name,
+            chunk.chunk_type.as_str(),
+            chunk.start_line,
+            chunk.end_line,
+            result.score,
+        ));
+        output.push_str(&chunk.content);
+        output.push_str("\n\n");
+
+        if let Some(parent_id) = chunk.parent_chunk_id
+            && !result_chunk_ids.contains(&parent_id)
+            && let Some(parent) = parent_chunks.get(&parent_id)
+        {
+            let parent_name = parent.name.as_deref().unwrap_or("(unnamed)");
+            output.push_str(&format!(
+                "  Parent context: {} [{}] — {}:{}\n",
+                parent_name,
+                parent.chunk_type.as_str(),
+                parent.start_line,
+                parent.end_line,
+            ));
+            output.push_str(&parent.content);
+            output.push_str("\n\n");
+        }
+    }
+}
+
+pub(crate) fn format_results_grouped(
+    results: &[storage::SearchResult],
+    ctx: &EnrichmentContext,
+    parent_chunks: &HashMap<i64, storage::Chunk>,
+) -> String {
+    let mut groups: HashMap<&str, Vec<(usize, &storage::SearchResult)>> = HashMap::new();
+    for (i, result) in results.iter().enumerate() {
+        groups
+            .entry(&result.chunk.file_path)
+            .or_default()
+            .push((i, result));
+    }
+
+    let mut sorted: Vec<_> = groups.into_iter().collect();
+    sorted.sort_by(|a, b| {
+        let best = |items: &[(usize, &storage::SearchResult)]| {
+            items
+                .iter()
+                .map(|(_, r)| r.score)
+                .fold(f32::NEG_INFINITY, f32::max)
+        };
+        best(&b.1).total_cmp(&best(&a.1))
+    });
+
+    let mut output = String::new();
+    let result_chunk_ids: HashSet<i64> = results.iter().filter_map(|r| r.chunk_id).collect();
+
+    for (file_path, chunks) in &sorted {
+        format_file_group(
+            &mut output,
+            file_path,
+            chunks,
+            ctx,
+            parent_chunks,
+            &result_chunk_ids,
+        );
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{Chunk, ChunkType, Dependent, MatchSource, SearchResult};
+
+    fn dependent(file_path: &str, depth: u32) -> Dependent {
+        Dependent {
+            file_path: file_path.to_owned(),
+            depth,
+        }
+    }
+
+    fn semantic_hit(file_path: &str, score: f32) -> SearchResult {
+        SearchResult {
+            chunk: Chunk {
+                file_path: file_path.to_owned(),
+                chunk_type: ChunkType::RustFn,
+                name: None,
+                content: String::new(),
+                start_line: 1,
+                end_line: 1,
+                parent_chunk_id: None,
+                source_kind: None,
+                injection_flags: None,
+            },
+            chunk_id: None,
+            distance: 0.1,
+            match_source: MatchSource::Semantic,
+            score,
+        }
+    }
+
+    // T-706: format_impact_all_renders_semantic_section_when_related_present
+    #[test]
+    fn format_impact_all_renders_semantic_section_when_related_present() {
+        let deps = vec![dependent("src/a.rs", 1)];
+        let related = vec![semantic_hit("src/b.rs", 0.83)];
+        let out = format_impact_all("foo", &deps, &related);
+        assert!(
+            out.contains("### Structural dependents (import graph)"),
+            "expected structural heading, got: {out}"
+        );
+        assert!(
+            out.contains("### Semantic related (embedding search)"),
+            "expected semantic heading, got: {out}"
+        );
+        assert!(
+            out.contains("src/b.rs (similarity: 0.83)"),
+            "expected semantic hit line, got: {out}"
+        );
+    }
+
+    // T-707: format_impact_results_renders_symbol_refs_and_semantic_section
+    #[test]
+    fn format_impact_results_renders_symbol_refs_and_semantic_section() {
+        let deps = vec![dependent("src/a.rs", 1)];
+        let related = vec![semantic_hit("src/b.rs", 0.5)];
+        let out = format_impact_results("foo", &["bar".to_owned()], &deps, &related);
+        assert!(
+            out.contains("### Direct symbol references"),
+            "expected symbol-refs heading, got: {out}"
+        );
+        assert!(
+            out.contains("- bar"),
+            "expected symbol ref line, got: {out}"
+        );
+        assert!(
+            out.contains("### Semantic related (embedding search)"),
+            "expected semantic heading, got: {out}"
+        );
+    }
+}


### PR DESCRIPTION
## What & Why

RC-009 (#137) の file 分割。`tools/format.rs` が 520 行で THRESHOLDS (≤400) と #255 file-size gate を超過していたため、markdown rendering を抽出して format.rs を 315 行に縮小し、gate allowlist から除去する。挙動は完全保存（コード移動のみ、ロジック変更なし）。

## Changes

- **`src/tools/format/render.rs`** (296、新規): markdown rendering — `format_impact_all` / `format_impact_results` / `format_results_grouped` (pub(crate)) + 内部 helper (`format_dependents_by_depth` / `format_semantic_section` / `format_file_group` / `format_imports_line` / `format_siblings_line`、private) + `EnrichmentContext`。semantic_related 経路の直接ユニットテスト 2 件 (T-706/T-707) を同梱
- **`src/tools/format.rs`** (520→315): JSON envelope formatter (`format_results_json` 等) + coverage helper を残す。`pub(super) use render::{}` で公開 API を再エクスポート → 兄弟 (`search.rs` / `impact.rs`) の `use super::format::{}` 不変
- **`.github/workflows/ci.yml`**: allowlist から `src/tools/format.rs` を除去 (ratchet 自浄)

## Design Decisions

- **分割方向 = render-out**（json-out でなく）: `format/tests.rs` が JSON 内部テスト (`JsonChunk`/`JsonResponse`) を `use super::*` で参照しており、`coverage_if_partial` が json↔text 共有。JSON を据え置くことで**テスト不変**＋**cross-module 呼び出しゼロ**
- **可視性 pub(crate)**: render は孫モジュール (`tools::format::render`)。format.rs が tools レベルへ再エクスポートするため、`pub(super)` / `pub(in crate::tools)` は E0364 で不可（検証済み）。`pub(crate)` が compile する最小で、`mod render` が private のため実効到達は tools 内に限定（理由は render.rs に明記）
- **テスト追加**: semantic_related レンダリング経路は分割前から未カバー。新ファイルで diff-cover の追加行となり floor を割るため、直接ユニットテストで covered 化（実挙動テスト）

## How to Test

1. `cargo nextest run --profile ci --features test-support -p yomu` → **720 passed** (4 skipped、うち新規 2)
2. `cargo clippy --all-targets --all-features -p yomu -- -D warnings` → exit 0
3. file-size gate: `format.rs` 315 ≤ 400 かつ allowlist から除去済み → step green
4. diff-cover: render.rs 99.6%（line 83 = empty-symbol_refs 分岐のみ未カバー、impact.rs 統合テストで間接 covered）

レビュー観点: **equivalence**（`git show HEAD~1:src/tools/format.rs` と render.rs の移動が verbatim か）と **可視性**（`pub(super) use` 再エクスポートで外部呼び出しが不変か）。

`/audit` 実施（8 reviewer + critic-audit/critic-evidence）で「クリーンな分割」を確認。5 件の in-scope 改善を反映済み: pub(crate) の E0364 理由をコメント化、`EnrichmentContext` に `#[derive(Debug)]`、module doc を coverage helper 込みに更新、新テストに T-NNN、fixture の `chunk_id` を `None` に。

## Related

- Refs #137 (RC-009 file 分割。残り: `brief.rs` 516 / `storage/search.rs` 500 / `indexer/chunker/ts.rs` 421 を後続 PR で分割し allowlist を縮める)
