### PR TITLE
refactor(yomu): Yomu::search を validate/run/notes の seam に分解 (#137)

### DIFF
--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -22,22 +22,10 @@ impl Yomu {
         json: bool,
         from_target: Option<&str>,
     ) -> Result<String, YomuError> {
-        if let Some(q) = query {
-            if q.is_empty() {
-                return Err(YomuError::InvalidInput(InvalidInputKind::EmptyQuery));
-            }
-            if q.len() > MAX_QUERY_LENGTH {
-                return Err(YomuError::InvalidInput(InvalidInputKind::QueryTooLong {
-                    max: MAX_QUERY_LENGTH,
-                    actual: q.len(),
-                }));
-            }
-        }
-
+        validate_search_query(query)?;
         for path in paths {
             validate_path(path)?;
         }
-
         let limit = limit.min(MAX_SEARCH_LIMIT);
 
         if let Some(from) = from_target {
@@ -47,13 +35,27 @@ impl Yomu {
 
         let query =
             query.ok_or_else(|| YomuError::InvalidInput(InvalidInputKind::QueryOrFromRequired))?;
-
-        let embedder = self.get_embedder();
         let offset = offset.min(MAX_SEARCH_OFFSET);
 
-        tracing::debug!(query, limit, offset, ?paths, "search request");
-
         let stats = self.with_db(storage::get_stats)?;
+        let outcome = self.run_search_query(query, limit, offset, paths)?;
+        let notes = self.build_search_notes(&stats, outcome.degraded);
+
+        self.format_search_results(&outcome.results, &stats, notes, json, outcome.degraded)
+    }
+
+    /// Runs the embedding-backed query and emits the query log when enabled,
+    /// isolating the DB + timing path from `search`'s validation and note
+    /// assembly so each part is testable on its own (RC-009 test seam).
+    fn run_search_query(
+        &self,
+        query: &str,
+        limit: u32,
+        offset: u32,
+        paths: &[String],
+    ) -> Result<query::SearchOutcome, YomuError> {
+        let embedder = self.get_embedder();
+        tracing::debug!(query, limit, offset, ?paths, "search request");
 
         let start = Instant::now();
         let outcome = query::search(
@@ -70,9 +72,14 @@ impl Yomu {
             let latency_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
             self.emit_query_log(query, &outcome, latency_ms);
         }
+        Ok(outcome)
+    }
 
+    /// Assembles the user-facing advisory notes (index-coverage hint, reranker
+    /// status, degraded-embedding warning) appended to search output.
+    fn build_search_notes(&self, stats: &storage::IndexStatus, degraded: bool) -> Vec<String> {
         let mut notes: Vec<String> = Vec::new();
-        if let Some(msg) = index_hint(&stats) {
+        if let Some(msg) = index_hint(stats) {
             notes.push(msg);
         }
         if let Some(note) = self.reranker_note() {
@@ -82,11 +89,10 @@ impl Yomu {
             if let Some(note) = degraded_reason_user_note(*reason, "yomu model download") {
                 notes.push(note);
             }
-        } else if outcome.degraded {
+        } else if degraded {
             notes.push("embedding model not loaded; results from text search only".into());
         }
-
-        self.format_search_results(&outcome.results, &stats, notes, json, outcome.degraded)
+        notes
     }
 
     fn search_from(
@@ -190,4 +196,22 @@ impl Yomu {
         }
         self.with_db(move |conn| storage::get_chunks_by_ids(conn, &parent_ids, None, &[]))
     }
+}
+
+/// Rejects an empty or over-length query before any DB work. Returns `Ok(())`
+/// when no query is supplied; the `--from` path validates its target separately.
+pub(super) fn validate_search_query(query: Option<&str>) -> Result<(), YomuError> {
+    let Some(q) = query else {
+        return Ok(());
+    };
+    if q.is_empty() {
+        return Err(YomuError::InvalidInput(InvalidInputKind::EmptyQuery));
+    }
+    if q.len() > MAX_QUERY_LENGTH {
+        return Err(YomuError::InvalidInput(InvalidInputKind::QueryTooLong {
+            max: MAX_QUERY_LENGTH,
+            actual: q.len(),
+        }));
+    }
+    Ok(())
 }

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -116,6 +116,23 @@ fn search_rejects_long_query() {
     );
 }
 
+// T-711: validate_search_query accepts an at-limit query and a missing query
+// (complements T-175 empty / T-176 over-limit: the reject boundary is MAX + 1,
+// so MAX itself must pass; None defers to the `--from` path).
+#[test]
+fn validate_search_query_accepts_at_limit_and_none() {
+    use super::search::validate_search_query;
+    let at_limit = "a".repeat(MAX_QUERY_LENGTH);
+    assert!(
+        validate_search_query(Some(&at_limit)).is_ok(),
+        "a query of exactly MAX_QUERY_LENGTH must be accepted"
+    );
+    assert!(
+        validate_search_query(None).is_ok(),
+        "a missing query is validated by the --from path, not here"
+    );
+}
+
 // T-177: search_rejects_path_traversal
 #[test]
 fn search_rejects_path_traversal() {


### PR DESCRIPTION
## なぜ

#137 (RC-009) DES-002。`Yomu::search` は 75 行で、入力検証 → embedding 検索 (DB/timing) → notes 組立 → format が 1 関数に同居し、受け入れ基準「全 fn ≤30 行」を超過。各相を単体テストする seam も無かった。

## 変更内容

`search` を 3 つの seam に分解し、オーケストレーション 30 行に圧縮:

- `validate_search_query` (pure free fn, `pub(super)`): query 検証。境界 accept (ちょうど `MAX_QUERY_LENGTH`) と None を **T-711** で直接テスト (reject 側は既存 T-175/T-176)。
- `run_search_query`: embedder + `query::search` + query-log の DB/timing 経路を隔離。
- `build_search_notes`: index-hint / reranker / degraded の note 組立を隔離 (nested `if` は `else if` の係り先保持のため原形維持)。

format 層は既存の `super::format::*` (pure) へ委譲済み。

## 検証

- `cargo nextest run --profile ci --features test-support -p yomu`: 724 passed
- diff-cover: 100% (34 changed lines, 0 missing)
- clippy `--all-targets --all-features -D warnings` / `cargo fmt --check`: clean
- `Yomu::search` 30 行 / `src/tools/search.rs` 217 行 (≤400)

## レビュー観点

behavior 不変のリファクタ。次の 2 点を確認ください:

- `build_search_notes` の `else if degraded` の係り先が outer `if let Some(reason)` に binding されている (degraded_reason が Some で inner note が None のとき generic note を push しない)
- `search_from` を**意図的に変更していない** (note 非対称は pre-existing。本 PR のスコープ外)

## audit 結果

`/audit` = **0 fix-now** (reviewer 9 + critic-audit + critic-evidence)。唯一の P1 (search_from の reranker note 欠落) は両 critic が「pre-existing・本コミット未変更」とトレースで反証。design の inline 提案は #137 の fn≤30 mandate と矛盾 (inline で 39-48 行に逆戻り) として却下。

繰延 follow-up: `build_search_notes` の pure 化 (有効だが被覆済み) / `--from` の note 非対称 (設計判断) / doc 補足。

Refs #137
