### PR TITLE
refactor(yomu): build_search_notes を pure free fn 化し note 分岐を直接テスト (#273)

### DIFF
--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 
 use crate::{query, storage};
 
-use super::embedder::EmbedderDegraded;
+use super::embedder::{DegradedReason, EmbedderDegraded};
 use super::format::{
     EnrichmentContext, format_no_results_message, format_results_grouped, format_results_json,
 };
@@ -39,7 +39,12 @@ impl Yomu {
 
         let stats = self.with_db(storage::get_stats)?;
         let outcome = self.run_search_query(query, limit, offset, paths)?;
-        let notes = self.build_search_notes(&stats, outcome.degraded);
+        let notes = build_search_notes(
+            &stats,
+            self.reranker_note(),
+            self.degraded_reason(),
+            outcome.degraded,
+        );
 
         self.format_search_results(&outcome.results, &stats, notes, format, outcome.degraded)
     }
@@ -75,26 +80,6 @@ impl Yomu {
         Ok(outcome)
     }
 
-    /// Assembles the user-facing advisory notes (index-coverage hint, reranker
-    /// status, degraded-embedding warning) appended to search output.
-    fn build_search_notes(&self, stats: &storage::IndexStatus, degraded: bool) -> Vec<String> {
-        let mut notes: Vec<String> = Vec::new();
-        if let Some(msg) = index_hint(stats) {
-            notes.push(msg);
-        }
-        if let Some(note) = self.reranker_note() {
-            notes.push(note);
-        }
-        if let Some(reason) = self.degraded_reason() {
-            if let Some(note) = EmbedderDegraded(*reason).user_note("yomu model download") {
-                notes.push(note);
-            }
-        } else if degraded {
-            notes.push("embedding model not loaded; results from text search only".into());
-        }
-        notes
-    }
-
     fn search_from(
         &self,
         from: &str,
@@ -115,6 +100,11 @@ impl Yomu {
             Ok((chunk_ids, embedding_bytes))
         })?;
 
+        // Intentional note asymmetry vs the main search path (#273): `--from`
+        // replays stored embeddings through `query::search_from_file`, which
+        // uses neither the query-time embedder nor the reranker — emitting
+        // their degradation notes here would claim a degradation in features
+        // this path does not exercise. Only the index-coverage hint applies.
         let mut notes: Vec<String> = Vec::new();
         if let Some(msg) = index_hint(&stats) {
             notes.push(msg);
@@ -196,6 +186,33 @@ impl Yomu {
         }
         self.with_db(move |conn| storage::get_chunks_by_ids(conn, &parent_ids, None, &[]))
     }
+}
+
+/// Assembles the user-facing advisory notes (index-coverage hint, reranker
+/// status, degraded-embedding warning) appended to search output. Pure free
+/// fn (depends only on its arguments) so the note-assembly branches are
+/// directly unit-testable without constructing a `Yomu` (#273).
+pub(super) fn build_search_notes(
+    stats: &storage::IndexStatus,
+    reranker_note: Option<String>,
+    degraded_reason: Option<&DegradedReason>,
+    degraded: bool,
+) -> Vec<String> {
+    let mut notes: Vec<String> = Vec::new();
+    if let Some(msg) = index_hint(stats) {
+        notes.push(msg);
+    }
+    if let Some(note) = reranker_note {
+        notes.push(note);
+    }
+    if let Some(reason) = degraded_reason {
+        if let Some(note) = EmbedderDegraded(*reason).user_note("yomu model download") {
+            notes.push(note);
+        }
+    } else if degraded {
+        notes.push("embedding model not loaded; results from text search only".into());
+    }
+    notes
 }
 
 /// Rejects an empty or over-length query before any DB work. Returns `Ok(())`

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -135,6 +135,118 @@ fn validate_search_query_accepts_at_limit_and_none() {
     );
 }
 
