### PR TITLE
chore(deps): rusqlite を 0.40 へ更新し rurico/amici を追従

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 [[package]]
 name = "amici"
 version = "0.1.0"
-source = "git+https://github.com/thkt/amici?rev=f122653#f12265318aab45c0e1a87d668eda2e28d20454a0"
+source = "git+https://github.com/thkt/amici?rev=5f4ee12#5f4ee1211655d09d31495c7b70534c02224679a0"
 dependencies = [
  "bytemuck",
  "rand 0.10.1",
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "block-buffer"
@@ -1383,9 +1383,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "a76001fb4daed01e5f2b518aac0b4dc592e7c734da63dbffcf0c64fa612a8d0c"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1421,9 +1421,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "mach-sys"
@@ -2104,7 +2104,7 @@ dependencies = [
 [[package]]
 name = "rurico"
 version = "0.2.0"
-source = "git+https://github.com/thkt/rurico?rev=e330c22#e330c2258c890e41bc70fd388cabb057d69d1cbd"
+source = "git+https://github.com/thkt/rurico?rev=adbe3a8#adbe3a8b7457dc8f174160b629b604479c6019cf"
 dependencies = [
  "bytemuck",
  "hf-hub",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "rurico-ffi"
 version = "0.1.0"
-source = "git+https://github.com/thkt/rurico?rev=e330c22#e330c2258c890e41bc70fd388cabb057d69d1cbd"
+source = "git+https://github.com/thkt/rurico?rev=adbe3a8#adbe3a8b7457dc8f174160b629b604479c6019cf"
 dependencies = [
  "mlx-sys",
  "rusqlite",
@@ -2131,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+checksum = "1b3492ea85308705c3a5cc24fb9b9cf77273d30590349070db42991202b214c4"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -2984,9 +2984,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,13 @@ repository = "https://github.com/thkt/yomu"
 test-support = ["rurico/test-support"]
 
 [dependencies]
-amici = { git = "https://github.com/thkt/amici", rev = "f122653" }
+amici = { git = "https://github.com/thkt/amici", rev = "5f4ee12" }
 bytemuck = "1"
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
-rurico = { git = "https://github.com/thkt/rurico", rev = "e330c22" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "adbe3a8" }
 regex = "1"
-rusqlite = { version = "0.39", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
@@ -39,7 +39,7 @@ tree-sitter-rust = "0.24"
 tree-sitter-typescript = "0.23"
 
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "e330c22", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "adbe3a8", features = ["test-support"] }
 tempfile = "3"
 tracing-test = { version = "0.2", features = ["no-env-filter"] }
 


### PR DESCRIPTION
## 概要
rurico の rusqlite 0.40 追従(rurico PR#208 / amici PR#141)に合流。libsqlite3-sys 0.37/0.38 の `links = "sqlite3"` 重複(同一 links の複数版を cargo が禁止)を避けるため、自前 rusqlite と rurico/amici rev を同一変更で 0.40 系へ揃える。

## 変更
- rusqlite 0.39 → 0.40
- rurico e330c22 → adbe3a8([dependencies] / [dev-dependencies] の 2 箇所)
- amici f122653 → 5f4ee12(amici 経由の rurico rev も adbe3a8 で一致)

## vendor submodule は更新しない(issue タスクの撤回)
issue は vendor 同期を挙げているが撤回した。理由:
1. vendor は **build 非依存**(cargo は git rev を直接解決、path/patch override なし)。`links` 重複の論拠は vendor に適用されない
2. vendor は **GT recall corpus の pinned rev に固定**されている(src/recall/corpus.rs:25、tests/brief_recall.rs の check_rev が FR-017 で強制)。bump すると Gate1(gate1_seeded_recall_meets_floor)が rev 不一致で panic し、corpus の re-baseline が必要 → #281 のスコープ外

## 検証(issue チェックリスト)
- libsqlite3-sys 0.38.0 単一に解決(0.37 消滅)、rusqlite 0.40.0 ✅
- MSRV 1.96 compatible 明示(cargo update が "latest Rust 1.96 compatible versions" を報告) ✅
- VTab API 未使用 ✅
- build / clippy clean、`cargo check --workspace` clean ✅
- FTS5 / vec0 + **Gate1 含む** nextest 736 passed(--features test-support) ✅

Closes #281