### PR TITLE
refactor(yomu): storage/search.rs から chunk fetch 層を子モジュールへ分離 (#137)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: File size gate
         run: |
           threshold=400
-          allowlist="src/indexer/chunker/ts.rs src/storage/search.rs"
+          allowlist="src/indexer/chunker/ts.rs"
           fail=0
           # 1. New or regrown source files over the ceiling fail (tests excluded).
           while IFS= read -r f; do

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -1,15 +1,18 @@
 use std::collections::{HashMap, HashSet};
 
-use amici::storage::filter::{
-    append_exclude_ids, append_in_filter, append_include_ids, append_like_prefix_filter,
-};
+use amici::storage::filter::{append_exclude_ids, append_include_ids, append_like_prefix_filter};
 use bytemuck::cast_slice;
 use rurico::storage::{fts_quote, prepare_match_query};
-use rusqlite::{Connection, Error as RusqliteError, Row, params, params_from_iter, types::ToSql};
+use rusqlite::{Connection, params, params_from_iter, types::ToSql};
 
 use super::{
-    Chunk, ChunkType, MatchSource, SearchResult, SourceKind, StorageError, anon_placeholders,
-    fts_normalization, in_placeholders,
+    Chunk, ChunkType, MatchSource, SearchResult, StorageError, anon_placeholders, fts_normalization,
+};
+
+mod fetch;
+
+pub use fetch::{
+    get_chunk_by_id, get_chunks_by_ids, get_chunks_for_files, get_chunks_for_from_target,
 };
 
 const VEC_MAXSIM_OVERSAMPLE: u32 = 10;
@@ -65,50 +68,6 @@ fn build_semantic_results(
     results
 }
 
-fn chunk_from_row(row: &Row<'_>, offset: usize) -> rusqlite::Result<Chunk> {
-    let injection_flags_json: Option<String> = row.get(offset + 8)?;
-    let injection_flags = injection_flags_json.and_then(|s| {
-        serde_json::from_str::<Vec<String>>(&s)
-            .inspect_err(|e| {
-                tracing::warn!(error = %e, "injection_flags JSON parse failed, treating as None");
-            })
-            .ok()
-    });
-    Ok(Chunk {
-        file_path: row.get(offset)?,
-        chunk_type: ChunkType::from_db(row.get::<_, String>(offset + 1)?.as_ref()),
-        name: row.get(offset + 2)?,
-        content: row.get(offset + 3)?,
-        start_line: row.get(offset + 4)?,
-        end_line: row.get(offset + 5)?,
-        parent_chunk_id: row.get(offset + 6)?,
-        source_kind: row
-            .get::<_, Option<String>>(offset + 7)?
-            .map(|s| SourceKind::from_db(s.as_ref())),
-        injection_flags,
-    })
-}
-
-/// Appends a chunk-type `IN (...)` filter, treating both `None` and
-/// `Some(&[])` as "no filter". Contrast with [`append_in_filter`], which
-/// renders `Some(&[])` as `AND 1 = 0`.
-///
-/// Precondition: `sql` ends inside an open WHERE clause — callers anchor with
-/// `MATCH ?` (FTS path) or a trailing `IN (...)` (vec path) so the leading
-/// ` AND ` from amici helpers attaches cleanly.
-fn append_chunk_type_filter(
-    sql: &mut String,
-    params: &mut Vec<Box<dyn ToSql>>,
-    column: &'static str,
-    types: Option<&[ChunkType]>,
-) {
-    let Some(types) = types.filter(|t| !t.is_empty()) else {
-        return;
-    };
-    let strings: Vec<String> = types.iter().map(|c| c.as_str().to_owned()).collect();
-    append_in_filter(sql, params, column, Some(&strings));
-}
-
 pub fn vec_search(
     conn: &Connection,
     query_embedding: &[f32],
@@ -136,7 +95,7 @@ pub fn vec_search(
     }
 
     let chunk_ids: Vec<i64> = best.keys().copied().collect();
-    let meta = get_chunks_by_ids(conn, &chunk_ids, type_filter, path_filter)?;
+    let meta = fetch::get_chunks_by_ids(conn, &chunk_ids, type_filter, path_filter)?;
     Ok(build_semantic_results(best, &meta, limit))
 }
 
@@ -196,7 +155,7 @@ pub fn search_by_fts(
     let mut params: Vec<Box<dyn ToSql>> = Vec::new();
     params.push(Box::new(fts_query));
 
-    append_chunk_type_filter(&mut sql, &mut params, "c.chunk_type", type_filter);
+    fetch::append_chunk_type_filter(&mut sql, &mut params, "c.chunk_type", type_filter);
     append_exclude_ids(&mut sql, &mut params, "c.id", exclude_ids);
     append_include_ids(&mut sql, &mut params, "c.id", include_ids);
     append_like_prefix_filter(&mut sql, &mut params, "c.file_path", path_filter);
@@ -216,7 +175,7 @@ pub fn search_by_fts(
         let abs = bm25_f32.abs();
         let base_score = abs / (1.0 + abs);
         Ok(SearchResult {
-            chunk: chunk_from_row(row, 1)?,
+            chunk: fetch::chunk_from_row(row, 1)?,
             chunk_id: Some(row.get(0)?),
             distance: f32::INFINITY,
             match_source: MatchSource::Fts,
@@ -224,68 +183,6 @@ pub fn search_by_fts(
         })
     })?;
 
-    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
-}
-
-pub fn get_chunk_by_id(conn: &Connection, chunk_id: i64) -> Result<Option<Chunk>, StorageError> {
-    let mut stmt = conn.prepare_cached(
-        "SELECT file_path, chunk_type, name, content, start_line, end_line, parent_chunk_id, source_kind, injection_flags
-         FROM chunks WHERE id = ?1",
-    )?;
-    match stmt.query_row([chunk_id], |row| chunk_from_row(row, 0)) {
-        Ok(chunk) => Ok(Some(chunk)),
-        Err(RusqliteError::QueryReturnedNoRows) => Ok(None),
-        Err(e) => Err(e.into()),
-    }
-}
-
-/// Bulk-fetch chunk metadata by ids with optional type/path filters applied
-/// at the SQL layer. Shared by [`vec_search`], [`vec_search_multi`], and
-/// callers that need a plain id→chunk lookup.
-pub fn get_chunks_by_ids(
-    conn: &Connection,
-    ids: &[i64],
-    type_filter: Option<&[ChunkType]>,
-    path_filter: &[String],
-) -> Result<HashMap<i64, Chunk>, StorageError> {
-    if ids.is_empty() {
-        return Ok(HashMap::new());
-    }
-    let mut sql = format!(
-        "SELECT id, file_path, chunk_type, name, content, start_line, end_line, parent_chunk_id, source_kind, injection_flags \
-         FROM chunks WHERE id IN ({})",
-        anon_placeholders(ids.len())
-    );
-    let mut params: Vec<Box<dyn ToSql>> = ids
-        .iter()
-        .map(|id| Box::new(*id) as Box<dyn ToSql>)
-        .collect();
-    append_like_prefix_filter(&mut sql, &mut params, "file_path", path_filter);
-    append_chunk_type_filter(&mut sql, &mut params, "chunk_type", type_filter);
-
-    let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map(params_from_iter(params.iter()), |row| {
-        Ok((row.get::<_, i64>(0)?, chunk_from_row(row, 1)?))
-    })?;
-    rows.collect::<Result<HashMap<_, _>, _>>()
-        .map_err(Into::into)
-}
-
-/// Bulk-fetch every Chunk (with body content) belonging to the given files.
-/// Output is sorted by `(file_path, start_line)` so brief expansion can apply
-/// topological ordering on top without an extra sort pass.
-pub fn get_chunks_for_files(conn: &Connection, paths: &[&str]) -> Result<Vec<Chunk>, StorageError> {
-    if paths.is_empty() {
-        return Ok(Vec::new());
-    }
-    let placeholders = in_placeholders(paths.len());
-    let sql = format!(
-        "SELECT file_path, chunk_type, name, content, start_line, end_line, parent_chunk_id, source_kind, injection_flags
-         FROM chunks WHERE file_path IN ({placeholders})
-         ORDER BY file_path, start_line"
-    );
-    let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map(params_from_iter(paths.iter()), |row| chunk_from_row(row, 0))?;
     rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
 }
 
@@ -427,32 +324,8 @@ pub fn vec_search_multi(
     }
 
     let chunk_ids: Vec<i64> = best.keys().copied().collect();
-    let meta = get_chunks_by_ids(conn, &chunk_ids, type_filter, path_filter)?;
+    let meta = fetch::get_chunks_by_ids(conn, &chunk_ids, type_filter, path_filter)?;
     Ok(build_semantic_results(best, &meta, limit))
-}
-
-pub fn get_chunks_for_from_target(
-    conn: &Connection,
-    file_path: &str,
-    symbol: Option<&str>,
-) -> Result<Vec<i64>, StorageError> {
-    let mut sql = String::from(
-        "SELECT id FROM chunks \
-         WHERE file_path = ?1 AND chunk_type != 'inner_fn'",
-    );
-    if symbol.is_some() {
-        sql.push_str(" AND name = ?2");
-    }
-
-    let mut stmt = conn.prepare(&sql)?;
-    let ids = if let Some(sym) = symbol {
-        stmt.query_map(params![file_path, sym], |row| row.get::<_, i64>(0))?
-            .collect::<Result<Vec<_>, _>>()?
-    } else {
-        stmt.query_map([file_path], |row| row.get::<_, i64>(0))?
-            .collect::<Result<Vec<_>, _>>()?
-    };
-    Ok(ids)
 }
 
 pub fn get_sub_embeddings_for_chunks(

--- a/src/storage/search/fetch.rs
+++ b/src/storage/search/fetch.rs
@@ -1,0 +1,148 @@
+//! Chunk row retrieval: the shared row mapper and chunk-type filter, the
+//! id/path metadata getters that read `chunks` rows without ranking, and the
+//! id-only source-navigation lookup (`get_chunks_for_from_target`).
+
+use std::collections::HashMap;
+
+use amici::storage::filter::{append_in_filter, append_like_prefix_filter};
+use rusqlite::{Connection, Error as RusqliteError, Row, params, params_from_iter, types::ToSql};
+
+use crate::storage::{
+    Chunk, ChunkType, SourceKind, StorageError, anon_placeholders, in_placeholders,
+};
+
+/// Deserializes a [`Chunk`] from a row whose columns at `offset..=offset + 8`
+/// are, in `chunks` table order: file_path, chunk_type, name, content,
+/// start_line, end_line, parent_chunk_id, source_kind, injection_flags. Callers
+/// that prefix extra columns pass the matching offset — `get_chunk_by_id`
+/// selects the 9 columns at offset 0; `get_chunks_by_ids` and the FTS path
+/// prefix `id` and pass offset 1.
+pub(super) fn chunk_from_row(row: &Row<'_>, offset: usize) -> rusqlite::Result<Chunk> {
+    let injection_flags_json: Option<String> = row.get(offset + 8)?;
+    let injection_flags = injection_flags_json.and_then(|s| {
+        serde_json::from_str::<Vec<String>>(&s)
+            .inspect_err(|e| {
+                tracing::warn!(error = %e, "injection_flags JSON parse failed, treating as None");
+            })
+            .ok()
+    });
+    Ok(Chunk {
+        file_path: row.get(offset)?,
+        chunk_type: ChunkType::from_db(row.get::<_, String>(offset + 1)?.as_ref()),
+        name: row.get(offset + 2)?,
+        content: row.get(offset + 3)?,
+        start_line: row.get(offset + 4)?,
+        end_line: row.get(offset + 5)?,
+        parent_chunk_id: row.get(offset + 6)?,
+        source_kind: row
+            .get::<_, Option<String>>(offset + 7)?
+            .map(|s| SourceKind::from_db(s.as_ref())),
+        injection_flags,
+    })
+}
+
+/// Appends a chunk-type `IN (...)` filter, treating both `None` and
+/// `Some(&[])` as "no filter". Contrast with [`append_in_filter`], which
+/// renders `Some(&[])` as `AND 1 = 0`.
+///
+/// Precondition: `sql` ends inside an open WHERE clause — callers anchor with
+/// `MATCH ?` (FTS path) or a trailing `IN (...)` (vec path) so the leading
+/// ` AND ` from amici helpers attaches cleanly.
+pub(super) fn append_chunk_type_filter(
+    sql: &mut String,
+    params: &mut Vec<Box<dyn ToSql>>,
+    column: &'static str,
+    types: Option<&[ChunkType]>,
+) {
+    let Some(types) = types.filter(|t| !t.is_empty()) else {
+        return;
+    };
+    let strings: Vec<String> = types.iter().map(|c| c.as_str().to_owned()).collect();
+    append_in_filter(sql, params, column, Some(&strings));
+}
+
+pub fn get_chunk_by_id(conn: &Connection, chunk_id: i64) -> Result<Option<Chunk>, StorageError> {
+    let mut stmt = conn.prepare_cached(
+        "SELECT file_path, chunk_type, name, content, start_line, end_line, parent_chunk_id, source_kind, injection_flags
+         FROM chunks WHERE id = ?1",
+    )?;
+    match stmt.query_row([chunk_id], |row| chunk_from_row(row, 0)) {
+        Ok(chunk) => Ok(Some(chunk)),
+        Err(RusqliteError::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Bulk-fetch chunk metadata by ids with optional type/path filters applied
+/// at the SQL layer. Shared by [`super::vec_search`], [`super::vec_search_multi`], and
+/// callers that need a plain id→chunk lookup.
+pub fn get_chunks_by_ids(
+    conn: &Connection,
+    ids: &[i64],
+    type_filter: Option<&[ChunkType]>,
+    path_filter: &[String],
+) -> Result<HashMap<i64, Chunk>, StorageError> {
+    if ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let mut sql = format!(
+        "SELECT id, file_path, chunk_type, name, content, start_line, end_line, parent_chunk_id, source_kind, injection_flags \
+         FROM chunks WHERE id IN ({})",
+        anon_placeholders(ids.len())
+    );
+    let mut params: Vec<Box<dyn ToSql>> = ids
+        .iter()
+        .map(|id| Box::new(*id) as Box<dyn ToSql>)
+        .collect();
+    append_like_prefix_filter(&mut sql, &mut params, "file_path", path_filter);
+    append_chunk_type_filter(&mut sql, &mut params, "chunk_type", type_filter);
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_from_iter(params.iter()), |row| {
+        Ok((row.get::<_, i64>(0)?, chunk_from_row(row, 1)?))
+    })?;
+    rows.collect::<Result<HashMap<_, _>, _>>()
+        .map_err(Into::into)
+}
+
+/// Bulk-fetch every Chunk (with body content) belonging to the given files.
+/// Output is sorted by `(file_path, start_line)` so brief expansion can apply
+/// topological ordering on top without an extra sort pass.
+pub fn get_chunks_for_files(conn: &Connection, paths: &[&str]) -> Result<Vec<Chunk>, StorageError> {
+    if paths.is_empty() {
+        return Ok(Vec::new());
+    }
+    let placeholders = in_placeholders(paths.len());
+    let sql = format!(
+        "SELECT file_path, chunk_type, name, content, start_line, end_line, parent_chunk_id, source_kind, injection_flags
+         FROM chunks WHERE file_path IN ({placeholders})
+         ORDER BY file_path, start_line"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_from_iter(paths.iter()), |row| chunk_from_row(row, 0))?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+}
+
+pub fn get_chunks_for_from_target(
+    conn: &Connection,
+    file_path: &str,
+    symbol: Option<&str>,
+) -> Result<Vec<i64>, StorageError> {
+    let mut sql = String::from(
+        "SELECT id FROM chunks \
+         WHERE file_path = ?1 AND chunk_type != 'inner_fn'",
+    );
+    if symbol.is_some() {
+        sql.push_str(" AND name = ?2");
+    }
+
+    let mut stmt = conn.prepare(&sql)?;
+    let ids = if let Some(sym) = symbol {
+        stmt.query_map(params![file_path, sym], |row| row.get::<_, i64>(0))?
+            .collect::<Result<Vec<_>, _>>()?
+    } else {
+        stmt.query_map([file_path], |row| row.get::<_, i64>(0))?
+            .collect::<Result<Vec<_>, _>>()?
+    };
+    Ok(ids)
+}

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -4881,6 +4881,32 @@ fn get_chunk_by_id_projects_source_kind_and_injection_flags() {
     );
 }
 
+// T-709: get_chunks_by_ids_empty_ids_returns_empty_map
+//
+// Perspective: Boundary (empty input short-circuits before any query).
+#[test]
+fn get_chunks_by_ids_empty_ids_returns_empty_map() {
+    let (conn, _dir) = test_db();
+    let map = get_chunks_by_ids(&conn, &[], None, &[]).unwrap();
+    assert!(
+        map.is_empty(),
+        "empty id list yields empty map without a query"
+    );
+}
+
+// T-710: get_chunks_for_files_empty_paths_returns_empty
+//
+// Perspective: Boundary (empty input short-circuits before any query).
+#[test]
+fn get_chunks_for_files_empty_paths_returns_empty() {
+    let (conn, _dir) = test_db();
+    let chunks = get_chunks_for_files(&conn, &[]).unwrap();
+    assert!(
+        chunks.is_empty(),
+        "empty path list yields empty vec without a query"
+    );
+}
+
 // T-304: get_chunks_by_ids_projects_source_kind_and_injection_flags
 //
 // Perspective: Equivalence (3 rows, each fully populated) + Boundary (offset 1


### PR DESCRIPTION
500 行の `storage/search.rs` を #255 file-size gate (400 行) 内に収めるため、chunk 行取得層を子モジュール `fetch` へ verbatim 抽出。#137 (RC-009) 分割キャンペーンの 5 本目（残りは `indexer/chunker/ts.rs` の 1 本）。

## 変更

- `src/storage/search/fetch.rs` (148): `chunk_from_row` + `append_chunk_type_filter`（共有 helper, `pub(super)`）+ `get_chunk_by_id` / `get_chunks_by_ids` / `get_chunks_for_files` / `get_chunks_for_from_target`（getter, `pub`）
- `search.rs`: 500 → 373 行。vector(semantic) と FTS は残置し、`fetch::` 経由で helper/getter を呼ぶ
- `pub use fetch::{...}` で再公開 → `storage::<fn>` 外部パスと storage::tests の `use super::*` は無改変
- `T-709` / `T-710`: get_chunks_by_ids / get_chunks_for_files の空入力境界を単体テスト化
- `.github/workflows/ci.yml`: file-size gate allowlist から `src/storage/search.rs` を除去

関数本体は verbatim 移動（diff: vector/FTS は無変更 context、削除＋fetch:: 配線のみ）。

## 抽出 cut の選定理由

素直な vector/FTS/fetch の 3-way ではなく fetch 層のみ抽出。vector と FTS は hermetic test で trigger 不能な防御分岐（vector の >30k truncation guard、FTS の bulk doc-freq fallback ~17 行）を持ち、子ファイルへ抽出すると diff-cover の「追加行」として gated 化し ~86-92% 上限で 95% floor に到達不能（lcov の per-file LF/LH で実測）。被覆率の高い fetch 層を抽出し、vector/FTS は search.rs に context 残置（pre-split と同じ未カバー状態を維持）。

## 検証

- `cargo clippy --all-targets --all-features -p yomu -- -D warnings` clean
- `cargo fmt -- --check` clean
- `cargo nextest run --profile ci --features test-support -p yomu` 723 pass
- diff-cover 97.8%（search.rs 100% / fetch.rs 97.8%、残 2 行は get_chunk_by_id の `?`/Err DB-error 防御で untestable）
- `cargo check --workspace` clean
- file-size gate exit 0（allowlist 残 `ts.rs` のみ）

## 監査（/audit）

10 reviewer → critic-audit → critic-evidence。fix-now 3 件を適用（全て新 fetch.rs の doc）: cross-module 化した intra-doc link を `super::` 修飾（cargo doc 警告消失を実測）、chunk_from_row に 9 列 offset 契約 doc、module doc を正確化。critic が reviewer の誤りを 2 件 refute（T-709/710 は `IN ()` 構文エラーで falsify 可能・健全 / get_chunk_by_id None は T-538 でカバー済）。

## フォローアップ

`append_chunk_type_filter` は FTS/fetch 共用だが被覆率維持のため fetch.rs に同梱（FTS が `fetch::` 経由で呼ぶ）。coverage 制約が緩めば search.rs の sibling filter 群に戻す（restructure は別 issue）。

Refs #137