### PR TITLE
test(yomu): メッセージなし assert!(matches!) を assert_matches! 化

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::assert_matches;
 use std::io::Cursor;
 
 /// A reader whose every `read` fails, for exercising the stdin I/O error path.
@@ -39,7 +40,7 @@ fn resolve_query_with_none_terminal_returns_no_query() {
     let mut stdin = Cursor::new(b"");
     let result = resolve_query_with(None, &mut stdin, true);
     let err = result.unwrap_err();
-    assert!(matches!(err, QueryError::NoQuery(_)));
+    assert_matches!(err, QueryError::NoQuery(_));
     assert!(err.to_string().contains("query required"));
 }
 
@@ -49,7 +50,7 @@ fn resolve_query_with_empty_stdin_returns_no_query() {
     let mut stdin = Cursor::new(b"   ");
     let result = resolve_query_with(None, &mut stdin, false);
     let err = result.unwrap_err();
-    assert!(matches!(err, QueryError::NoQuery(_)));
+    assert_matches!(err, QueryError::NoQuery(_));
     assert!(err.to_string().contains("empty query"));
 }
 
@@ -59,7 +60,7 @@ fn resolve_query_with_empty_stdin_returns_no_query() {
 fn resolve_query_with_io_error_returns_io_variant() {
     let result = resolve_query_with(None, &mut FailingReader, false);
     let err = result.unwrap_err();
-    assert!(matches!(err, QueryError::Io(_)));
+    assert_matches!(err, QueryError::Io(_));
     assert!(err.to_string().contains("failed to read from stdin"));
 }
 
@@ -100,17 +101,17 @@ fn resolve_search_query_with_no_from_present_returns_some() {
 fn resolve_search_query_with_no_from_missing_is_error() {
     let mut stdin = Cursor::new(b"");
     let result = resolve_search_query_with(None, false, &mut stdin, true);
-    assert!(matches!(
+    assert_matches!(
         result.unwrap_err(),
         QueryError::NoQuery(NoQueryReason::Terminal)
-    ));
+    );
 }
 
 // T-717: resolve_search_query_with — a stdin I/O failure propagates as Io
 #[test]
 fn resolve_search_query_with_io_error_propagates() {
     let result = resolve_search_query_with(None, false, &mut FailingReader, false);
-    assert!(matches!(result.unwrap_err(), QueryError::Io(_)));
+    assert_matches!(result.unwrap_err(), QueryError::Io(_));
 }
 
 // T-718: resolve_search_query_with — no --from + empty piped stdin is EmptyStdin
@@ -118,21 +119,21 @@ fn resolve_search_query_with_io_error_propagates() {
 fn resolve_search_query_with_no_from_empty_stdin_is_empty_stdin() {
     let mut stdin = Cursor::new(b"   ");
     let result = resolve_search_query_with(None, false, &mut stdin, false);
-    assert!(matches!(
+    assert_matches!(
         result.unwrap_err(),
         QueryError::NoQuery(NoQueryReason::EmptyStdin)
-    ));
+    );
 }
 
 // T-719: missing_query_kind maps each NoQueryReason to its input error
 #[test]
 fn missing_query_kind_maps_each_reason() {
-    assert!(matches!(
+    assert_matches!(
         missing_query_kind(&NoQueryReason::Terminal),
         InvalidInputKind::QueryOrFromRequired
-    ));
-    assert!(matches!(
+    );
+    assert_matches!(
         missing_query_kind(&NoQueryReason::EmptyStdin),
         InvalidInputKind::EmptyQuery
-    ));
+    );
 }


### PR DESCRIPTION
## 概要
失敗時に値が見えない `assert!(matches!)` を `assert_matches!`(Rust 1.96 安定化)へ置換し、テスト失敗時の診断性を上げる。

## 変更
- `assert!(matches!)` → `assert_matches!`: src/tests.rs 8 箇所

## 対象外: src/indexer/tests.rs:127/135
FileAction(Debug 未実装)を assert_matches! 化するには `#[derive(Debug)]` が必要だが、chunk_only.rs が 400 行上限(#255 file-size gate)で 1 行追加すると超過する。chunk_only.rs 分割時に別途対応。

## issue との差分
- 変更内容1(rust-version 1.95→1.96)は #278 で導入済みのため Cargo.toml は変更なし
- メッセージ付き assert は Display 表示維持のため対象外(issue 指定通り)

## 検証
- `cargo nextest run --profile ci --features test-support -p yomu`: 736 passed
- `cargo clippy --all-targets --all-features -p yomu -- -D warnings`: clean
- `cargo fmt -- --check`: clean
- file-size gate: chunk_only.rs 400 行(上限内)

Closes #276