### PR TITLE
refactor(yomu): storage の collect/IN-query scaffold を amici query_helpers へ移行 (#144)

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -31,7 +31,9 @@ pub(crate) fn fts_normalization() -> QueryNormalizationConfig {
     QueryNormalizationConfig::default()
 }
 
-pub(crate) use amici::storage::{anon_placeholders, as_sql_params, in_placeholders};
+pub(crate) use amici::storage::{
+    anon_placeholders, as_sql_params, collect_rows, fetch_by_in_clause, in_placeholders,
+};
 
 /// SQL predicate selecting embeddable chunks, parameterized by table alias.
 ///
@@ -99,7 +101,7 @@ pub fn get_stats(conn: &Connection) -> Result<IndexStatus, StorageError> {
 pub fn get_all_file_paths(conn: &Connection) -> Result<HashSet<String>, StorageError> {
     let mut stmt = conn.prepare_cached("SELECT DISTINCT file_path FROM chunks")?;
     let paths = stmt.query_map([], |row| row.get::<_, String>(0))?;
-    paths.collect::<Result<HashSet<_>, _>>().map_err(Into::into)
+    collect_rows(paths)
 }
 
 #[cfg(test)]

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -4,27 +4,20 @@ use rurico::embed::ChunkedEmbedding;
 use rusqlite::Connection;
 
 use super::{
-    ChunkType, StorageError, anon_placeholders, as_sql_params, embeddable_predicate,
-    in_placeholders, insert_sub_embeddings,
+    ChunkType, StorageError, anon_placeholders, as_sql_params, collect_rows, embeddable_predicate,
+    fetch_by_in_clause, insert_sub_embeddings,
 };
 
 fn existing_embedded_ids(
     conn: &Connection,
     chunk_ids: &[i64],
 ) -> Result<HashSet<i64>, StorageError> {
-    if chunk_ids.is_empty() {
-        return Ok(HashSet::new());
-    }
-    let sql = format!(
-        "SELECT chunk_id FROM embedded_chunk_ids WHERE chunk_id IN ({})",
-        in_placeholders(chunk_ids.len())
-    );
-    let params = as_sql_params(chunk_ids);
-    let mut stmt = conn.prepare(&sql)?;
-    let ids = stmt
-        .query_map(params.as_slice(), |row| row.get::<_, i64>(0))?
-        .collect::<Result<HashSet<_>, _>>()?;
-    Ok(ids)
+    fetch_by_in_clause(
+        conn,
+        chunk_ids,
+        "SELECT chunk_id FROM embedded_chunk_ids WHERE chunk_id IN ({placeholders})",
+        |row| row.get(0),
+    )
 }
 
 pub fn add_chunked_embeddings(
@@ -78,7 +71,7 @@ pub fn get_unembedded_chunks_for_file(
             parent_name: row.get(4)?,
         })
     })?;
-    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    collect_rows(rows)
 }
 
 pub fn get_imports_for_file(conn: &Connection, file_path: &str) -> Result<String, StorageError> {
@@ -115,7 +108,7 @@ pub fn get_files_with_chunk_types(
     let rows = stmt.query_map(as_sql_params(&params).as_slice(), |row| {
         row.get::<_, String>(0)
     })?;
-    rows.collect::<Result<HashSet<_>, _>>().map_err(Into::into)
+    collect_rows(rows)
 }
 
 /// Counts chunks on the embed worklist ([`embeddable_predicate`], the same
@@ -190,7 +183,7 @@ pub fn get_unembedded_file_paths(conn: &Connection) -> Result<Vec<(String, u32)>
     let rows = stmt.query_map([], |row| {
         Ok((row.get::<_, String>(0)?, row.get::<_, u32>(1)?))
     })?;
-    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    collect_rows(rows)
 }
 
 #[cfg(test)]

--- a/src/storage/graph.rs
+++ b/src/storage/graph.rs
@@ -4,7 +4,10 @@ use rusqlite::{Connection, params_from_iter};
 
 #[cfg(test)]
 use super::Reference;
-use super::{ChunkType, RefKind, StorageError, anon_placeholders, as_sql_params, in_placeholders};
+use super::{
+    ChunkType, RefKind, StorageError, anon_placeholders, as_sql_params, collect_rows,
+    fetch_by_in_clause, in_placeholders,
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Dependent {
@@ -78,7 +81,7 @@ pub fn get_transitive_dependents(
             depth: row.get(1)?,
         })
     })?;
