### PR TITLE
refactor(yomu): ts.rs から import 解析を子モジュールへ分離し allowlist を空に (#137)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,16 @@ jobs:
       # File-size ratchet gate (#255): block re-bloat of the yomu crate's src/
       # past the THRESHOLDS file ceiling (sibling crates/ are out of scope).
       # Runs before the build for fast feedback and lives in this required job
-      # so it blocks merge. Pre-existing oversized files are grandfathered in
-      # `allowlist`; once a file is split below the ceiling the gate forces its
-      # removal from the list, so the ratchet cannot silently rot — analogous
-      # to the self-expiring `#[expect(clippy::too_many_lines)]` in src/main.rs.
+      # so it blocks merge. Pre-existing oversized files were grandfathered in
+      # `allowlist` and split below the ceiling over #137; the list is now empty,
+      # so every src/ file is at or under the ceiling. Step 2 self-cleans the
+      # list (forcing removal once an allowlisted file shrinks), so the ratchet
+      # cannot silently rot — analogous to the self-expiring
+      # `#[expect(clippy::too_many_lines)]` in src/main.rs.
       - name: File size gate
         run: |
           threshold=400
-          allowlist="src/indexer/chunker/ts.rs"
+          allowlist=""
           fail=0
           # 1. New or regrown source files over the ceiling fail (tests excluded).
           while IFS= read -r f; do

--- a/src/indexer/chunker/ts.rs
+++ b/src/indexer/chunker/ts.rs
@@ -3,28 +3,20 @@ use crate::storage::ChunkType;
 use tree_sitter::{Node, Parser};
 
 use super::{
-    FileChunks, ImportKind, ImportSpecifier, ParsedImport, RawChunk, ReExport,
-    attach_pending_comments, chunk_fallback, classify_function, extract_inner_functions,
-    extract_name, find_child_by_kind, make_chunk, make_parser, other_or_skip,
-    should_extract_subchunks,
+    FileChunks, RawChunk, ReExport, attach_pending_comments, chunk_fallback, classify_function,
+    extract_inner_functions, extract_name, find_child_by_kind, make_chunk, make_parser,
+    other_or_skip, should_extract_subchunks,
 };
 
-fn has_type_keyword(node: &Node) -> bool {
-    let mut cursor = node.walk();
-    node.children(&mut cursor)
-        .any(|child| !child.is_named() && child.kind() == "type")
-}
+mod imports;
+
+#[cfg(test)]
+use super::ParsedImport;
 
 fn has_star_export(node: &Node) -> bool {
     let mut cursor = node.walk();
     node.children(&mut cursor)
         .any(|c| c.kind() == "*" || c.kind() == "namespace_export")
-}
-
-fn extract_import_source(node: &Node, source: &str) -> Option<String> {
-    let string_node = find_child_by_kind(node, "string")?;
-    let fragment = find_child_by_kind(&string_node, "string_fragment")?;
-    Some(source[fragment.byte_range()].to_owned())
 }
 
 fn extract_export_source(node: &Node, source: &str) -> Option<String> {
@@ -41,100 +33,6 @@ fn extract_specifier_name(spec: &Node, source: &str) -> Option<String> {
     spec.child_by_field_name("name")
         .or_else(|| find_child_by_kind(spec, "identifier"))
         .map(|n| source[n.byte_range()].to_string())
-}
-
-fn parse_import_specifier(
-    node: &Node,
-    source: &str,
-    is_type_import: bool,
-) -> Option<ImportSpecifier> {
-    let has_inline_type = has_type_keyword(node);
-    let mut identifiers: Vec<String> = Vec::new();
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        if child.kind() == "identifier" {
-            identifiers.push(source[child.byte_range()].to_string());
-        }
-    }
-    let (name, alias) = match identifiers.len() {
-        0 => return None,
-        1 => (identifiers.remove(0), None),
-        _ => {
-            let name = identifiers.remove(0);
-            let alias = Some(identifiers.remove(0));
-            (name, alias)
-        }
-    };
-    let kind = if is_type_import || has_inline_type {
-        ImportKind::TypeOnly
-    } else {
-        ImportKind::Named
-    };
-    Some(ImportSpecifier { name, alias, kind })
-}
-
-fn parse_named_imports_node(
-    node: &Node,
-    source: &str,
-    is_type_import: bool,
-    specifiers: &mut Vec<ImportSpecifier>,
-) {
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        if child.kind() == "import_specifier"
-            && let Some(spec) = parse_import_specifier(&child, source, is_type_import)
-        {
-            specifiers.push(spec);
-        }
-    }
-}
-
-fn parse_import_clause(clause: &Node, source: &str, is_type_import: bool) -> Vec<ImportSpecifier> {
-    let mut specifiers = Vec::new();
-    let mut cursor = clause.walk();
-    for child in clause.children(&mut cursor) {
-        match child.kind() {
-            "identifier" => {
-                let name = source[child.byte_range()].to_string();
-                let kind = if is_type_import {
-                    ImportKind::TypeOnly
-                } else {
-                    ImportKind::Default
-                };
-                specifiers.push(ImportSpecifier {
-                    name,
-                    alias: None,
-                    kind,
-                });
-            }
-            "named_imports" => {
-                parse_named_imports_node(&child, source, is_type_import, &mut specifiers);
-            }
-            "namespace_import" => {
-                let alias = find_child_by_kind(&child, "identifier")
-                    .map(|id| source[id.byte_range()].to_string());
-                specifiers.push(ImportSpecifier {
-                    name: "*".to_owned(),
-                    alias,
-                    kind: ImportKind::Namespace,
-                });
-            }
-            _ => {}
-        }
-    }
-    specifiers
-}
-
-fn parse_single_import(node: &Node, source: &str) -> Option<ParsedImport> {
-    let source_path = extract_import_source(node, source)?;
-    let is_type_import = has_type_keyword(node);
-    let specifiers = find_child_by_kind(node, "import_clause").map_or_else(Vec::new, |clause| {
-        parse_import_clause(&clause, source, is_type_import)
-    });
-    Some(ParsedImport {
-        specifiers,
-        source: source_path,
-    })
 }
 
 fn classify_lexical_declaration(node: &Node, source: &str) -> (ChunkType, Option<String>) {
@@ -273,7 +171,7 @@ fn chunk_js_like_with_imports(source: &str, parser: &mut Parser) -> FileChunks {
     for node in root.children(&mut cursor) {
         if node.kind() == "import_statement" {
             imports.push(source[node.byte_range()].to_string());
-            if let Some(pi) = parse_single_import(&node, source) {
+            if let Some(pi) = imports::parse_single_import(&node, source) {
                 parsed_imports.push(pi);
             }
             pending_comments.clear();
@@ -368,7 +266,7 @@ fn parse_imports_from_ast(source: &str, parser: &mut Parser) -> Vec<ParsedImport
     let mut cursor = root.walk();
     root.children(&mut cursor)
         .filter(|node| node.kind() == "import_statement")
-        .filter_map(|node| parse_single_import(&node, source))
+        .filter_map(|node| imports::parse_single_import(&node, source))
         .collect()
 }
 

--- a/src/indexer/chunker/ts/imports.rs
+++ b/src/indexer/chunker/ts/imports.rs
@@ -1,0 +1,113 @@
+//! TypeScript/JavaScript import-statement parsing: walks an `import_statement`
+//! AST node into a [`ParsedImport`] (source path + [`ImportSpecifier`] list),
+//! handling default, named, namespace, and inline/statement `type` imports.
+
+use tree_sitter::Node;
+
+use super::super::{ImportKind, ImportSpecifier, ParsedImport, find_child_by_kind};
+
+fn has_type_keyword(node: &Node) -> bool {
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .any(|child| !child.is_named() && child.kind() == "type")
+}
+
+fn extract_import_source(node: &Node, source: &str) -> Option<String> {
+    let string_node = find_child_by_kind(node, "string")?;
+    let fragment = find_child_by_kind(&string_node, "string_fragment")?;
+    Some(source[fragment.byte_range()].to_owned())
+}
+
+fn parse_import_specifier(
+    node: &Node,
+    source: &str,
+    is_type_import: bool,
+) -> Option<ImportSpecifier> {
+    let has_inline_type = has_type_keyword(node);
+    let mut identifiers: Vec<String> = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "identifier" {
+            identifiers.push(source[child.byte_range()].to_string());
+        }
+    }
+    let (name, alias) = match identifiers.len() {
+        0 => return None,
+        1 => (identifiers.remove(0), None),
+        _ => {
+            let name = identifiers.remove(0);
+            let alias = Some(identifiers.remove(0));
+            (name, alias)
+        }
+    };
+    let kind = if is_type_import || has_inline_type {
+        ImportKind::TypeOnly
+    } else {
+        ImportKind::Named
+    };
+    Some(ImportSpecifier { name, alias, kind })
+}
+
+fn parse_named_imports_node(
+    node: &Node,
+    source: &str,
+    is_type_import: bool,
+    specifiers: &mut Vec<ImportSpecifier>,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "import_specifier"
+            && let Some(spec) = parse_import_specifier(&child, source, is_type_import)
+        {
+            specifiers.push(spec);
+        }
+    }
+}
+
+fn parse_import_clause(clause: &Node, source: &str, is_type_import: bool) -> Vec<ImportSpecifier> {
+    let mut specifiers = Vec::new();
+    let mut cursor = clause.walk();
+    for child in clause.children(&mut cursor) {
+        match child.kind() {
+            "identifier" => {
+                let name = source[child.byte_range()].to_string();
+                let kind = if is_type_import {
+                    ImportKind::TypeOnly
+                } else {
+                    ImportKind::Default
+                };
+                specifiers.push(ImportSpecifier {
+                    name,
+                    alias: None,
+                    kind,
+                });
+            }
+            "named_imports" => {
+                parse_named_imports_node(&child, source, is_type_import, &mut specifiers);
+            }
+            "namespace_import" => {
+                let alias = find_child_by_kind(&child, "identifier")
+                    .map(|id| source[id.byte_range()].to_string());
+                specifiers.push(ImportSpecifier {
+                    name: "*".to_owned(),
+                    alias,
+                    kind: ImportKind::Namespace,
+                });
+            }
+            _ => {}
+        }
+    }
+    specifiers
+}
+
+pub(super) fn parse_single_import(node: &Node, source: &str) -> Option<ParsedImport> {
+    let source_path = extract_import_source(node, source)?;
+    let is_type_import = has_type_keyword(node);
+    let specifiers = find_child_by_kind(node, "import_clause").map_or_else(Vec::new, |clause| {
+        parse_import_clause(&clause, source, is_type_import)
+    });
+    Some(ParsedImport {
+        specifiers,
+        source: source_path,
+    })
+}


### PR DESCRIPTION
421 行の `indexer/chunker/ts.rs` を #255 file-size gate (400 行) 内に収めるため、import 文解析を子モジュール `imports` へ verbatim 抽出。**#137 (RC-009) 分割キャンペーンの最終 PR** で、file-size gate allowlist が空になり ratchet が完遂します。

## 変更

- `src/indexer/chunker/ts/imports.rs` (113): import 文解析 6 関数（`parse_single_import` のみ `pub(super)`、他 5 つ private）
- `ts.rs`: 421 → 319 行。`imports::parse_single_import` 経由で呼ぶ。`ParsedImport` は抽出後 cfg(test) 専用化したため `#[cfg(test)] use` でゲート
- `.github/workflows/ci.yml`: allowlist から ts.rs を除去 → 空。コメントを完遂状態に更新

関数本体は verbatim 移動。`imports` は chunker の孫モジュールで、`super::super::` で `ImportKind` 等と private な `find_child_by_kind` を参照（子孫は祖先 private を参照可）。

## 抽出 cut の選定理由

分割前に lcov の per-cluster 被覆率を実測し、untestable な parser/make_parser 失敗分岐を持たない import cluster（zero-hit 2 行）を選択。reexport/chunking/public（parser 失敗分岐持ち）は context 残置。storage/search では cut 選定を誤りピボットが必要だったが、本 PR は事前計測で一発通過。

## 検証

- `cargo clippy --all-targets --all-features -p yomu -- -D warnings` clean
- `cargo fmt -- --check` clean
- `cargo nextest run --profile ci --features test-support -p yomu` 723 pass
- diff-cover 97.7%（ts.rs 100% / imports.rs 97.7%、残 2 行は到達不能 edge）
- `cargo check --workspace` clean
- file-size gate exit 0（allowlist 空、全 src ≤400）

## 監査（/audit）

10 reviewer → critic-audit → critic-evidence で 0 fix-now。導入回帰なし（cfg(test) ゲート idiomatic・super::super 正当・ci.yml 正確）。検出した実 gap（mixed default+named import 等の shape テスト未整備・find_child_by_kind の可視性 honesty）は pre-existing behavioral gap として followup へ分離。

## フォローアップ

import shape のテスト被覆（mixed default+named / inline-type+alias / type-namespace）+ `find_child_by_kind` の `pub(super)` 化 + 軽微な明確化コメント。別 issue。

## キャンペーン完遂

| PR | ファイル | 抽出 |
|----|---------|------|
| #264 | query.rs | keyword/rank |
| #265 | tools/format.rs | render |
| #266 | brief.rs | cap/topo |
| #267 | storage/search.rs | fetch 層 |
| 本PR | indexer/chunker/ts.rs | import 解析 |

全 src ファイルが 400 行以下、file-size gate allowlist が空になります。

Refs #137