### PR TITLE
refactor(yomu): chunker の chunk_rust/use-list 解析を ≤30 関数へ分解 (#137)

### DIFF
--- a/src/indexer/chunker/rust.rs
+++ b/src/indexer/chunker/rust.rs
@@ -41,69 +41,80 @@ fn extract_impl_methods(impl_node: &Node, source: &str, impl_index: usize) -> Ve
     result
 }
 
+/// An [`ImportSpecifier`] with no alias — the common shape for a `use` leaf, a
+/// `*` glob, or a `mod` declaration. `use x as y` builds its specifier inline
+/// because it carries an alias.
+fn simple_specifier(name: String, kind: ImportKind) -> ImportSpecifier {
+    ImportSpecifier {
+        name,
+        alias: None,
+        kind,
+    }
+}
+
+/// A `a::b` member *inside* a `use` list (e.g. `bar::Baz` in
+/// `use crate::foo::{bar::Baz, Quux}`). Unlike [`parse_scoped_identifier`], the
+/// enclosing `use` was already `is_internal_path`-filtered, so this re-roots the
+/// member under `base_path` without re-checking internality.
+fn scoped_identifier_import(base_path: &str, node: &Node, source: &str) -> Option<ParsedImport> {
+    let path_node = node.child_by_field_name("path")?;
+    let name_node = node.child_by_field_name("name")?;
+    let nested_path = format!("{}::{}", base_path, &source[path_node.byte_range()]);
+    Some(ParsedImport {
+        source: nested_path,
+        specifiers: vec![simple_specifier(
+            source[name_node.byte_range()].to_owned(),
+            ImportKind::Named,
+        )],
+    })
+}
+
+/// A nested `a::{...}` group *inside* a `use` list (e.g. `bar::{Baz, Qux}` in
+/// `use crate::foo::{bar::{Baz, Qux}}`). Re-roots under `base_path` and recurses
+/// into [`collect_use_list_imports`]; like [`scoped_identifier_import`] it skips
+/// the `is_internal_path` check that top-level [`parse_scoped_use_list`] applies.
+fn scoped_use_list_imports(base_path: &str, node: &Node, source: &str) -> Vec<ParsedImport> {
+    node.child_by_field_name("path")
+        .zip(node.child_by_field_name("list"))
+        .map(|(inner_path, inner_list)| {
+            let nested_path = format!("{}::{}", base_path, &source[inner_path.byte_range()]);
+            collect_use_list_imports(&nested_path, &inner_list, source)
+        })
+        .unwrap_or_default()
+}
+
+/// Flattens a `use` list's members into [`ParsedImport`]s. Bare names and globs
+/// collapse into a single import at `base_path`; scoped members
+/// ([`scoped_identifier_import`], [`scoped_use_list_imports`]) each get their own
+/// re-rooted entry, ordered after the `base_path` group.
 fn collect_use_list_imports(base_path: &str, list: &Node, source: &str) -> Vec<ParsedImport> {
     let mut base_specifiers = Vec::new();
     let mut extra_imports = Vec::new();
     let mut cursor = list.walk();
     for child in list.children(&mut cursor) {
         match child.kind() {
-            "identifier" => {
-                base_specifiers.push(ImportSpecifier {
-                    name: source[child.byte_range()].to_owned(),
-                    alias: None,
-                    kind: ImportKind::Named,
-                });
+            "identifier" => base_specifiers.push(simple_specifier(
+                source[child.byte_range()].to_owned(),
+                ImportKind::Named,
+            )),
+            "use_wildcard" => {
+                base_specifiers.push(simple_specifier("*".to_owned(), ImportKind::Namespace));
             }
             "scoped_identifier" => {
-                if let (Some(path_node), Some(name_node)) = (
-                    child.child_by_field_name("path"),
-                    child.child_by_field_name("name"),
-                ) {
-                    let nested_path = format!("{}::{}", base_path, &source[path_node.byte_range()]);
-                    extra_imports.push(ParsedImport {
-                        source: nested_path,
-                        specifiers: vec![ImportSpecifier {
-                            name: source[name_node.byte_range()].to_owned(),
-                            alias: None,
-                            kind: ImportKind::Named,
-                        }],
-                    });
-                }
+                extra_imports.extend(scoped_identifier_import(base_path, &child, source));
             }
             "scoped_use_list" => {
-                if let (Some(inner_path), Some(inner_list)) = (
-                    child.child_by_field_name("path"),
-                    child.child_by_field_name("list"),
-                ) {
-                    let nested_path =
-                        format!("{}::{}", base_path, &source[inner_path.byte_range()]);
-                    extra_imports.extend(collect_use_list_imports(
-                        &nested_path,
-                        &inner_list,
-                        source,
-                    ));
-                }
-            }
-            "use_wildcard" => {
-                base_specifiers.push(ImportSpecifier {
-                    name: "*".to_owned(),
-                    alias: None,
-                    kind: ImportKind::Namespace,
-                });
+                extra_imports.extend(scoped_use_list_imports(base_path, &child, source));
             }
             _ => {}
         }
     }
-    if !base_specifiers.is_empty() {
-        extra_imports.insert(
-            0,
-            ParsedImport {
-                source: base_path.to_owned(),
-                specifiers: base_specifiers,
-            },
-        );
-    }
-    extra_imports
+    let base_group = (!base_specifiers.is_empty()).then(|| ParsedImport {
+        source: base_path.to_owned(),
+        specifiers: base_specifiers,
+    });
+    // `Option::into_iter` yields the base group (0 or 1) before the scoped extras.
+    base_group.into_iter().chain(extra_imports).collect()
 }
 
 fn parse_scoped_identifier(
@@ -119,11 +130,10 @@ fn parse_scoped_identifier(
     }
     Some(ParsedImport {
         source: path.to_owned(),
-        specifiers: vec![ImportSpecifier {
-            name: source[name_node.byte_range()].to_owned(),
-            alias: None,
-            kind: ImportKind::Named,
-        }],
+        specifiers: vec![simple_specifier(
+            source[name_node.byte_range()].to_owned(),
+            ImportKind::Named,
+        )],
     })
 }
 
@@ -152,11 +162,7 @@ fn parse_use_wildcard(node: &Node, source: &str, crate_name: Option<&str>) -> Op
     }
     Some(ParsedImport {
         source: path.to_owned(),
-        specifiers: vec![ImportSpecifier {
-            name: "*".to_owned(),
-            alias: None,
-            kind: ImportKind::Namespace,
-        }],
+        specifiers: vec![simple_specifier("*".to_owned(), ImportKind::Namespace)],
     })
 }
 
