### PR TITLE
rurico を e330c22・amici を f122653 に更新し Rust を 1.96 へ

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=b545722#b54572260e8a7685c7503284de27eec0585dfd28"
+source = "git+https://github.com/thkt/amici?rev=f122653#f12265318aab45c0e1a87d668eda2e28d20454a0"
 dependencies = [
  "bytemuck",
  "rand 0.10.1",
@@ -2104,7 +2104,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=a573655#a573655f0a811deeae96f87640d28fcd117dec7b"
+source = "git+https://github.com/thkt/rurico?rev=e330c22#e330c2258c890e41bc70fd388cabb057d69d1cbd"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=a573655#a573655f0a811deeae96f87640d28fcd117dec7b"
+source = "git+https://github.com/thkt/rurico?rev=e330c22#e330c2258c890e41bc70fd388cabb057d69d1cbd"
 dependencies = [
  "mlx-sys",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 name = "yomu"
 version = "0.16.0"
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 description = "Frontend code search for AI agents"
 license = "MIT"
 repository = "https://github.com/thkt/yomu"
@@ -16,11 +16,11 @@ repository = "https://github.com/thkt/yomu"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "b545722" }
+amici = { git = "https://github.com/thkt/amici", rev = "f122653" }
 bytemuck = "1"
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
-rurico = { git = "https://github.com/thkt/rurico", rev = "a573655" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "e330c22" }
 regex = "1"
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
@@ -39,7 +39,7 @@ tree-sitter-rust = "0.24"
 tree-sitter-typescript = "0.23"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "a573655", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "e330c22", features = ["test-support"] }
 tempfile = "3"
 tracing-test = { version = "0.2", features = ["no-env-filter"] }
 

--- a/crates/recall-bench/Cargo.toml
+++ b/crates/recall-bench/Cargo.toml
@@ -2,7 +2,7 @@
 name = "recall-bench"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 publish = false
 
 [dependencies]

