### PR TITLE
recall-bench に embed 完全性チェックを追加 (#288)

### DIFF
--- a/src/recall.rs
+++ b/src/recall.rs
@@ -133,9 +133,8 @@ pub struct CorpusReport {
     /// Embeddable chunks with no embedding at measurement time (#288). Non-zero
     /// means indexing died mid-embed, so seed inference ran against a partial
     /// vec candidate space and the numbers are invalid until `yomu index` is
-    /// re-run. The measuring caller sets this from
-    /// `storage::embed_gap_count` and flags `degraded`; the report itself must
-    /// carry the reason because recall-bench has no tracing subscriber.
+    /// re-run. The report itself carries the reason because recall-bench has
+    /// no tracing subscriber.
     pub embed_gap: u32,
 }
 
@@ -144,8 +143,9 @@ impl CorpusReport {
     /// unweighted mean. An empty entry set (no GT entry matched `repo`) is
     /// degraded with a vacuous 1.0 mean, mirroring [`measure`]'s degraded-on-
     /// vacuous contract so a `--repo` typo never reads as a silent pass.
-    /// `embed_gap` starts at 0; the measuring caller overwrites it (#288).
-    pub fn new(repo: String, entries: Vec<EntryReport>) -> Self {
+    /// A non-zero `embed_gap` (#288) degrades the aggregate here, so the
+    /// invariant `embed_gap > 0 → degraded` is established at construction.
+    pub fn new(repo: String, entries: Vec<EntryReport>, embed_gap: u32) -> Self {
         let aggregate = if entries.is_empty() {
             RecallReport {
                 recall: 1.0,
@@ -157,14 +157,14 @@ impl CorpusReport {
             RecallReport {
                 recall: entries.iter().map(|e| e.report.recall).sum::<f64>() / n,
                 cap_fit: entries.iter().map(|e| e.report.cap_fit).sum::<f64>() / n,
-                degraded: entries.iter().any(|e| e.report.degraded),
+                degraded: entries.iter().any(|e| e.report.degraded) || embed_gap > 0,
             }
         };
         Self {
             repo,
             aggregate,
             entries,
-            embed_gap: 0,
+            embed_gap,
         }
     }
 }

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -130,6 +130,13 @@ pub struct CorpusReport {
     pub repo: String,
     pub aggregate: RecallReport,
     pub entries: Vec<EntryReport>,
+    /// Embeddable chunks with no embedding at measurement time (#288). Non-zero
+    /// means indexing died mid-embed, so seed inference ran against a partial
+    /// vec candidate space and the numbers are invalid until `yomu index` is
+    /// re-run. The measuring caller sets this from
+    /// `storage::embed_gap_count` and flags `degraded`; the report itself must
+    /// carry the reason because recall-bench has no tracing subscriber.
+    pub embed_gap: u32,
 }
 
 impl CorpusReport {
@@ -137,6 +144,7 @@ impl CorpusReport {
     /// unweighted mean. An empty entry set (no GT entry matched `repo`) is
     /// degraded with a vacuous 1.0 mean, mirroring [`measure`]'s degraded-on-
     /// vacuous contract so a `--repo` typo never reads as a silent pass.
+    /// `embed_gap` starts at 0; the measuring caller overwrites it (#288).
     pub fn new(repo: String, entries: Vec<EntryReport>) -> Self {
         let aggregate = if entries.is_empty() {
             RecallReport {
@@ -156,6 +164,7 @@ impl CorpusReport {
             repo,
             aggregate,
             entries,
+            embed_gap: 0,
         }
     }
 }
@@ -174,6 +183,13 @@ pub fn render_recall_plain(report: &CorpusReport) -> String {
         "recall report: {} (degraded: {})",
         report.repo, report.aggregate.degraded
     );
+    if report.embed_gap > 0 {
+        let _ = writeln!(
+            out,
+            "  warning: {} embeddable chunks lack embeddings (indexing died mid-embed?) — numbers are invalid; re-run `yomu index` (#288)",
+            report.embed_gap
+        );
+    }
     let _ = writeln!(
         out,
         "  aggregate: recall={:.3} cap_fit={:.3} over {} entries",

--- a/src/recall/arms.rs
+++ b/src/recall/arms.rs
@@ -218,21 +218,22 @@ pub struct ArmComparisonReport {
     /// Embeddable chunks with no embedding at measurement time (#288). Non-zero
     /// means indexing died mid-embed: FTS rows are complete (written at chunk
     /// time) but the embedding arm ran against a partial vec candidate space,
-    /// so the arm comparison is invalid until `yomu index` is re-run. Set by
-    /// the measuring caller; carried in the report because recall-bench has no
-    /// tracing subscriber.
+    /// so the arm comparison is invalid until `yomu index` is re-run. Carried
+    /// in the report because recall-bench has no tracing subscriber.
     pub embed_gap: u32,
 }
 
 impl ArmComparisonReport {
     /// Builds a report from per-entry rows, computing the `(arm, class)`
-    /// summaries via [`summarize_arms`]. `embed_gap` starts at 0; the measuring
-    /// caller overwrites it (#288).
+    /// summaries via [`summarize_arms`]. A non-zero `embed_gap` (#288) forces
+    /// `degraded`, so the invariant `embed_gap > 0 → degraded` is established
+    /// at construction.
     pub fn new(
         repo: String,
         entries: Vec<ArmEntryReport>,
         k_values: &[usize],
         degraded: bool,
+        embed_gap: u32,
     ) -> Self {
         let summaries = summarize_arms(&entries, k_values);
         Self {
@@ -240,8 +241,8 @@ impl ArmComparisonReport {
             k_values: k_values.to_vec(),
             summaries,
             entries,
-            degraded,
-            embed_gap: 0,
+            degraded: degraded || embed_gap > 0,
+            embed_gap,
         }
     }
 }

--- a/src/recall/arms.rs
+++ b/src/recall/arms.rs
@@ -215,11 +215,19 @@ pub struct ArmComparisonReport {
     pub summaries: Vec<ArmClassSummary>,
     pub entries: Vec<ArmEntryReport>,
     pub degraded: bool,
+    /// Embeddable chunks with no embedding at measurement time (#288). Non-zero
+    /// means indexing died mid-embed: FTS rows are complete (written at chunk
+    /// time) but the embedding arm ran against a partial vec candidate space,
+    /// so the arm comparison is invalid until `yomu index` is re-run. Set by
+    /// the measuring caller; carried in the report because recall-bench has no
+    /// tracing subscriber.
+    pub embed_gap: u32,
 }
 
 impl ArmComparisonReport {
     /// Builds a report from per-entry rows, computing the `(arm, class)`
-    /// summaries via [`summarize_arms`].
+    /// summaries via [`summarize_arms`]. `embed_gap` starts at 0; the measuring
+    /// caller overwrites it (#288).
     pub fn new(
         repo: String,
         entries: Vec<ArmEntryReport>,
@@ -233,6 +241,7 @@ impl ArmComparisonReport {
             summaries,
             entries,
             degraded,
+            embed_gap: 0,
         }
     }
 }
@@ -254,6 +263,13 @@ pub fn render_arm_plain(report: &ArmComparisonReport) -> String {
         "arm comparison: {} (degraded: {})",
         report.repo, report.degraded
     );
+    if report.embed_gap > 0 {
+        let _ = writeln!(
+            out,
+            "  warning: {} embeddable chunks lack embeddings (indexing died mid-embed?) — numbers are invalid; re-run `yomu index` (#288)",
+            report.embed_gap
+        );
+    }
     let _ = writeln!(
         out,
         "  N={} per-entry rows; per-class read is directional, not statistically powered",

--- a/src/recall/tests.rs
+++ b/src/recall/tests.rs
@@ -121,7 +121,7 @@ fn corpus_report_aggregates_mean_and_renders_keys() {
             },
         },
     ];
-    let report = CorpusReport::new("rurico".to_owned(), entries);
+    let report = CorpusReport::new("rurico".to_owned(), entries, 0);
     assert!(
         (report.aggregate.recall - 0.75).abs() < f64::EPSILON,
         "aggregate recall is the mean (0.75), got {}",
@@ -162,7 +162,7 @@ fn corpus_report_aggregates_mean_and_renders_keys() {
 // T-022: corpus_report_with_no_entries_is_degraded
 #[test]
 fn corpus_report_with_no_entries_is_degraded() {
-    let report = CorpusReport::new("ghost".to_owned(), Vec::new());
+    let report = CorpusReport::new("ghost".to_owned(), Vec::new(), 0);
     assert!(
         report.aggregate.degraded,
         "no entries (e.g. --repo mismatch) → degraded, never a silent pass"
@@ -391,7 +391,7 @@ fn arm_comparison_report_json_and_plain() {
             must_recall: 0.25,
         },
     ];
-    let report = ArmComparisonReport::new("rurico".to_owned(), entries, &[1, 5], false);
+    let report = ArmComparisonReport::new("rurico".to_owned(), entries, &[1, 5], false, 0);
 
     let json = render_arm_json(&report);
     assert!(
@@ -455,18 +455,38 @@ fn classify_query_far_when_only_shared_term_is_digits() {
     );
 }
 
-// T-038: corpus_report_renders_embed_gap_warning (#288)
+/// One non-degraded entry, so degraded-flag asserts are not masked by the
+/// vacuous empty-corpus path.
+fn clean_entry() -> EntryReport {
+    EntryReport {
+        id: "e1".to_owned(),
+        report: RecallReport {
+            recall: 1.0,
+            cap_fit: 1.0,
+            degraded: false,
+        },
+    }
+}
+
+// T-038: corpus_report_embed_gap_degrades_and_renders_warning (#288)
 #[test]
-fn corpus_report_renders_embed_gap_warning() {
-    let mut report = CorpusReport::new("rurico".to_owned(), Vec::new());
-    assert_eq!(report.embed_gap, 0, "new() starts with no gap");
+fn corpus_report_embed_gap_degrades_and_renders_warning() {
+    let clean = CorpusReport::new("rurico".to_owned(), vec![clean_entry()], 0);
     assert!(
-        !render_recall_plain(&report).contains("warning:"),
+        !clean.aggregate.degraded,
+        "no gap and no degraded entry → not degraded"
+    );
+    assert!(
+        !render_recall_plain(&clean).contains("warning:"),
         "a complete embed renders no warning"
     );
 
-    report.embed_gap = 7;
-    let plain = render_recall_plain(&report);
+    let gapped = CorpusReport::new("rurico".to_owned(), vec![clean_entry()], 7);
+    assert!(
+        gapped.aggregate.degraded,
+        "embed_gap > 0 must degrade at construction (invariant)"
+    );
+    let plain = render_recall_plain(&gapped);
     assert!(
         plain.contains("warning: 7 embeddable chunks lack embeddings"),
         "plain carries the gap count, got: {plain}"
@@ -475,25 +495,33 @@ fn corpus_report_renders_embed_gap_warning() {
         plain.contains("re-run `yomu index`"),
         "plain names the fix, got: {plain}"
     );
-    let json = render_recall_json(&report);
+    let json = render_recall_json(&gapped);
     assert!(
         json.contains("\"embed_gap\":7"),
         "json carries the gap field, got: {json}"
     );
 }
 
-// T-039: arm_comparison_report_renders_embed_gap_warning (#288)
+// T-039: arm_comparison_report_embed_gap_degrades_and_renders_warning (#288)
 #[test]
-fn arm_comparison_report_renders_embed_gap_warning() {
-    let mut report = ArmComparisonReport::new("amici".to_owned(), Vec::new(), ARM_K_VALUES, false);
-    assert_eq!(report.embed_gap, 0, "new() starts with no gap");
+fn arm_comparison_report_embed_gap_degrades_and_renders_warning() {
+    let clean = ArmComparisonReport::new("amici".to_owned(), Vec::new(), ARM_K_VALUES, false, 0);
+    assert!(!clean.degraded, "no gap and degraded=false stays false");
     assert!(
-        !render_arm_plain(&report).contains("warning:"),
+        !render_arm_plain(&clean).contains("warning:"),
         "a complete embed renders no warning"
     );
 
-    report.embed_gap = 3;
-    let plain = render_arm_plain(&report);
+    let gapped = ArmComparisonReport::new("amici".to_owned(), Vec::new(), ARM_K_VALUES, false, 3);
+    assert!(
+        gapped.degraded,
+        "embed_gap > 0 must degrade at construction (invariant)"
+    );
+    let plain = render_arm_plain(&gapped);
+    assert!(
+        plain.contains("(degraded: true)"),
+        "plain header reflects the gap-forced degraded flag, got: {plain}"
+    );
     assert!(
         plain.contains("warning: 3 embeddable chunks lack embeddings"),
         "plain carries the gap count, got: {plain}"
@@ -502,7 +530,7 @@ fn arm_comparison_report_renders_embed_gap_warning() {
         plain.contains("re-run `yomu index`"),
         "plain names the fix, got: {plain}"
     );
-    let json = render_arm_json(&report);
+    let json = render_arm_json(&gapped);
     assert!(
         json.contains("\"embed_gap\":3"),
         "json carries the gap field, got: {json}"

--- a/src/recall/tests.rs
+++ b/src/recall/tests.rs
@@ -454,3 +454,57 @@ fn classify_query_far_when_only_shared_term_is_digits() {
         "a digits-only term must not match a digit-stripped seed token"
     );
 }
+
+// T-038: corpus_report_renders_embed_gap_warning (#288)
+#[test]
+fn corpus_report_renders_embed_gap_warning() {
+    let mut report = CorpusReport::new("rurico".to_owned(), Vec::new());
+    assert_eq!(report.embed_gap, 0, "new() starts with no gap");
+    assert!(
+        !render_recall_plain(&report).contains("warning:"),
+        "a complete embed renders no warning"
+    );
+
+    report.embed_gap = 7;
+    let plain = render_recall_plain(&report);
+    assert!(
+        plain.contains("warning: 7 embeddable chunks lack embeddings"),
+        "plain carries the gap count, got: {plain}"
+    );
+    assert!(
+        plain.contains("re-run `yomu index`"),
+        "plain names the fix, got: {plain}"
+    );
+    let json = render_recall_json(&report);
+    assert!(
+        json.contains("\"embed_gap\":7"),
+        "json carries the gap field, got: {json}"
+    );
+}
+
+// T-039: arm_comparison_report_renders_embed_gap_warning (#288)
+#[test]
+fn arm_comparison_report_renders_embed_gap_warning() {
+    let mut report = ArmComparisonReport::new("amici".to_owned(), Vec::new(), ARM_K_VALUES, false);
+    assert_eq!(report.embed_gap, 0, "new() starts with no gap");
+    assert!(
+        !render_arm_plain(&report).contains("warning:"),
+        "a complete embed renders no warning"
+    );
+
+    report.embed_gap = 3;
+    let plain = render_arm_plain(&report);
+    assert!(
+        plain.contains("warning: 3 embeddable chunks lack embeddings"),
+        "plain carries the gap count, got: {plain}"
+    );
+    assert!(
+        plain.contains("re-run `yomu index`"),
+        "plain names the fix, got: {plain}"
+    );
+    let json = render_arm_json(&report);
+    assert!(
+        json.contains("\"embed_gap\":3"),
+        "json carries the gap field, got: {json}"
+    );
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -33,6 +33,18 @@ pub(crate) fn fts_normalization() -> QueryNormalizationConfig {
 
 pub(crate) use amici::storage::{anon_placeholders, as_sql_params, in_placeholders};
 
+/// SQL predicate selecting embeddable chunks, parameterized by table alias.
+///
+/// Single source of truth for what the embed worklist covers (#288 audit RC-3):
+/// test chunks are chunked and FTS-indexed but never embedded, `IS NOT` keeps
+/// NULL `source_kind` (legacy rows) embeddable, and `inner_fn` chunks are
+/// skipped. Shared by [`get_stats`], `get_unembedded_chunks_for_file`, and
+/// `embed_gap_count` — a drift between those would silently false-clean the
+/// embed-completeness check.
+pub(crate) fn embeddable_predicate(alias: &str) -> String {
+    format!("{alias}.chunk_type != 'inner_fn' AND {alias}.source_kind IS NOT 'test'")
+}
+
 pub fn file_exists_in_index(conn: &Connection, file_path: &str) -> Result<bool, StorageError> {
     let count: u32 = conn.query_row(
         "SELECT COUNT(*) FROM chunks WHERE file_path = ?1",
@@ -45,10 +57,11 @@ pub fn file_exists_in_index(conn: &Connection, file_path: &str) -> Result<bool, 
 pub fn get_stats(conn: &Connection) -> Result<IndexStatus, StorageError> {
     let total_chunks: u32 = conn.query_row("SELECT COUNT(*) FROM chunks", [], |row| row.get(0))?;
 
-    // Test chunks are chunked and FTS-indexed but not embedded, so they are not
-    // embeddable. `IS NOT` keeps NULL source_kind (legacy rows) embeddable.
     let embeddable_chunks: u32 = conn.query_row(
-        "SELECT COUNT(*) FROM chunks WHERE chunk_type != 'inner_fn' AND source_kind IS NOT 'test'",
+        &format!(
+            "SELECT COUNT(*) FROM chunks WHERE {}",
+            embeddable_predicate("chunks")
+        ),
         [],
         |row| row.get(0),
     )?;

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -120,6 +120,24 @@ pub fn get_files_with_chunk_types(
     rows.collect::<Result<HashSet<_>, _>>().map_err(Into::into)
 }
 
+/// Counts chunks on the embed worklist (same predicate as
+/// [`get_unembedded_chunks_for_file`]: non-test `source_kind`, non-`inner_fn`)
+/// that have no embedding. A non-zero gap means indexing died mid-embed (#288):
+/// FTS rows are written synchronously at chunk time, so the index looks
+/// complete while vector search runs against a partial candidate space.
+/// `yomu index` re-runs fill the gap incrementally.
+pub fn embed_gap_count(conn: &Connection) -> Result<u32, StorageError> {
+    conn.query_row(
+        "SELECT COUNT(*)
+         FROM chunks c
+         LEFT JOIN embedded_chunk_ids e ON c.id = e.chunk_id
+         WHERE e.chunk_id IS NULL AND c.chunk_type != 'inner_fn' AND c.source_kind IS NOT 'test'",
+        [],
+        |row| row.get(0),
+    )
+    .map_err(Into::into)
+}
+
 pub fn has_embeddings(conn: &Connection) -> bool {
     conn.query_row(
         "SELECT EXISTS(SELECT 1 FROM embedded_chunk_ids)",

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -4,8 +4,8 @@ use rurico::embed::ChunkedEmbedding;
 use rusqlite::Connection;
 
 use super::{
-    ChunkType, StorageError, anon_placeholders, as_sql_params, in_placeholders,
-    insert_sub_embeddings,
+    ChunkType, StorageError, anon_placeholders, as_sql_params, embeddable_predicate,
+    in_placeholders, insert_sub_embeddings,
 };
 
 fn existing_embedded_ids(
@@ -61,16 +61,14 @@ pub fn get_unembedded_chunks_for_file(
     conn: &Connection,
     file_path: &str,
 ) -> Result<Vec<UnembeddedChunk>, StorageError> {
-    // `c.source_kind IS NOT 'test'` skips test chunks from the embed worklist
-    // (test code is FTS-searchable but not embedded). `IS NOT` is NULL-safe, so
-    // legacy rows with NULL source_kind stay embeddable.
-    let mut stmt = conn.prepare_cached(
+    let mut stmt = conn.prepare_cached(&format!(
         "SELECT c.id, c.content, c.chunk_type, c.name, p.name
          FROM chunks c
          LEFT JOIN chunks p ON c.parent_chunk_id = p.id
          LEFT JOIN embedded_chunk_ids e ON c.id = e.chunk_id
-         WHERE c.file_path = ?1 AND e.chunk_id IS NULL AND c.chunk_type != 'inner_fn' AND c.source_kind IS NOT 'test'",
-    )?;
+         WHERE c.file_path = ?1 AND e.chunk_id IS NULL AND {}",
+        embeddable_predicate("c")
+    ))?;
     let rows = stmt.query_map([file_path], |row| {
         Ok(UnembeddedChunk {
             id: row.get(0)?,
@@ -120,18 +118,21 @@ pub fn get_files_with_chunk_types(
     rows.collect::<Result<HashSet<_>, _>>().map_err(Into::into)
 }
 
-/// Counts chunks on the embed worklist (same predicate as
-/// [`get_unembedded_chunks_for_file`]: non-test `source_kind`, non-`inner_fn`)
-/// that have no embedding. A non-zero gap means indexing died mid-embed (#288):
-/// FTS rows are written synchronously at chunk time, so the index looks
-/// complete while vector search runs against a partial candidate space.
-/// `yomu index` re-runs fill the gap incrementally.
+/// Counts chunks on the embed worklist ([`embeddable_predicate`], the same
+/// predicate as [`get_unembedded_chunks_for_file`]) that have no embedding. A
+/// non-zero gap means indexing died mid-embed (#288): FTS rows are written
+/// synchronously at chunk time, so the index looks complete while vector
+/// search runs against a partial candidate space. `yomu index` re-runs fill
+/// the gap incrementally.
 pub fn embed_gap_count(conn: &Connection) -> Result<u32, StorageError> {
     conn.query_row(
-        "SELECT COUNT(*)
-         FROM chunks c
-         LEFT JOIN embedded_chunk_ids e ON c.id = e.chunk_id
-         WHERE e.chunk_id IS NULL AND c.chunk_type != 'inner_fn' AND c.source_kind IS NOT 'test'",
+        &format!(
+            "SELECT COUNT(*)
+             FROM chunks c
+             LEFT JOIN embedded_chunk_ids e ON c.id = e.chunk_id
+             WHERE e.chunk_id IS NULL AND {}",
+            embeddable_predicate("c")
+        ),
         [],
         |row| row.get(0),
     )

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -1614,6 +1614,93 @@ fn get_unembedded_file_paths_returns_only_unembedded() {
     assert_eq!(c_count, 1);
 }
 
+// T-711: embed_gap_count_counts_only_embeddable_unembedded_chunks
+#[test]
+fn embed_gap_count_counts_only_embeddable_unembedded_chunks() {
+    let (conn, _dir) = test_db();
+
+    // Embedded src chunk: not a gap.
+    insert_chunk(
+        &conn,
+        "src/done.rs",
+        &NewChunk {
+            chunk_type: &ChunkType::RustFn,
+            name: Some("done"),
+            content: "fn done() {}",
+            start_line: 1,
+            end_line: 2,
+            parent_index: None,
+            source_kind: Some(SourceKind::Src),
+            injection_flags: None,
+        },
+        "h1",
+        &ce(vec![0.0_f32; EMBEDDING_DIMS]),
+        None,
+    )
+    .unwrap();
+    assert_eq!(
+        embed_gap_count(&conn).unwrap(),
+        0,
+        "a fully embedded index has no gap"
+    );
+
+    // Unembedded src + NULL-kind chunks: both count (NULL stays embeddable,
+    // mirroring the embed worklist's NULL-safe `IS NOT 'test'`).
+    let pending = vec![
+        NewChunk {
+            chunk_type: &ChunkType::RustFn,
+            name: Some("a"),
+            content: "fn a() {}",
+            start_line: 1,
+            end_line: 2,
+            parent_index: None,
+            source_kind: Some(SourceKind::Src),
+            injection_flags: None,
+        },
+        NewChunk {
+            chunk_type: &ChunkType::RustFn,
+            name: Some("b"),
+            content: "fn b() {}",
+            start_line: 4,
+            end_line: 5,
+            parent_index: None,
+            source_kind: None,
+            injection_flags: None,
+        },
+    ];
+    replace_file_chunks_only(&conn, "src/pending.rs", &pending, "h2", "", &[], None).unwrap();
+
+    // Unembedded test-kind and inner_fn chunks: design-excluded, not gaps.
+    let test_kind = vec![NewChunk {
+        chunk_type: &ChunkType::RustFn,
+        name: Some("t"),
+        content: "fn t() {}",
+        start_line: 1,
+        end_line: 2,
+        parent_index: None,
+        source_kind: Some(SourceKind::Test),
+        injection_flags: None,
+    }];
+    replace_file_chunks_only(&conn, "src/t_tests.rs", &test_kind, "h3", "", &[], None).unwrap();
+    let inner = vec![NewChunk {
+        chunk_type: &ChunkType::InnerFn,
+        name: Some("inner"),
+        content: "fn inner() {}",
+        start_line: 1,
+        end_line: 2,
+        parent_index: None,
+        source_kind: Some(SourceKind::Src),
+        injection_flags: None,
+    }];
+    replace_file_chunks_only(&conn, "src/outer.rs", &inner, "h4", "", &[], None).unwrap();
+
+    assert_eq!(
+        embed_gap_count(&conn).unwrap(),
+        2,
+        "gap counts unembedded src + NULL-kind chunks only; test/inner_fn are design-excluded"
+    );
+}
+
 // T-149: needs_embedding_returns_true_for_chunk_only_file
 #[test]
 fn needs_embedding_returns_true_for_chunk_only_file() {

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -1618,6 +1618,11 @@ fn get_unembedded_file_paths_returns_only_unembedded() {
 #[test]
 fn embed_gap_count_counts_only_embeddable_unembedded_chunks() {
     let (conn, _dir) = test_db();
+    assert_eq!(
+        embed_gap_count(&conn).unwrap(),
+        0,
+        "an empty index (no chunks) has no gap"
+    );
 
     // Embedded src chunk: not a gap.
     insert_chunk(
@@ -5212,5 +5217,17 @@ fn search_by_fts_projects_source_kind_and_injection_flags() {
         hit.score > 0.0,
         "bm25 score must remain readable at the shifted offset (offset 9), got {}",
         hit.score
+    );
+}
+
+// T-712: embed_gap_count_propagates_query_failure (#288 audit RC-1)
+#[test]
+fn embed_gap_count_propagates_query_failure() {
+    let (conn, _dir) = test_db();
+    conn.execute("DROP TABLE embedded_chunk_ids", [])
+        .expect("drop table to simulate a broken schema");
+    assert!(
+        embed_gap_count(&conn).is_err(),
+        "a gap that cannot be measured must surface as Err, never as 0"
     );
 }

--- a/src/tools/briefing.rs
+++ b/src/tools/briefing.rs
@@ -139,16 +139,28 @@ impl Yomu {
         })
     }
 
+    /// Unembedded embeddable-chunk count for the embed-completeness check
+    /// (#288). 0 on a query failure: a DB that cannot answer this also fails
+    /// the measurement queries themselves, so the error surfaces there.
+    #[cfg(not(feature = "test-support"))]
+    fn embed_gap(&self) -> u32 {
+        let conn = self.conn.lock().expect("DB lock poisoned (embed_gap)");
+        storage::embed_gap_count(&conn).unwrap_or(0)
+    }
+
     /// Measures seed-less recall and weighted cap-fit for every bundled GT entry
     /// whose repo matches `repo`, against the current index, and renders a
     /// per-entry plus aggregate report (FR-011). Returns the rendered text and the
     /// aggregate degraded flag. The caller exits non-zero when degraded (FR-012):
     /// an unavailable embedding model makes seed inference fall back and flag
-    /// degraded, so a model-less run never reports a silent pass.
+    /// degraded, so a model-less run never reports a silent pass. An incomplete
+    /// embed (index died mid-embed, #288) likewise degrades, with the gap count
+    /// carried in the report.
     #[cfg(not(feature = "test-support"))]
     pub fn recall(&self, repo: &str, json: bool) -> Result<(String, bool), YomuError> {
         let gt = corpus::load_bundled()
             .map_err(|e| YomuError::Internal(format!("bundled GT corpus: {e}")))?;
+        let embed_gap = self.embed_gap();
         let mut entries = Vec::new();
         for entry in gt.entries.iter().filter(|e| e.repo == repo) {
             let task = brief::TaskBrief {
@@ -170,7 +182,9 @@ impl Yomu {
                 report,
             });
         }
-        let report = recall::CorpusReport::new(repo.to_owned(), entries);
+        let mut report = recall::CorpusReport::new(repo.to_owned(), entries);
+        report.embed_gap = embed_gap;
+        report.aggregate.degraded |= embed_gap > 0;
         let text = if json {
             recall::render_recall_json(&report)
         } else {
@@ -247,8 +261,12 @@ impl Yomu {
             .map_err(|e| YomuError::Internal(format!("bundled GT corpus: {e}")))?;
         let depth = ARM_CANDIDATE_DEPTH;
         let k = depth as usize;
+        let embed_gap = self.embed_gap();
         let mut entries = Vec::new();
-        let mut degraded = false;
+        // An incomplete embed (#288) invalidates the embedding arm: FTS rows
+        // are complete, so only one arm degrades — exactly the asymmetry the
+        // arm comparison must not silently absorb.
+        let mut degraded = embed_gap > 0;
         for entry in gt.entries.iter().filter(|e| e.repo == repo) {
             let class = recall::classify_query(&entry.task, &entry.seed);
             let seed_set: HashSet<String> = entry.seed.iter().cloned().collect();
@@ -280,12 +298,13 @@ impl Yomu {
                 must_recall: recall::recall_at_k(&fts_ranked, &must_set, k),
             });
         }
-        let report = recall::ArmComparisonReport::new(
+        let mut report = recall::ArmComparisonReport::new(
             repo.to_owned(),
             entries,
             recall::ARM_K_VALUES,
             degraded,
         );
+        report.embed_gap = embed_gap;
         let text = if json {
             recall::render_arm_json(&report)
         } else {

--- a/src/tools/briefing.rs
+++ b/src/tools/briefing.rs
@@ -140,12 +140,14 @@ impl Yomu {
     }
 
     /// Unembedded embeddable-chunk count for the embed-completeness check
-    /// (#288). 0 on a query failure: a DB that cannot answer this also fails
-    /// the measurement queries themselves, so the error surfaces there.
+    /// (#288). A query failure propagates instead of folding to 0: a gap that
+    /// cannot be measured must not read as "no gap" (audit RC-1 — the gap
+    /// query touches `embedded_chunk_ids`, which the FTS/vec measurement
+    /// queries do not, so they can succeed while this fails).
     #[cfg(not(feature = "test-support"))]
-    fn embed_gap(&self) -> u32 {
+    fn embed_gap(&self) -> Result<u32, YomuError> {
         let conn = self.conn.lock().expect("DB lock poisoned (embed_gap)");
-        storage::embed_gap_count(&conn).unwrap_or(0)
+        Ok(storage::embed_gap_count(&conn)?)
     }
 
     /// Measures seed-less recall and weighted cap-fit for every bundled GT entry
@@ -156,11 +158,16 @@ impl Yomu {
     /// degraded, so a model-less run never reports a silent pass. An incomplete
     /// embed (index died mid-embed, #288) likewise degrades, with the gap count
     /// carried in the report.
+    ///
+    /// Not concurrent-safe: the gap is sampled once before the measurement
+    /// loop, so running `yomu index` against the same DB during a bench run
+    /// can desynchronize the two (audit RC-4). recall-bench is a one-shot
+    /// maintainer diagnostic; do not run it while indexing.
     #[cfg(not(feature = "test-support"))]
     pub fn recall(&self, repo: &str, json: bool) -> Result<(String, bool), YomuError> {
         let gt = corpus::load_bundled()
             .map_err(|e| YomuError::Internal(format!("bundled GT corpus: {e}")))?;
-        let embed_gap = self.embed_gap();
+        let embed_gap = self.embed_gap()?;
         let mut entries = Vec::new();
         for entry in gt.entries.iter().filter(|e| e.repo == repo) {
             let task = brief::TaskBrief {
@@ -182,9 +189,7 @@ impl Yomu {
                 report,
             });
         }
-        let mut report = recall::CorpusReport::new(repo.to_owned(), entries);
-        report.embed_gap = embed_gap;
-        report.aggregate.degraded |= embed_gap > 0;
+        let report = recall::CorpusReport::new(repo.to_owned(), entries, embed_gap);
         let text = if json {
             recall::render_recall_json(&report)
         } else {
@@ -255,18 +260,22 @@ impl Yomu {
     /// diagnostic (ADR-0005 / OUTCOME.md:39), never a product CLI flag. A
     /// degraded embedding arm records an empty candidate list rather than
     /// falling back to FTS, so the two arms stay isolated.
+    ///
+    /// Not concurrent-safe, same contract as [`Yomu::recall`] (audit RC-4):
+    /// do not run while `yomu index` writes the same DB.
     #[cfg(not(feature = "test-support"))]
     pub fn recall_arms(&self, repo: &str, json: bool) -> Result<(String, bool), YomuError> {
         let gt = corpus::load_bundled()
             .map_err(|e| YomuError::Internal(format!("bundled GT corpus: {e}")))?;
         let depth = ARM_CANDIDATE_DEPTH;
         let k = depth as usize;
-        let embed_gap = self.embed_gap();
-        let mut entries = Vec::new();
         // An incomplete embed (#288) invalidates the embedding arm: FTS rows
         // are complete, so only one arm degrades — exactly the asymmetry the
-        // arm comparison must not silently absorb.
-        let mut degraded = embed_gap > 0;
+        // arm comparison must not silently absorb. The constructor folds the
+        // gap into `degraded`.
+        let embed_gap = self.embed_gap()?;
+        let mut entries = Vec::new();
+        let mut degraded = false;
         for entry in gt.entries.iter().filter(|e| e.repo == repo) {
             let class = recall::classify_query(&entry.task, &entry.seed);
             let seed_set: HashSet<String> = entry.seed.iter().cloned().collect();
@@ -298,19 +307,19 @@ impl Yomu {
                 must_recall: recall::recall_at_k(&fts_ranked, &must_set, k),
             });
         }
-        let mut report = recall::ArmComparisonReport::new(
+        let report = recall::ArmComparisonReport::new(
             repo.to_owned(),
             entries,
             recall::ARM_K_VALUES,
             degraded,
+            embed_gap,
         );
-        report.embed_gap = embed_gap;
         let text = if json {
             recall::render_arm_json(&report)
         } else {
             recall::render_arm_plain(&report)
         };
-        Ok((text, degraded))
+        Ok((text, report.degraded))
     }
 }
 


### PR DESCRIPTION
Closes #288

## 概要

#250 Phase 1b で発生した「embed が途中で死んだ index 上の無効測定」(FTS は chunk 書き込み時に完全、vec だけ部分欠損 — 外形上は完成に見える) を、recall-bench が機械的に検出して degraded 扱いにする。

- `storage::embed_gap_count`: embed worklist と同一述語で未 embed chunk を数える
- `embeddable_predicate(alias)`: 「embeddable chunk」の SQL 定義を単一化 (get_stats / get_unembedded_chunks_for_file / embed_gap_count の 3 箇所が共有 — 述語 drift によるチェックの false-clean を防ぐ)
- `CorpusReport` / `ArmComparisonReport` に `embed_gap` を constructor 引数として追加し、`embed_gap > 0 → degraded` の不変条件を構築時に確立。render に warning 行 (件数 + `yomu index` 再実行の案内)
- 理由を report 本文 (stdout) に載せるのは recall-bench が tracing subscriber を持たないため (`tracing::warn!` は no-op)
- `Yomu::embed_gap()` は query 失敗を `Result` で伝播 (0 に畳まない — gap query だけが `embedded_chunk_ids` を触り、FTS/vec の測定 query とテーブルが交差しないため、失敗を 0 に畳むと false-clean になる)
- `recall` / `recall_arms` に non-concurrent 契約を doc 化 (gap は loop 前の単一サンプル)

## 監査

実装後に /audit (12 reviewers → challenger/verifier → integrator) を実施し、確定指摘 RC-1〜RC-4 を 2nd commit で修正済み:

- RC-1 (high): `unwrap_or(0)` の false-clean 経路 → Result 伝播化
- RC-2 (high): 不変条件が constructor 外に散在 (二段階初期化) → 引数化
- RC-3 (medium): SQL 述語の 3 箇所重複 (DRY 3+ gate) → `embeddable_predicate`
- RC-4 (medium): TOCTOU → non-concurrent 契約の明文化 (one-shot 診断 CLI のため txn 化はオーバーキルと裁定)
- RC-6 (low): JSON surface (`embed_gap:0` 常時出力 / degraded_reason なし) は YAGNI で wontfix

## テスト計画

- [x] `cargo nextest run --profile ci --features test-support -p yomu` — 755 passed (T-711 boundary 込み / T-712 Err 伝播 / T-038・T-039 invariant)
- [x] `cargo clippy --all-targets --all-features -p yomu -- -D warnings` / `cargo fmt -- --check`
- [x] 実機 E2E (直列実行): 部分 embed DB → warning + exit 75 / 完全 index → exit 0 / `embedded_chunk_ids` 欠損 DB → migration が空再作成し gap=358 として検出 + exit 75
- 注: `recall` / `recall_arms` の配線は `cfg(not(feature = "test-support"))` のため CI では実行されない (CI は test-support ビルド)。部品は unit-tested、配線は constructor 化で 1 行の `?` + new() 呼び出しまで薄くした上で、上記 E2E を手動確認