### PR TITLE
refactor(yomu): run_chunk_only_index_inner を index_changed_files に分解 (#137)

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -32,7 +32,7 @@ pub enum IndexError {
     CorpusInit(#[from] injection::CorpusError),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct IndexResult {
     pub files_processed: u32,
     pub chunks_created: u32,

--- a/src/indexer/chunk_only.rs
+++ b/src/indexer/chunk_only.rs
@@ -3,7 +3,7 @@ mod references;
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use super::{DryRunResult, IndexError, IndexResult, chunker, injection, source_kind, walker};
@@ -185,6 +185,7 @@ pub(super) fn prepare_chunks(
     })
 }
 
+#[derive(Clone, Copy)]
 enum FileOutcome {
     Processed(u32),
     Skipped,
@@ -300,6 +301,58 @@ pub fn dry_run_index(
     })
 }
 
+impl IndexResult {
+    /// Folds one file's [`FileOutcome`] into the running counts.
+    fn record(&mut self, outcome: FileOutcome) {
+        match outcome {
+            FileOutcome::Processed(n) => {
+                self.chunks_created += n;
+                self.files_processed += 1;
+            }
+            FileOutcome::Skipped => self.files_skipped += 1,
+            FileOutcome::Errored => self.files_errored += 1,
+        }
+    }
+}
+
+/// Indexes every changed file under one DB lock, returning the run counts and
+/// the set of relative paths seen (used by the caller for orphan removal). The
+/// lock guard drops on return, before the caller re-locks for cleanup.
+/// Past the 30-line guideline only because the 5-arg signature wraps; the body is one cohesive locked pass.
+fn index_changed_files(
+    conn: &Arc<Mutex<Db>>,
+    root: &Path,
+    files: &[PathBuf],
+    force: bool,
+    corpus: &injection::Corpus,
+) -> Result<(IndexResult, HashSet<String>), IndexError> {
+    let resolver = Resolver::new(root);
+    let rust_resolver = RustResolver::new(root);
+    let mut result = IndexResult::default();
+    let mut current_rel_paths = HashSet::with_capacity(files.len());
+    let conn_guard = conn.lock().expect("DB lock poisoned (index_changed_files)");
+    let _automerge = storage::FtsAutomergeGuard::new(&conn_guard)?;
+
+    for file_path in files {
+        let rel_path = to_rel_path(root, file_path);
+        current_rel_paths.insert(rel_path.clone());
+        let outcome = process_file(
+            &conn_guard,
+            rel_path,
+            file_path,
+            force,
+            &resolver,
+            &rust_resolver,
+            corpus,
+        )?;
+        result.record(outcome);
+    }
+    if result.files_processed > 0 {
+        storage::fts_optimize(&conn_guard)?;
+    }
+    Ok((result, current_rel_paths))
+}
+
 pub(super) fn run_chunk_only_index_inner(
     conn: &Arc<Mutex<Db>>,
     root: &Path,
@@ -316,71 +369,18 @@ pub(super) fn run_chunk_only_index_inner(
         "Starting chunk-only indexing"
     );
 
-    let resolver = Resolver::new(root);
-    let rust_resolver = RustResolver::new(root);
-
-    let (files_processed, chunks_created, files_skipped, files_errored, current_rel_paths) = {
-        let mut files_processed = 0u32;
-        let mut chunks_created = 0u32;
-        let mut files_skipped = 0u32;
-        let mut files_errored = 0u32;
-        let mut current_rel_paths = HashSet::with_capacity(files.len());
-
-        let conn_guard = conn
-            .lock()
-            .expect("DB lock poisoned (run_chunk_only_index_inner)");
-        let _automerge = storage::FtsAutomergeGuard::new(&conn_guard)?;
-
-        for file_path in &files {
-            let rel_path = to_rel_path(root, file_path);
-            current_rel_paths.insert(rel_path.clone());
-            match process_file(
-                &conn_guard,
-                rel_path,
-                file_path,
-                force,
-                &resolver,
-                &rust_resolver,
-                &corpus,
-            )? {
-                FileOutcome::Processed(n) => {
-                    chunks_created += n;
-                    files_processed += 1;
-                }
-                FileOutcome::Skipped => files_skipped += 1,
-                FileOutcome::Errored => files_errored += 1,
-            }
-        }
-
-        if files_processed > 0 {
-            storage::fts_optimize(&conn_guard)?;
-        }
-
-        (
-            files_processed,
-            chunks_created,
-            files_skipped,
-            files_errored,
-            current_rel_paths,
-        )
-    };
-
+    let (result, current_rel_paths) = index_changed_files(conn, root, &files, force, &corpus)?;
     remove_orphans(conn, &current_rel_paths)?;
 
     tracing::info!(
-        files_processed,
-        chunks_created,
-        files_skipped,
-        files_errored,
+        files_processed = result.files_processed,
+        chunks_created = result.chunks_created,
+        files_skipped = result.files_skipped,
+        files_errored = result.files_errored,
         "Chunk-only indexing complete"
     );
 
-    Ok(IndexResult {
-        files_processed,
-        chunks_created,
-        files_skipped,
-        files_errored,
-    })
+    Ok(result)
 }
 
 pub fn run_chunk_only_index(


### PR DESCRIPTION
#137 関数分解フェーズの最終ユニット（DES-005 / TEST-006）。`src/indexer/chunk_only.rs` の 82 行の `run_chunk_only_index_inner` を分解し、追跡対象の巨大関数を全て ≤30 にする。挙動は不変（リファクタのみ）。

## 変更点

- **`run_chunk_only_index_inner` (82→29 行)**: scoped-block が 5-tuple `(files_processed, chunks_created, files_skipped, files_errored, current_rel_paths)` を返すパターンを解体。per-file の locked indexing pass を `index_changed_files` に抽出し、本体は corpus load → walk → 呼び出し → orphan 除去 → tracing の orchestration に。
- **`IndexResult` を accumulator 流用**: `Default` 追加 + private `record(&mut self, FileOutcome)` メソッドで inline match を畳み込み。フィールドが accumulator と完全一致するため別 `IndexCounts` struct + 変換を作らず流用（Occam）。`record` は分割 impl で `chunk_only.rs` に置く（`IndexResult` 定義は `indexer.rs`、LANG.md 公認）。
- **`FileOutcome` に `Copy`**: POD enum（`Processed(u32)|Skipped|Errored`）。`record` の値渡しで `clippy::needless_pass_by_value` を避ける。
- **`index_changed_files`**: `Resolver`/`RustResolver` を内部構築して引数 5 に抑制（context struct を導入すると `process_file`/`check_file` も巻き込む file-wide refactor になるため回避）。DB ロックを保持しループ→`fts_optimize`、`(IndexResult, HashSet<String>)` を返す。ロックガードは return で drop し、呼び出し側の `remove_orphans` 再ロック前に解放される。

## テスト（TEST-006: test seam）

新規 unit test は追加していない。理由:
- per-file の seam は既存 `process_file`、loop の seam は新 `index_changed_files`、accumulation の seam は pure な `record` ── 3 層とも seam 化済み。
- `record` の 3 つの `FileOutcome` arm は既存の統合テストが最終 `IndexResult` カウントで網羅: T-382/T-397（`Processed` の dual-counter `chunks_created += n` & `files_processed += 1`）、T-374（`Skipped`）、T-398（`Errored`）、加えて T-375（force）/ T-376（orphan 除去）/ `if files_processed > 0` の fts 分岐両方。
- `record` 専用 unit test は `FileOutcome`/`record` を `pub(super)` 化させるだけで被覆は増えない（TESTING.md の冗長テスト回避）。

## 検証

- 追跡対象 6 関数すべて ≤30 達成（`run_chunk_only_index_inner` 29）。新ヘルパー `index_changed_files` は total 33（5 引数の signature 折返し由来 ── doc に理由コメント。同ファイルの既存 `process_file` 42 / `prepare_chunks` 41 / `dry_run_index` 40 と同水準）。
- `clippy --all-targets --all-features -D warnings` clean / `cargo fmt --check` clean
- `cargo nextest --profile ci --features test-support` **735 passed**
- file-size gate: chunk_only.rs **400 行（≤400）**
- diff-cover **97.6%（≥95）**。残 1 行は `process_file` の `?` エラー伝播（storage 障害時のみ、テストの実 SQLite では未到達、main から挙動不変）

## レビュー観点

挙動保存リファクタ。reviewer はまず DB ロックの drop タイミング（`index_changed_files` の return で解放 → `remove_orphans` が再ロック）が原実装と等価か確認すると効率的。本 PR は監査を **2 回独立実行**（reviewer 10 + critic-audit + critic-evidence ×2）し、両パスとも 10 中 9 が 0 findings。`Default` 除去案・tuple の type alias 案・`record` リネーム案はいずれも却下（前二者は 400 行 gate を破壊、後者は accumulator として明瞭で命名 convention 衝突なし）。

Refs #137