--- a/src/indexer/embed.rs
+++ b/src/indexer/embed.rs
@@ -23,7 +23,7 @@ enum EmbedFailure {
 }
 
 fn validate_chunked_embeddings(embs: Vec<ChunkedEmbedding>) -> Result<Vec<ChunkedEmbedding>, ()> {
-    if embs.iter().any(|e| e.chunks.is_empty()) {
+    if embs.iter().any(|e| e.chunks().is_empty()) {
         return Err(());
     }
     Ok(embs)

--- a/src/indexer/embed/tests.rs
+++ b/src/indexer/embed/tests.rs
@@ -1,18 +1,11 @@
 use super::*;
 
-// T-360: validate_rejects_empty_chunks
-#[test]
-fn validate_rejects_empty_chunks() {
-    let embs = vec![ChunkedEmbedding::new(vec![])];
-    assert!(validate_chunked_embeddings(embs).is_err());
-}
-
 // T-361: validate_passes_non_empty_chunks
 #[test]
 fn validate_passes_non_empty_chunks() {
     let embs = vec![
-        ChunkedEmbedding::new(vec![vec![1.0_f32; 3]]),
-        ChunkedEmbedding::new(vec![vec![2.0_f32; 3], vec![3.0_f32; 3]]),
+        ChunkedEmbedding::try_new(vec![vec![1.0_f32; 3]]).unwrap(),
+        ChunkedEmbedding::try_new(vec![vec![2.0_f32; 3], vec![3.0_f32; 3]]).unwrap(),
     ];
     assert!(validate_chunked_embeddings(embs).is_ok());
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -245,7 +245,7 @@ fn search_pipeline(
 #[allow(clippy::too_many_arguments)]
 pub fn search(
     conn: &Arc<Mutex<Db>>,
-    embedder: &(impl Embed + ?Sized),
+    embedder: Option<&dyn Embed>,
     query: &str,
     limit: u32,
     offset: u32,
@@ -253,12 +253,15 @@ pub fn search(
     path_filter: &[String],
     capture_stages: bool,
 ) -> Result<SearchOutcome, QueryError> {
-    let (query_embedding, degraded) = match embedder.embed_query(query) {
-        Ok(emb) => (Some(emb), false),
-        Err(e) => {
-            tracing::warn!(error = %e, "Query embedding failed, falling back to text search");
-            (None, true)
-        }
+    let (query_embedding, degraded) = match embedder {
+        Some(e) => match e.embed_query(query) {
+            Ok(emb) => (Some(emb), false),
+            Err(err) => {
+                tracing::warn!(error = %err, "Query embedding failed, falling back to text search");
+                (None, true)
+            }
+        },
+        None => (None, true),
     };
 
     let conn = conn.lock().expect("DB lock poisoned (query::search)");

--- a/src/query/tests.rs
+++ b/src/query/tests.rs
@@ -49,7 +49,7 @@ fn search_with_mock_embedder() {
     let conn = Arc::new(Mutex::new(conn));
     let outcome = search(
         &conn,
-        &MockEmbedder::default(),
+        Some(&MockEmbedder::default()),
         "button",
         10,
         0,
@@ -250,7 +250,7 @@ fn search_fallback_merges_vector_and_name_results() {
     let conn = Arc::new(Mutex::new(conn));
     let results = search(
         &conn,
-        &MockEmbedder::default(),
+        Some(&MockEmbedder::default()),
         "auth",
         5,
         0,
@@ -316,7 +316,7 @@ fn search_deduplicates_vector_and_name_results() {
     let conn = Arc::new(Mutex::new(conn));
     let results = search(
         &conn,
-        &MockEmbedder::default(),
+        Some(&MockEmbedder::default()),
         "auth",
         5,
         0,
@@ -707,7 +707,7 @@ fn search_returns_results_sorted_by_score() {
     let conn = Arc::new(Mutex::new(conn));
     let results = search(
         &conn,
-        &MockEmbedder::default(),
+        Some(&MockEmbedder::default()),
         "auth hook",
         5,
         0,
@@ -933,7 +933,7 @@ fn search_degrades_on_embed_failure() {
     let conn = Arc::new(Mutex::new(conn));
     let outcome = search(
         &conn,
-        &FailingEmbedder::query_only("embedding unavailable"),
+        Some(&FailingEmbedder::query_only("embedding unavailable")),
         "auth",
         10,
         0,
@@ -954,9 +954,9 @@ fn search_degrades_on_embed_failure() {
     );
 }
 
-// T-290: search_degrades_on_model_not_available
+// T-290: search_degrades_when_embedder_returns_error
 #[test]
-fn search_degrades_on_model_not_available() {
+fn search_degrades_when_embedder_returns_error() {
     let embedder = FailingEmbedder::all_fail("embedder not available");
 
     let dir = tempdir().unwrap();
@@ -964,10 +964,55 @@ fn search_degrades_on_model_not_available() {
     let conn = storage::open_db(&db_path).unwrap();
     let conn = Arc::new(Mutex::new(conn));
 
-    let outcome = search(&conn, &embedder, "test", 10, 0, None, &[], false).unwrap();
+    let outcome = search(&conn, Some(&embedder), "test", 10, 0, None, &[], false).unwrap();
     assert!(
         outcome.degraded,
         "should degrade to FTS5 when model not available"
+    );
+}
+
+// T-292: search_degrades_when_embedder_absent
+#[test]
+fn search_degrades_when_embedder_absent() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let conn = storage::open_db(&db_path).unwrap();
+
+    storage::replace_file_chunks_only(
+        &conn,
+        "src/Auth.tsx",
+        &[storage::NewChunk {
+            chunk_type: &storage::ChunkType::Component,
+            name: Some("AuthForm"),
+            content: "function AuthForm() { return <form/>; }",
+            start_line: 1,
+            end_line: 3,
+            parent_index: None,
+            source_kind: None,
+            injection_flags: None,
+        }],
+        "h1",
+        "",
+        &[],
+        None,
+    )
+    .unwrap();
+
+    let conn = Arc::new(Mutex::new(conn));
+    // `None` embedder = model absent at load time. Exercises the query.rs None arm
+    // directly (the tools::search wrapper covers it only transitively via try_embedder().ok()).
+    let outcome = search(&conn, None, "auth", 10, 0, None, &[], false).unwrap();
+    assert!(
+        outcome.degraded,
+        "absent embedder (None) must degrade to FTS"
+    );
+    assert!(
+        !outcome.results.is_empty(),
+        "FTS results should still return when the embedder is absent"
+    );
+    assert_ne!(
+        outcome.results[0].match_source,
+        storage::MatchSource::Semantic
     );
 }
 
@@ -1074,7 +1119,7 @@ fn reranker_reorders_results_by_cross_encoder_score() {
     let conn = Arc::new(Mutex::new(conn));
     let outcome = search(
         &conn,
-        &MockEmbedder::default(),
+        Some(&MockEmbedder::default()),
         "auth",
         5,
         0,
@@ -1127,7 +1172,7 @@ fn no_reranker_produces_rrf_results() {
     let conn = Arc::new(Mutex::new(conn));
     let outcome = search(
         &conn,
-        &MockEmbedder::default(),
+        Some(&MockEmbedder::default()),
         "auth",
         5,
         0,
@@ -1139,7 +1184,7 @@ fn no_reranker_produces_rrf_results() {
 
     let outcome_existing = search(
         &conn,
-        &MockEmbedder::default(),
+        Some(&MockEmbedder::default()),
         "auth",
         5,
         0,
@@ -1208,7 +1253,7 @@ fn reranker_increases_fetch_limit() {
     let conn = Arc::new(Mutex::new(conn));
     let outcome = search(
         &conn,
-        &MockEmbedder::default(),
+        Some(&MockEmbedder::default()),
         "component",
         limit,
         offset,
@@ -1302,7 +1347,7 @@ fn reranker_scores_applied_before_cap_per_file() {
     let conn = Arc::new(Mutex::new(conn));
     let outcome = search(
         &conn,
-        &MockEmbedder::default(),
+        Some(&MockEmbedder::default()),
         "auth",
         10,
         0,
@@ -1351,7 +1396,7 @@ fn reranker_scores_applied_before_cap_per_file() {
 #[ignore = "requires model download"]
 fn search_returns_results() {
     use rurico::embed::download_model;
-    let paths = download_model(ModelId::default()).expect("download model");
+    let paths = download_model(ModelId::DEFAULT).expect("download model");
     let embedder = Embedder::new(&paths).expect("load model");
     let dir = tempdir().unwrap();
     let db_path = dir.path().join("test.db");
@@ -1378,7 +1423,7 @@ fn search_returns_results() {
     .unwrap();
 
     let conn = Arc::new(Mutex::new(conn));
-    let outcome = search(&conn, &embedder, "button", 10, 0, None, &[], false).unwrap();
+    let outcome = search(&conn, Some(&embedder), "button", 10, 0, None, &[], false).unwrap();
     assert!(!outcome.results.is_empty(), "expected at least one result");
 }
 
@@ -1532,7 +1577,7 @@ fn text_only_search_with_offset_returns_results() {
     let conn = Arc::new(Mutex::new(conn));
     let outcome = search(
         &conn,
-        &FailingEmbedder::query_only("unavailable"),
+        Some(&FailingEmbedder::query_only("unavailable")),
         "widget",
         3,
         10,
@@ -1580,7 +1625,7 @@ fn search_chunk_only_index_with_embedder_falls_back_to_text() {
     let conn = Arc::new(Mutex::new(conn));
     let outcome = search(
         &conn,
-        &MockEmbedder::default(),
+        Some(&MockEmbedder::default()),
         "button",
         10,
         0,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -94,7 +94,7 @@ use rurico::embed::ChunkedEmbedding;
 
 #[cfg(test)]
 pub(crate) fn ce(v: Vec<f32>) -> ChunkedEmbedding {
-    ChunkedEmbedding::new(vec![v])
+    ChunkedEmbedding::try_new(vec![v]).expect("ce: vec![v] always has exactly one chunk")
 }
 
 #[cfg(test)]

--- a/src/storage/mutation.rs
+++ b/src/storage/mutation.rs
@@ -60,7 +60,7 @@ pub(super) fn insert_sub_embeddings(
     chunk_id: i64,
     chunked_emb: &ChunkedEmbedding,
 ) -> Result<(), StorageError> {
-    for (sub_idx, emb_slice) in chunked_emb.chunks.iter().enumerate() {
+    for (sub_idx, emb_slice) in chunked_emb.chunks().iter().enumerate() {
         let bytes: &[u8] = cast_slice(emb_slice);
         conn.prepare_cached(
             "INSERT INTO vec_chunks (embedding, chunk_id, sub_idx) VALUES (?1, ?2, ?3)",

--- a/src/tools/embedder.rs
+++ b/src/tools/embedder.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use rurico::embed::{ChunkedEmbedding, Embed, EmbedError};
+use rurico::embed::Embed;
 
 // Real-model loading is compiled only into the production binary. Under
 // `--features test-support` the embedder is a deterministic stub (see the
@@ -16,7 +16,7 @@ use rurico::embed::MockEmbedder;
 #[cfg(feature = "test-support")]
 use std::env;
 
-pub(super) use amici::model::embedder::{DegradedReason, degraded_reason_user_note};
+pub(super) use amici::model::embedder::{DegradedReason, EmbedderDegraded};
 
 use super::Yomu;
 
@@ -44,24 +44,10 @@ pub(super) fn get_recorded_warnings() -> Vec<(DegradedReason, String)> {
     RECORDED_WARNINGS.with(|w| w.borrow().clone())
 }
 
-struct NoOpEmbedder;
-
-impl Embed for NoOpEmbedder {
-    fn embed_query(&self, _text: &str) -> Result<Vec<f32>, EmbedError> {
-        Err(EmbedError::Inference("embedder not available".into()))
-    }
-    fn embed_document(&self, _text: &str) -> Result<ChunkedEmbedding, EmbedError> {
-        Err(EmbedError::Inference("embedder not available".into()))
-    }
-    fn embed_text(&self, _text: &str, _prefix: &str) -> Result<Vec<f32>, EmbedError> {
-        Err(EmbedError::Inference("embedder not available".into()))
-    }
-}
-
 #[cfg(not(feature = "test-support"))]
 fn try_load_embedder() -> Result<Arc<dyn Embed>, DegradedReason> {
     let result = try_load_embedder_with(
-        || cached_artifacts(ModelId::default()),
+        || cached_artifacts(ModelId::DEFAULT),
         |e| tracing::warn!(error = %e, "failed to delete corrupt model files"),
         |e| tracing::warn!(error = %e, "embedder probe failed"),
     );
@@ -109,11 +95,6 @@ impl Yomu {
             .as_ref()
             .map(Arc::clone)
             .map_err(|r| *r)
-    }
-
-    pub(super) fn get_embedder(&self) -> &dyn Embed {
-        static NOOP: NoOpEmbedder = NoOpEmbedder;
-        self.try_embedder().unwrap_or(&NOOP)
     }
 
     pub(super) fn degraded_reason(&self) -> Option<&DegradedReason> {

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 
 use crate::{query, storage};
 
-use super::embedder::degraded_reason_user_note;
+use super::embedder::EmbedderDegraded;
 use super::format::{
     EnrichmentContext, format_no_results_message, format_results_grouped, format_results_json,
 };
@@ -54,7 +54,7 @@ impl Yomu {
         offset: u32,
         paths: &[String],
     ) -> Result<query::SearchOutcome, YomuError> {
-        let embedder = self.get_embedder();
+        let embedder = self.try_embedder().ok();
         tracing::debug!(query, limit, offset, ?paths, "search request");
 
         let start = Instant::now();
@@ -86,7 +86,7 @@ impl Yomu {
             notes.push(note);
         }
         if let Some(reason) = self.degraded_reason() {
-            if let Some(note) = degraded_reason_user_note(*reason, "yomu model download") {
+            if let Some(note) = EmbedderDegraded(*reason).user_note("yomu model download") {
                 notes.push(note);
             }
         } else if degraded {


### PR DESCRIPTION
## 概要
rurico を e330c22 (PR#205)、amici を f122653 (PR#139) に更新し Rust を 1.96 へ。

## 背景
rurico/amici が先行移行済。yomu は rurico を直接 + amici 経由で二重依存するため rurico rev を揃える必要がある (Cargo 同一 git dep 制約)。amici は merge-commit pin 慣習に従い main tip `f122653` を採用 (rurico `e330c22` と同様)。

## 破壊的変更への対応 (C案)
rurico e330c22 で embed API contract が変更 (`EmbedError` コンストラクタ pub(crate) 化、`ChunkedEmbedding::try_new`/accessor、`ModelId::DEFAULT`、`EmbedderDegraded::user_note`)。
- `NoOpEmbedder` 廃止 (consumer が EmbedError を構築不可になったため)
- `query::search` の embedder を `Option<&dyn Embed>` 化、不在を None で表現
- accessor / try_new / DEFAULT / EmbedderDegraded へ追従

## テスト
- T-292 `search_degrades_when_embedder_absent` 追加 (None 分岐の直接検証)
- T-290 を `search_degrades_when_embedder_returns_error` に改名

## 検証
- `cargo build --workspace` / test 643 passed / `clippy -D warnings` すべて緑
- /audit 実施 (reviewer → challenger → verifier)、確定 finding (embedder dyn 化) 対応済

## follow-up (別 issue 予定)
- dead な `validate_chunked_embeddings` + `EmbedFailure::Contract` 除去
- Abort 時の partial embed commit 残留