-    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    collect_rows(rows)
 }
 
 /// Returns every `(source_file, target_file)` edge where both endpoints are
@@ -102,7 +105,7 @@ pub fn get_edges_among_files(
     let rows = stmt.query_map(params_from_iter(params.iter()), |row| {
         Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
     })?;
-    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    collect_rows(rows)
 }
 
 /// Forward closure: files that `seed` transitively depends on, ordered by
@@ -166,7 +169,7 @@ pub fn get_transitive_dependencies_multi(
             depth: row.get(1)?,
         })
     })?;
-    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    collect_rows(rows)
 }
 
 /// Returns every direct (depth=1) reference edge that points at `target_file`.
@@ -198,7 +201,7 @@ pub fn get_direct_references(
             via_symbol,
         })
     })?;
-    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    collect_rows(rows)
 }
 
 pub fn get_symbol_dependents(
@@ -213,7 +216,7 @@ pub fn get_symbol_dependents(
     let rows = stmt.query_map(rusqlite::params![target_file, symbol_name], |row| {
         row.get::<_, String>(0)
     })?;
-    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    collect_rows(rows)
 }
 
 pub fn get_reference_count(conn: &Connection) -> Result<u32, StorageError> {
@@ -226,7 +229,7 @@ pub fn get_reference_count(conn: &Connection) -> Result<u32, StorageError> {
 pub fn get_files_by_import_count(conn: &Connection) -> Result<Vec<String>, StorageError> {
     let mut stmt = conn.prepare_cached(SQL_FILES_BY_IMPORT_COUNT)?;
     let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
-    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    collect_rows(rows)
 }
 
 pub fn get_import_counts(
@@ -255,46 +258,31 @@ pub fn get_import_counts(
     let rows = stmt.query_map(as_sql_params(file_paths).as_slice(), |row| {
         Ok((row.get::<_, String>(0)?, row.get::<_, u32>(1)?))
     })?;
-    rows.collect::<Result<HashMap<_, _>, _>>()
-        .map_err(Into::into)
+    collect_rows(rows)
 }
 
 pub fn get_file_mtimes(
     conn: &Connection,
     file_paths: &[&str],
 ) -> Result<HashMap<String, i64>, StorageError> {
-    if file_paths.is_empty() {
-        return Ok(HashMap::new());
-    }
-    let placeholders = in_placeholders(file_paths.len());
-    let sql = format!(
-        "SELECT file_path, mtime_epoch FROM file_context WHERE file_path IN ({placeholders}) AND mtime_epoch IS NOT NULL"
-    );
-    let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map(as_sql_params(file_paths).as_slice(), |row| {
-        Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
-    })?;
-    rows.collect::<Result<HashMap<_, _>, _>>()
-        .map_err(Into::into)
+    fetch_by_in_clause(
+        conn,
+        file_paths,
+        "SELECT file_path, mtime_epoch FROM file_context WHERE file_path IN ({placeholders}) AND mtime_epoch IS NOT NULL",
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )
 }
 
 pub fn get_file_contexts(
     conn: &Connection,
     file_paths: &[&str],
 ) -> Result<HashMap<String, String>, StorageError> {
-    if file_paths.is_empty() {
-        return Ok(HashMap::new());
-    }
-    let placeholders = in_placeholders(file_paths.len());
-    let sql = format!(
-        "SELECT file_path, imports_text FROM file_context WHERE file_path IN ({placeholders})"
-    );
-    let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map(as_sql_params(file_paths).as_slice(), |row| {
-        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-    })?;
-    rows.collect::<Result<HashMap<_, _>, _>>()
-        .map_err(Into::into)
+    fetch_by_in_clause(
+        conn,
+        file_paths,
+        "SELECT file_path, imports_text FROM file_context WHERE file_path IN ({placeholders})",
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )
 }
 
 pub fn get_file_siblings(
@@ -371,5 +359,5 @@ pub fn get_dependents(
             depth: 1,
         })
     })?;
-    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    collect_rows(rows)
 }

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -6,7 +6,8 @@ use rurico::storage::{fts_quote, prepare_match_query};
 use rusqlite::{Connection, params, params_from_iter, types::ToSql};
 
 use super::{
-    Chunk, ChunkType, MatchSource, SearchResult, StorageError, anon_placeholders, fts_normalization,
+    Chunk, ChunkType, MatchSource, SearchResult, StorageError, anon_placeholders, collect_rows,
+    fts_normalization,
 };
 
 mod fetch;
@@ -40,7 +41,7 @@ fn knn_only(conn: &Connection, embedding: &[f32], k: u32) -> Result<Vec<(i64, f3
     let rows = stmt.query_map(params![query_bytes, k], |row| {
         Ok((row.get(0)?, row.get(1)?))
     })?;
-    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    collect_rows(rows)
 }
 
 /// Assemble [`SearchResult`]s from a `chunk_id → min distance` map and a
@@ -183,7 +184,7 @@ pub fn search_by_fts(
         })
     })?;
 
