### PR TITLE
refactor(yomu): グラフエッジを FileEdge 名前付き構造体に (#143)

### DIFF
--- a/src/brief/tests.rs
+++ b/src/brief/tests.rs
@@ -8,7 +8,7 @@ use super::cap::apply_cap;
 use super::topo::topo_sort;
 use super::*;
 use crate::storage::{
-    EMBEDDING_DIMS, NewChunk, RefKind, Reference, SourceKind, ce, insert_chunk, open_db,
+    EMBEDDING_DIMS, FileEdge, NewChunk, RefKind, Reference, SourceKind, ce, insert_chunk, open_db,
     replace_file_references,
 };
 
@@ -36,6 +36,13 @@ fn test_db() -> (Connection, TempDir) {
     let dir = tempdir().unwrap();
     let conn = open_db(&dir.path().join("test.db")).unwrap();
     (conn, dir)
+}
+
+fn file_edge(source: &str, target: &str) -> FileEdge {
+    FileEdge {
+        source: source.to_owned(),
+        target: target.to_owned(),
+    }
 }
 
 fn seed_file(value: &str) -> Seed {
@@ -427,8 +434,8 @@ fn topo_sort_orders_dependencies_first() {
         make_brief_chunk("src/c.rs", "c"),
     ];
     let edges = vec![
-        ("src/a.rs".to_owned(), "src/b.rs".to_owned()),
-        ("src/b.rs".to_owned(), "src/c.rs".to_owned()),
+        file_edge("src/a.rs", "src/b.rs"),
+        file_edge("src/b.rs", "src/c.rs"),
     ];
 
     let sorted = topo_sort(chunks, &edges);
@@ -454,8 +461,8 @@ fn topo_sort_orders_fan_in_after_all_dependencies() {
         make_brief_chunk("src/c.rs", "c"),
     ];
     let edges = vec![
-        ("src/a.rs".to_owned(), "src/b.rs".to_owned()),
-        ("src/a.rs".to_owned(), "src/c.rs".to_owned()),
+        file_edge("src/a.rs", "src/b.rs"),
+        file_edge("src/a.rs", "src/c.rs"),
     ];
 
     let sorted = topo_sort(chunks, &edges);
@@ -716,8 +723,8 @@ fn topo_sort_places_cycle_members_at_tail() {
         make_brief_chunk("src/a.rs", "a"),
     ];
     let edges = vec![
-        ("src/a.rs".to_owned(), "src/b.rs".to_owned()),
-        ("src/b.rs".to_owned(), "src/a.rs".to_owned()),
+        file_edge("src/a.rs", "src/b.rs"),
+        file_edge("src/b.rs", "src/a.rs"),
     ];
 
     let sorted = topo_sort(chunks, &edges);

--- a/src/brief/topo.rs
+++ b/src/brief/topo.rs
@@ -3,19 +3,27 @@
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 
+use crate::storage::FileEdge;
+
 use super::BriefChunk;
 
 type DepGraph = (HashMap<String, u32>, HashMap<String, Vec<String>>);
 
-fn build_dep_graph(chunks: &[BriefChunk], edges: &[(String, String)]) -> DepGraph {
+fn build_dep_graph(chunks: &[BriefChunk], edges: &[FileEdge]) -> DepGraph {
     let in_scope: HashSet<&str> = chunks.iter().map(|c| c.file_path.as_str()).collect();
     let mut out_degree: HashMap<String, u32> =
         in_scope.iter().map(|p| ((*p).to_owned(), 0)).collect();
     let mut dependents: HashMap<String, Vec<String>> = HashMap::new();
-    for (src, tgt) in edges {
-        if src != tgt && in_scope.contains(src.as_str()) && in_scope.contains(tgt.as_str()) {
-            *out_degree.entry(src.clone()).or_insert(0) += 1;
-            dependents.entry(tgt.clone()).or_default().push(src.clone());
+    for FileEdge { source, target } in edges {
+        if source != target
+            && in_scope.contains(source.as_str())
+            && in_scope.contains(target.as_str())
+        {
+            *out_degree.entry(source.clone()).or_insert(0) += 1;
+            dependents
+                .entry(target.clone())
+                .or_default()
+                .push(source.clone());
         }
     }
     (out_degree, dependents)
@@ -69,7 +77,7 @@ fn kahn_positions(graph: DepGraph) -> HashMap<String, usize> {
 /// come before their dependents), tie-breaking by file_path lex order.
 /// Within the same file, chunks keep their `start_line` ordering. Cycles
 /// degrade to lex order at the tail of the result.
-pub(super) fn topo_sort(chunks: Vec<BriefChunk>, edges: &[(String, String)]) -> Vec<BriefChunk> {
+pub(super) fn topo_sort(chunks: Vec<BriefChunk>, edges: &[FileEdge]) -> Vec<BriefChunk> {
     let positions = kahn_positions(build_dep_graph(&chunks, edges));
     let mut sorted = chunks;
     sorted.sort_by_key(|c| {

--- a/src/storage/graph.rs
+++ b/src/storage/graph.rs
@@ -15,6 +15,13 @@ pub struct Dependent {
     pub depth: u32,
 }
 
+/// One dependency edge between two files: `source` imports/references `target`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FileEdge {
+    pub source: String,
+    pub target: String,
+}
+
 /// One reference edge from `source_file` to a target file, retaining the
 /// `ref_kind` (named/default/...) and the symbol that triggered it.
 ///
@@ -84,13 +91,13 @@ pub fn get_transitive_dependents(
     collect_rows(rows)
 }
 
-/// Returns every `(source_file, target_file)` edge where both endpoints are
-/// in `paths`. Used by brief topo sort to build a dependency graph
-/// restricted to the in-scope chunk set.
+/// Returns every [`FileEdge`] where both endpoints are in `paths`. Used by
+/// brief topo sort to build a dependency graph restricted to the in-scope
+/// chunk set.
 pub fn get_edges_among_files(
     conn: &Connection,
     paths: &[&str],
-) -> Result<Vec<(String, String)>, StorageError> {
+) -> Result<Vec<FileEdge>, StorageError> {
     if paths.is_empty() {
         return Ok(Vec::new());
     }
@@ -103,7 +110,10 @@ pub fn get_edges_among_files(
     let mut params: Vec<&str> = paths.to_vec();
     params.extend_from_slice(paths);
     let rows = stmt.query_map(params_from_iter(params.iter()), |row| {
-        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        Ok(FileEdge {
+            source: row.get(0)?,
+            target: row.get(1)?,
+        })
     })?;
     collect_rows(rows)
 }

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -731,6 +731,30 @@ fn replace_file_references_replaces_existing() {
     assert_eq!(dependents[0].file_path, "src/A.tsx");
 }
 
+// T-736: get_edges_among_files_maps_source_and_target_columns
+#[test]
+fn get_edges_among_files_maps_source_and_target_columns() {
+    let (conn, _dir) = test_db();
+    let refs = vec![Reference {
+        source_file: "src/A.tsx".into(),
+        target_file: "src/B.tsx".into(),
+        symbol_name: Some("B".into()),
+        ref_kind: RefKind::Named,
+    }];
+    replace_file_references(&conn, "src/A.tsx", &refs).unwrap();
+
+    // Pins the row-mapper direction: a swap of source/target would invert
+    // every dependency edge fed into brief topo sort.
+    let edges = get_edges_among_files(&conn, &["src/A.tsx", "src/B.tsx"]).unwrap();
+    assert_eq!(
+        edges,
+        vec![FileEdge {
+            source: "src/A.tsx".to_owned(),
+            target: "src/B.tsx".to_owned(),
+        }]
+    );
+}
+
 // T-571: get_direct_references_returns_kind_and_symbol_per_edge
 #[test]
 fn get_direct_references_returns_kind_and_symbol_per_edge() {


### PR DESCRIPTION
## 概要と目的

ファイル依存エッジが `(String, String)` タプルで、source/target の意味が型に乗っていなかった。FileEdge 名前付き構造体にして取り違えを型レベルで防ぐ。

#144 (query_helpers 移行) の上に stacked。親マージ後に base が main へ auto-retarget される。

## 変更内容

- `FileEdge { source, target }` を storage/graph.rs に追加 (source が target を import/参照する向き)
- get_edges_among_files → `Result<Vec<FileEdge>, StorageError>`、topo_sort / build_dep_graph が `&[FileEdge]` を受けパターン分解
- brief/tests.rs に file_edge ヘルパー (3 テストの edges 構築を置換)
- T-736: SQL 層を通して row mapper の列対応 (source_file→source / target_file→target) を exact assert — mapper swap は brief topo の全エッジ反転になるが、既存 topo テストは SQL をバイパスしていて検出できなかった (audit 検出の gap)

## テスト方法

1. `cargo nextest run --features test-support` → 756 passed
2. audit 済 (SQL 列順 vs フィールド対応の swap 検証 / derive セットの兄弟型一貫性 / タプル残存 caller なし)

## 関連

- Closes #143