### PR TITLE
refactor(yomu): Yomu::impact を validate/gather/render の seam に分解 (#137)

### DIFF
--- a/src/tools/impact.rs
+++ b/src/tools/impact.rs
@@ -10,6 +10,19 @@ use super::{
 
 const SEMANTIC_THRESHOLD: f32 = 0.7;
 
+/// The data `Yomu::impact` gathers for one target before rendering: index
+/// presence, transitive + symbol dependents, grouped direct references, and
+/// semantically-related files. Bundling the DB results lets the fetch and
+/// render seams pass one value instead of a long argument list.
+#[derive(Debug)]
+struct ImpactReport {
+    file_in_index: bool,
+    dependents: Vec<storage::Dependent>,
+    symbol_refs: Vec<String>,
+    direct_refs: HashMap<String, Vec<storage::DirectReference>>,
+    semantic_related: Vec<storage::SearchResult>,
+}
+
 impl Yomu {
     /// Lexicographically-first `max` indexed file paths. Used to populate
     /// `EmptyTarget.candidates` when impact is invoked with an empty target
@@ -35,12 +48,7 @@ impl Yomu {
         json: bool,
         semantic: bool,
     ) -> Result<String, YomuError> {
-        if target.is_empty() {
-            let candidates = self.first_indexed_paths(MAX_EMPTY_TARGET_CANDIDATES);
-            return Err(YomuError::InvalidInput(InvalidInputKind::EmptyTarget {
-                candidates,
-            }));
-        }
+        self.require_nonempty_target(target)?;
 
         let stats = self.with_db(storage::get_stats)?;
         if stats.total_chunks == 0 {
@@ -48,14 +56,45 @@ impl Yomu {
         }
 
         let (file_path, parsed_symbol) = parse_impact_target(target);
-
         validate_path(file_path)?;
-
         let symbol_filter = symbol.or(parsed_symbol);
         let max_depth = depth.min(MAX_IMPACT_DEPTH);
+
+        let report = self.gather_impact_report(file_path, symbol_filter, max_depth, semantic)?;
+        Ok(render_impact_output(
+            target,
+            file_path,
+            &report,
+            symbol_filter,
+            json,
+        ))
+    }
+
+    /// Rejects an empty impact target, surfacing the first indexed paths as
+    /// candidates so the caller can correct the argument (#197, FR-004 / BR-002).
+    fn require_nonempty_target(&self, target: &str) -> Result<(), YomuError> {
+        if target.is_empty() {
+            let candidates = self.first_indexed_paths(MAX_EMPTY_TARGET_CANDIDATES);
+            return Err(YomuError::InvalidInput(InvalidInputKind::EmptyTarget {
+                candidates,
+            }));
+        }
+        Ok(())
+    }
+
+    /// Gathers everything `impact` reports on for one target, isolating the DB
+    /// access from the orchestration and rendering. The four graph queries run
+    /// in one `with_db` transaction; the semantic pass is a separate query made
+    /// only when requested.
+    fn gather_impact_report(
+        &self,
+        file_path: &str,
+        symbol_filter: Option<&str>,
+        max_depth: u32,
+        semantic: bool,
+    ) -> Result<ImpactReport, YomuError> {
         let fp = file_path.to_owned();
         let sym_owned = symbol_filter.map(str::to_owned);
-
         let (file_in_index, dependents, symbol_refs, direct_refs) = self.with_db(move |conn| {
             let exists = storage::file_exists_in_index(conn, &fp)?;
             let dependents = storage::get_transitive_dependents(conn, &fp, max_depth)?;
@@ -77,38 +116,13 @@ impl Yomu {
             vec![]
         };
 
-        if json {
-            let (degraded, notes) = never_degraded();
-            return Ok(format_impact_json(
-                target,
-                file_in_index,
-                &dependents,
-                &direct_refs,
-                &symbol_refs,
-                &semantic_related,
-                degraded,
-                notes,
-            ));
-        }
-
-        if dependents.is_empty() && semantic_related.is_empty() {
-            return Ok(if file_in_index {
-                format!("No dependents found for `{}`.", target)
-            } else {
-                format!(
-                    "`{}` not found in index. Run `yomu index` to update.",
-                    file_path
-                )
-            });
-        }
-
-        let text = if symbol_filter.is_some() {
-            format_impact_results(target, &symbol_refs, &dependents, &semantic_related)
-        } else {
-            format_impact_all(target, &dependents, &semantic_related)
-        };
-
-        Ok(text)
+        Ok(ImpactReport {
+            file_in_index,
+            dependents,
+            symbol_refs,
+            direct_refs,
+            semantic_related,
+        })
     }
 
     fn semantic_search(
@@ -134,5 +148,54 @@ impl Yomu {
         let mut seen: HashSet<String> = HashSet::new();
         results.retain(|r| seen.insert(r.chunk.file_path.clone()));
         Ok(results)
+    }
+}
+
+/// Renders a gathered [`ImpactReport`] to the user-facing string: JSON when
+/// requested; an empty-result message (no dependents found, or the target not
+/// in the index) when there is nothing to show; otherwise the symbol-scoped vs
+/// whole-file view. Pure (depends only on its arguments), so it is
+/// unit-testable without a DB.
+fn render_impact_output(
+    target: &str,
+    file_path: &str,
+    report: &ImpactReport,
+    symbol_filter: Option<&str>,
+    json: bool,
+) -> String {
+    if json {
+        let (degraded, notes) = never_degraded();
+        return format_impact_json(
+            target,
+            report.file_in_index,
+            &report.dependents,
+            &report.direct_refs,
+            &report.symbol_refs,
+            &report.semantic_related,
+            degraded,
+            notes,
+        );
+    }
+
+    if report.dependents.is_empty() && report.semantic_related.is_empty() {
+        return if report.file_in_index {
+            format!("No dependents found for `{}`.", target)
+        } else {
+            format!(
+                "`{}` not found in index. Run `yomu index` to update.",
+                file_path
+            )
+        };
+    }
+
+    if symbol_filter.is_some() {
+        format_impact_results(
+            target,
+            &report.symbol_refs,
+            &report.dependents,
+            &report.semantic_related,
+        )
+    } else {
+        format_impact_all(target, &report.dependents, &report.semantic_related)
     }
 }


### PR DESCRIPTION
## なぜ

#137 (RC-009) DES-003。`Yomu::impact` は 83 行で、empty-target 検証 → DB 集約（4 グラフクエリ + semantic）→ 出力 render が 1 関数に同居し、受け入れ基準「全 fn ≤30 行」を超過。各相を単体テストする seam も無かった。

## 変更内容

`impact` を 3 つの seam + 1 struct に分解し、オーケストレーション 29 行に圧縮:

- `require_nonempty_target`: empty-target ガード（候補提示）。
- `gather_impact_report`: 4 グラフクエリ（1 transaction）+ semantic を `ImpactReport` struct に集約。4-tuple を named struct 化（LANG.md の tuple→struct）。
- `render_impact_output`（pure free fn）: json / empty-result / symbol-scoped vs whole-file の出力選択。DB 不要で単体テスト可能。

`ImpactReport` は DB から gather した結果のみを束ねる（入力の `target` / `file_path` は分離維持）。

## 検証

- `cargo nextest run --profile ci --features test-support -p yomu`: 724 passed
- diff-cover: 100% (67 changed lines, 0 missing)
- clippy `--all-targets --all-features -D warnings` / `cargo fmt --check`: clean
- `Yomu::impact` 29 行 / `src/tools/impact.rs` 201 行 (≤400)

## レビュー観点

behavior 不変のリファクタ。次を確認ください:

- `gather_impact_report` 内で `semantic_search` が DB closure の**後**に別 transaction で走る（元の順序を保持）。`symbol_filter` は元と同値。
- empty-result 分岐は no-dependents と not-indexed の 2 メッセージに分岐（doc に両方明記）。

## audit 結果

`/audit` で reviewer 9 + critic-audit + critic-evidence を実施。**3 fix-now を適用済み**:

- `ImpactReport` に `#[derive(Debug)]`（storage 層 data 構造体の peer pattern に整合）
- `render_impact_output` doc の不正確を修正（not-indexed ケース明記）
- `gather_impact_report` の引数名 `symbol` → `symbol_filter`（呼び出し側と統一）

param 数（render 5 / gather 4 vs ≤3 guideline）の struct 畳み込み提案は、入力を結果 struct に混ぜ cohesion を壊すため両 critic が却下。doc の what-comment 指摘も bundling/seam の why を保持として却下。

繰延 follow-up: `semantic_search`/`search_from` の共有 fetch（3rd caller 出現時）/ format.rs の serde 構造体の Debug 欠落（pre-existing、別 hygiene PR）。

Refs #137