+fn index_status(total_chunks: u32, embedded_chunks: u32) -> storage::IndexStatus {
+    storage::IndexStatus {
+        total_files: 1,
+        total_chunks,
+        embeddable_chunks: total_chunks,
+        embedded_chunks,
+        last_indexed_at: None,
+    }
+}
+
+// T-728: build_search_notes_appends_reranker_note_after_index_hint
+#[test]
+fn build_search_notes_appends_reranker_note_after_index_hint() {
+    use super::search::build_search_notes;
+    let notes = build_search_notes(
+        &index_status(0, 0),
+        Some("reranker note".to_owned()),
+        None,
+        false,
+    );
+    assert_eq!(
+        notes,
+        vec![
+            "index is empty; run `yomu index`".to_owned(),
+            "reranker note".to_owned(),
+        ],
+        "index hint first, then the reranker note"
+    );
+}
+
+// T-729: build_search_notes_prefers_degraded_reason_over_flag
+#[test]
+fn build_search_notes_prefers_degraded_reason_over_flag() {
+    use super::search::build_search_notes;
+    let notes = build_search_notes(
+        &index_status(10, 10),
+        None,
+        Some(&DegradedReason::NotInstalled),
+        true,
+    );
+    assert_eq!(
+        notes,
+        vec![
+            "embedding model not installed; run `yomu model download` to enable semantic search"
+                .to_owned(),
+        ],
+        "a known reason replaces the generic degraded-flag note"
+    );
+}
+
+// T-730: build_search_notes_degraded_flag_without_reason
+#[test]
+fn build_search_notes_degraded_flag_without_reason() {
+    use super::search::build_search_notes;
+    let notes = build_search_notes(&index_status(10, 10), None, None, true);
+    assert_eq!(
+        notes,
+        vec!["embedding model not loaded; results from text search only".to_owned()],
+        "without a recorded reason the degraded flag emits the generic note"
+    );
+}
+
+// T-731: build_search_notes_disabled_reason_suppresses_note
+#[test]
+fn build_search_notes_disabled_reason_suppresses_note() {
+    use super::search::build_search_notes;
+    let notes = build_search_notes(
+        &index_status(10, 10),
+        None,
+        Some(&DegradedReason::Disabled),
+        true,
+    );
+    assert_eq!(
+        notes,
+        Vec::<String>::new(),
+        "Disabled is caller opt-out: no degradation note even with the flag set"
+    );
+}
+
+// T-737: build_search_notes_with_healthy_index_and_no_degradation_is_empty
+#[test]
+fn build_search_notes_with_healthy_index_and_no_degradation_is_empty() {
+    use super::search::build_search_notes;
+    let notes = build_search_notes(&index_status(10, 10), None, None, false);
+    assert_eq!(
+        notes,
+        Vec::<String>::new(),
+        "a healthy index with no degradation must not inject phantom notes"
+    );
+}
+
+// T-738: build_search_notes_orders_hint_reranker_degraded
+#[test]
+fn build_search_notes_orders_hint_reranker_degraded() {
+    use super::search::build_search_notes;
+    let notes = build_search_notes(
+        &index_status(0, 0),
+        Some("reranker note".to_owned()),
+        Some(&DegradedReason::BackendUnavailable),
+        false,
+    );
+    assert_eq!(
+        notes,
+        vec![
+            "index is empty; run `yomu index`".to_owned(),
+            "reranker note".to_owned(),
+            "embedding model unavailable; results from text search only".to_owned(),
+        ],
+        "push order is hint, reranker, degraded; BackendUnavailable maps to the unavailable wording"
+    );
+}
+
 // T-177: search_rejects_path_traversal
 #[test]
 fn search_rejects_path_traversal() {


### PR DESCRIPTION
## 概要と目的

search の advisory note 分岐 (index hint / reranker / degraded) が &self メソッド内にあり、Yomu を構築しないとテストできなかった。pure free fn に抽出して分岐を直接 pin する。

#145 (OutputFormat) の上に stacked。親マージ後に base が main へ auto-retarget される。

## 変更内容

- build_search_notes を pub(super) free fn 化 (引数: stats / reranker_note / degraded_reason / degraded)
- T-728〜T-731 + T-737/T-738: note 分岐の直接テスト (hint→reranker→degraded の順序 / Disabled 抑制 / 全入力空の identity / BackendUnavailable 文言)
- search_from の意図的非対称をコメント化: --from は保存済み embedding を再生し query-time embedder / reranker を使わないため、両者の劣化 note を出すと実行していない機能の劣化を主張することになる

## 設計判断

- search_from への note 対称化 (issue 案 item 2) は不採用 — query::search_from_file が embedder/reranker 非使用であることを検証済み (内部の rank::rerank はヒューリスティックで cross-encoder ではない)

## テスト方法

1. `cargo nextest run --features test-support` → 761 passed
2. audit 済 (抽出等価性: push 順序 / else-if 構造 / 文字列の同一性、分岐網羅 6 ケース)

## 関連

- Closes #273