@@ -198,11 +204,7 @@ fn parse_mod_decl(node: &Node, source: &str) -> Option<ParsedImport> {
     let name = source[name_node.byte_range()].to_owned();
     Some(ParsedImport {
         source: name.clone(),
-        specifiers: vec![ImportSpecifier {
-            name,
-            alias: None,
-            kind: ImportKind::ModDecl,
-        }],
+        specifiers: vec![simple_specifier(name, ImportKind::ModDecl)],
     })
 }
 
@@ -241,6 +243,85 @@ fn extract_rust_impl_name(node: &Node, source: &str) -> Option<String> {
     }
 }
 
+/// Accumulates the imports and chunks discovered while walking a Rust file's
+/// top-level nodes. `pending` holds doc comments awaiting the next chunk; its
+/// `'a` lifetime ties the borrowed [`Node`]s to the parse tree they index.
+#[derive(Debug, Default)]
+struct RustChunkState<'a> {
+    imports: Vec<String>,
+    parsed_imports: Vec<ParsedImport>,
+    chunks: Vec<RawChunk>,
+    pending: Vec<Node<'a>>,
+}
+
+impl<'a> RustChunkState<'a> {
+    /// Routes one top-level node to its accumulator. Comments queue in `pending`
+    /// for the next chunk; every other kind clears `pending`, so a `use`/`mod`
+    /// between a doc comment and its item drops the comment. Takes `&Node<'a>`
+    /// (not the elided `&Node` of the sibling methods) because the comment arm
+    /// stores `*node` into `pending: Vec<Node<'a>>`.
+    fn add_node(&mut self, node: &Node<'a>, source: &str, crate_name: Option<&str>) {
+        match node.kind() {
+            "use_declaration" => {
+                self.imports.push(source[node.byte_range()].to_owned());
+                self.parsed_imports
+                    .extend(parse_rust_use(node, source, crate_name));
+                self.pending.clear();
+            }
+            "mod_item" => self.add_mod(node, source),
+            "line_comment" | "block_comment" => self.pending.push(*node),
+            "impl_item" => self.add_impl(node, source),
+            _ => self.classify_or_clear(node, source),
+        }
+    }
+
+    /// `mod foo;` becomes an import; `mod foo { ... }` falls through to a chunk.
+    fn add_mod(&mut self, node: &Node, source: &str) {
+        if let Some(import) = parse_mod_decl(node, source) {
+            self.parsed_imports.push(import);
+            self.pending.clear();
+        } else {
+            self.classify_or_clear(node, source);
+        }
+    }
+
+    /// Emits the impl header chunk followed by one chunk per method, linking each
+    /// method back to the header via `parent_index`.
+    fn add_impl(&mut self, node: &Node, source: &str) {
+        let impl_index = self.chunks.len();
+        let name = extract_rust_impl_name(node, source);
+        let mut impl_chunk = make_chunk(source, node, ChunkType::RustImpl, name);
+        attach_pending_comments(&mut impl_chunk, &mut self.pending, source);
+        self.chunks.push(impl_chunk);
+        self.chunks
+            .extend(extract_impl_methods(node, source, impl_index));
+    }
+
+    /// Pushes a classifiable node as a chunk (carrying any pending comments); a
+    /// node that is not a chunk boundary instead discards the pending comments.
+    fn classify_or_clear(&mut self, node: &Node, source: &str) {
+        if let Some(mut chunk) = classify_rust_node(node, source) {
+            attach_pending_comments(&mut chunk, &mut self.pending, source);
+            self.chunks.push(chunk);
+        } else {
+            self.pending.clear();
+        }
+    }
+
+    /// Consumes the accumulated state into [`FileChunks`], substituting the
+    /// line-based fallback when no structural chunk was found.
+    fn into_file_chunks(mut self, source: &str) -> FileChunks {
+        if self.chunks.is_empty() {
+            self.chunks = chunk_fallback(source);
+        }
+        FileChunks {
+            imports: self.imports,
+            parsed_imports: self.parsed_imports,
+            chunks: self.chunks,
+        }
+    }
+}
+
 pub(super) fn chunk_rust(source: &str, crate_name: Option<&str>) -> FileChunks {
     let Some(mut parser) = make_parser(&tree_sitter_rust::LANGUAGE.into()) else {
         return FileChunks::chunks_only(chunk_fallback(source));
@@ -250,56 +331,10 @@ pub(super) fn chunk_rust(source: &str, crate_name: Option<&str>) -> FileChunks {
         return FileChunks::chunks_only(chunk_fallback(source));
     };
     let root = tree.root_node();
-    let mut imports = Vec::new();
-    let mut parsed_imports = Vec::new();
-    let mut chunks = Vec::new();
-    let mut pending_comments: Vec<Node> = Vec::new();
+    let mut state = RustChunkState::default();
     let mut cursor = root.walk();
     for node in root.children(&mut cursor) {
-        match node.kind() {
-            "use_declaration" => {
-                imports.push(source[node.byte_range()].to_owned());
-                parsed_imports.extend(parse_rust_use(&node, source, crate_name));
-                pending_comments.clear();
-            }
-            "mod_item" => {
-                if let Some(import) = parse_mod_decl(&node, source) {
-                    parsed_imports.push(import);
-                    pending_comments.clear();
-                } else if let Some(mut chunk) = classify_rust_node(&node, source) {
-                    attach_pending_comments(&mut chunk, &mut pending_comments, source);
-                    chunks.push(chunk);
-                } else {
-                    pending_comments.clear();
-                }
-            }
-            "line_comment" | "block_comment" => {
-                pending_comments.push(node);
-            }
-            "impl_item" => {
-                let impl_index = chunks.len();
-                let name = extract_rust_impl_name(&node, source);
-                let mut impl_chunk = make_chunk(source, &node, ChunkType::RustImpl, name);
-                attach_pending_comments(&mut impl_chunk, &mut pending_comments, source);
-                chunks.push(impl_chunk);
-                chunks.extend(extract_impl_methods(&node, source, impl_index));
-            }
-            _ => {
-                if let Some(mut chunk) = classify_rust_node(&node, source) {
-                    attach_pending_comments(&mut chunk, &mut pending_comments, source);
-                    chunks.push(chunk);
-                } else {
-                    pending_comments.clear();
-                }
-            }
-        }
+        state.add_node(&node, source, crate_name);
     }
-    if chunks.is_empty() {
-        chunks = chunk_fallback(source);
-    }
-    FileChunks {
-        imports,
-        parsed_imports,
-        chunks,
-    }
+    state.into_file_chunks(source)
 }

--- a/src/indexer/chunker/tests.rs
+++ b/src/indexer/chunker/tests.rs
@@ -933,6 +933,50 @@ fn chunk_rust_parses_nested_grouped_use() {
     assert_eq!(result.parsed_imports[1].specifiers[0].name, "Baz");
 }
 
+// T-720: chunk_rust_parses_doubly_nested_grouped_use
+#[test]
+fn chunk_rust_parses_doubly_nested_grouped_use() {
+    // `bar::{Baz, Qux}` is a `scoped_use_list` nested inside the outer list, so it
+    // recurses through `scoped_use_list_imports` and re-roots under `crate::foo::bar`.
+    let source = "use crate::foo::{bar::{Baz, Qux}};\nfn run() {}";
+    let result = chunk_file(source, "rs");
+    assert_eq!(result.parsed_imports.len(), 1);
+    assert_eq!(result.parsed_imports[0].source, "crate::foo::bar");
+    assert_eq!(result.parsed_imports[0].specifiers.len(), 2);
+    assert_eq!(result.parsed_imports[0].specifiers[0].name, "Baz");
+    assert_eq!(result.parsed_imports[0].specifiers[1].name, "Qux");
+}
+
+// T-721: chunk_rust — a list mixing a bare name and a nested group keeps the base group first
+#[test]
+fn chunk_rust_parses_mixed_identifier_and_nested_group() {
+    // Quux populates base_specifiers; bar::{Baz, Qux} goes through the scoped_use_list
+    // arm into extra_imports. The base group must be emitted before the scoped extra.
+    let source = "use crate::foo::{Quux, bar::{Baz, Qux}};\nfn run() {}";
+    let result = chunk_file(source, "rs");
+    assert_eq!(result.parsed_imports.len(), 2);
+    assert_eq!(result.parsed_imports[0].source, "crate::foo");
+    assert_eq!(result.parsed_imports[0].specifiers[0].name, "Quux");
+    assert_eq!(result.parsed_imports[1].source, "crate::foo::bar");
+    assert_eq!(result.parsed_imports[1].specifiers.len(), 2);
+    assert_eq!(result.parsed_imports[1].specifiers[0].name, "Baz");
+    assert_eq!(result.parsed_imports[1].specifiers[1].name, "Qux");
+}
+
+// T-722: chunk_rust — a scoped use-list member missing its path is skipped, not panicked
+#[test]
+fn chunk_rust_skips_scoped_member_without_path() {
+    // `::Bar` parses as a scoped_identifier with no `path` field; scoped_identifier_import
+    // returns None and the member is dropped rather than producing a partial import.
+    let source = "use crate::foo::{::Bar};\nfn run() {}";
+    let result = chunk_file(source, "rs");
+    assert!(
+        result.parsed_imports.is_empty(),
+        "malformed scoped member should be skipped, got: {:?}",
+        result.parsed_imports
+    );
+}
+
 // T-472: chunk_rust_parses_use_as_clause
 #[test]
 fn chunk_rust_parses_use_as_clause() {


### PR DESCRIPTION
#137 関数分解フェーズの PR4。`src/indexer/chunker/rust.rs` の 2 つの 30 行超関数を分解し、「全 fn ≤30」基準を満たす。挙動は不変（リファクタのみ）。

## 変更点

- **`chunk_rust` (62→14 行)**: 4 アキュムレータ（imports / parsed_imports / chunks / pending）を共有する node-kind dispatch ループを `RustChunkState<'a>` 状態構造体 + メソッド（`add_node` / `add_mod` / `add_impl` / `classify_or_clear` / `into_file_chunks`）に分離。`chunk_rust` は parser setup + ループ + return の薄い orchestration に。
- **`collect_use_list_imports` (64→29 行)**: `scoped_identifier_import`（use-list 内の `a::b` メンバー）と `scoped_use_list_imports`（ネスト `a::{...}`）を抽出。両者は既存の `parse_scoped_*` と異なり `is_internal_path` フィルタ済み前提のため再チェックしない旨を doc に明記。
- **`simple_specifier`**: `alias: None` の `ImportSpecifier` 構築をファイル内 6 箇所で共通化（DRY）。

`RustChunkState` は単一エントリ（`chunk_rust`）でしか使わないが、4 アキュムレータの取り回しと `classify_or_clear`（`mod_item` else と `_` arm の重複解消）をまとめるため state struct を採用。free fn 化だと `&mut Vec` を 4 つ引数で渡すことになり ≤3 引数ガイドラインに反する。

## テスト

| ID | 検証内容 |
| --- | --- |
| T-720 | 二重ネスト use-list `use crate::foo::{bar::{Baz, Qux}}` が `crate::foo::bar` に再ルートされ 1 ParsedImport になる（`scoped_use_list_imports` の再帰経路）|
| T-721 | bare name + ネストグループ混在 `{Quux, bar::{Baz, Qux}}` で base group が scoped extra より先に並ぶ順序契約 |
| T-722 | path 欠落の scoped メンバー `{::Bar}`（tree-sitter が `scoped_identifier path=None` を emit）を panic せず skip する堅牢性 |

## 検証

- 全 fn ≤30（最大 `collect_use_list_imports` 29 行、escape hatch 不使用）
- `clippy --all-targets --all-features -D warnings` clean / `cargo fmt --check` clean
- `cargo nextest --profile ci --features test-support` **735 passed**
- diff-cover **97%**（≥95 gate）。残 2 行は `classify_or_clear` の防御分岐（`other_or_skip` が空白ノードに None を返す経路。到達する入力は未観測、main から挙動不変）

## レビュー観点

挙動保存リファクタのため、reviewer はまず `RustChunkState` の不変条件（`pending` コメント順序・`parent_index` リンク）が分割で崩れていないか確認すると効率的。監査（10 reviewer + critic-audit + critic-evidence）で encapsulation / silence / duplication / operations / reuse は 0 findings、`then_some` 化・inline 化・命名変更の提案は critic で却下済み（`then_some` は `to_owned` を eager 化、inline は ~40 行で 30 超）。

## Follow-up

`alias: None` の `ImportSpecifier` 構築は `src/indexer/chunker/ts/imports.rs` にも inline で残る（本 diff の範囲外）。横断的に `ImportSpecifier::new` を型へ生やせば rust/ts 両チャンカーで統一できる。次の機会に検討。

Refs #137