-    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    collect_rows(rows)
 }
 
 pub fn get_keyword_doc_frequencies(

--- a/src/storage/search/fetch.rs
+++ b/src/storage/search/fetch.rs
@@ -8,7 +8,7 @@ use amici::storage::filter::{append_in_filter, append_like_prefix_filter};
 use rusqlite::{Connection, Error as RusqliteError, Row, params, params_from_iter, types::ToSql};
 
 use crate::storage::{
-    Chunk, ChunkType, SourceKind, StorageError, anon_placeholders, in_placeholders,
+    Chunk, ChunkType, SourceKind, StorageError, anon_placeholders, collect_rows, fetch_by_in_clause,
 };
 
 /// Deserializes a [`Chunk`] from a row whose columns at `offset..=offset + 8`
@@ -101,26 +101,21 @@ pub fn get_chunks_by_ids(
     let rows = stmt.query_map(params_from_iter(params.iter()), |row| {
         Ok((row.get::<_, i64>(0)?, chunk_from_row(row, 1)?))
     })?;
-    rows.collect::<Result<HashMap<_, _>, _>>()
-        .map_err(Into::into)
+    collect_rows(rows)
 }
 
 /// Bulk-fetch every Chunk (with body content) belonging to the given files.
 /// Output is sorted by `(file_path, start_line)` so brief expansion can apply
 /// topological ordering on top without an extra sort pass.
 pub fn get_chunks_for_files(conn: &Connection, paths: &[&str]) -> Result<Vec<Chunk>, StorageError> {
-    if paths.is_empty() {
-        return Ok(Vec::new());
-    }
-    let placeholders = in_placeholders(paths.len());
-    let sql = format!(
+    fetch_by_in_clause(
+        conn,
+        paths,
         "SELECT file_path, chunk_type, name, content, start_line, end_line, parent_chunk_id, source_kind, injection_flags
          FROM chunks WHERE file_path IN ({placeholders})
-         ORDER BY file_path, start_line"
-    );
-    let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map(params_from_iter(paths.iter()), |row| chunk_from_row(row, 0))?;
-    rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+         ORDER BY file_path, start_line",
+        |row| chunk_from_row(row, 0),
+    )
 }
 
 pub fn get_chunks_for_from_target(


### PR DESCRIPTION
## 概要と目的

storage 配下に同形の手書き rusqlite パターン (collect+map_err 13 箇所、empty-guard+IN-clause 組み立て 4 箇所) が散在していた。amici query_helpers (collect_rows / fetch_by_in_clause) へ移行し net -21 行。挙動は同一 (下記検証)。

## 変更内容

- `.collect::<Result<C,_>>().map_err(Into::into)` → `collect_rows(rows)` 13 箇所 (embed / graph / search / search/fetch / storage)
- empty-guard + `in_placeholders` + prepare + query_map の定型 → `fetch_by_in_clause` 4 箇所 (existing_embedded_ids / get_file_mtimes / get_file_contexts / get_chunks_for_files)

## スコープ

- **対象外**: get_file_siblings (1 行→複数 entry の one-to-many)、get_edges_among_files / get_files_with_chunk_types (IN clause 2 つ)、get_chunks_by_ids (動的 filter 付加)、get_keyword_doc_frequencies (raw rusqlite::Error を fallback 判定に使う意図的非変換) — helper の単一 {placeholders} / 1行1要素 mapper に合わない

## テスト方法

1. `cargo nextest run --features test-support` → 755 passed
2. diff-cover (base=main) → 100%
3. audit 済: 等価性検証 (空キー経路 / {placeholders} 展開 / prepare 選択 / バインド順 / エラー variant 同一性) で findings 0

## 関連

- Closes #144