### PR TITLE
fix(yomu): brief の degraded note を原因別にし空 closure の誤帰属を解消 (#238)

### DIFF
--- a/src/brief.rs
+++ b/src/brief.rs
@@ -72,10 +72,37 @@ pub struct BriefChunk {
     pub injection_flags: Option<Vec<String>>,
 }
 
+/// Why a brief run is degraded. One run can carry several causes in stage
+/// order (seed inference before closure expansion); `render_plain` names each
+/// so an empty closure is no longer misattributed to the FTS fallback (#238).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DegradedCause {
+    /// Seed inference fell back to FTS-only (embedding model unavailable).
+    SeedFtsFallback,
+    /// No file seeds reached expansion (inference resolved none).
+    EmptySeeds,
+    /// Seeds expanded to zero chunks (not in index, or no dependencies).
+    EmptyClosure,
+}
+
+impl DegradedCause {
+    fn describe(self) -> &'static str {
+        match self {
+            Self::SeedFtsFallback => "FTS-only seed selection",
+            Self::EmptySeeds => "no file seeds resolved",
+            Self::EmptyClosure => "seeds expanded to zero chunks (not in index or no dependencies)",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct BriefOutput {
     pub chunks: Vec<BriefChunk>,
-    pub degraded: bool,
+    /// Degradation causes in stage order; empty means a healthy run. The
+    /// boolean view ([`BriefOutput::degraded`]) derives from this so flag and
+    /// cause cannot drift apart.
+    pub degraded_causes: Vec<DegradedCause>,
     pub total_chunks: u32,
     pub total_bytes: u32,
     /// Distinct files reachable in the closure after the test filter and before
@@ -83,6 +110,14 @@ pub struct BriefOutput {
     /// is the must-include weight reachable here, isolating the cap's effect
     /// from the closure's coverage. Not serialized in the CLI output.
     pub reachable_files: Vec<String>,
+}
+
+impl BriefOutput {
+    /// Whether any degradation cause was recorded. JSON output and the recall
+    /// aggregate keep consuming this boolean view.
+    pub fn degraded(&self) -> bool {
+        !self.degraded_causes.is_empty()
+    }
 }
 
 fn collect_seed_paths(task: &TaskBrief) -> Vec<String> {
@@ -207,7 +242,7 @@ struct JsonChunk<'a> {
 /// no pretty-printing). See `JsonOutput` / `JsonChunk` for the shape.
 pub fn render_json(output: &BriefOutput) -> String {
     let json = JsonOutput {
-        degraded: output.degraded,
+        degraded: output.degraded(),
         chunks: output
             .chunks
             .iter()
@@ -230,13 +265,21 @@ pub fn render_json(output: &BriefOutput) -> String {
     serde_json::to_string(&json).expect("BriefOutput JSON serialization is infallible")
 }
 
-const DEGRADED_NOTE: &str = "Note: degraded mode — FTS-only seed selection";
+/// Renders the degradation advisory naming every recorded cause in stage
+/// order, or `None` for a healthy run. Cause-specific wording is the #238
+/// fix: a one-size note misattributed empty closures to the FTS fallback.
+fn degraded_note(causes: &[DegradedCause]) -> Option<String> {
+    if causes.is_empty() {
+        return None;
+    }
+    let reasons: Vec<&str> = causes.iter().map(|c| c.describe()).collect();
+    Some(format!("Note: degraded mode — {}", reasons.join("; ")))
+}
 
 /// Plain CLI rendering (FR-011 + FR-014): each chunk becomes
 /// `<file_path>:<start_line>-<end_line>\n<content>`, separated by `\n---\n`.
-/// When `output.degraded` is true, prepends an advisory line so the caller
-/// knows seed selection fell back to FTS-only. Empty + non-degraded renders
-/// to an empty string.
+/// A degraded run prepends an advisory line naming each recorded cause
+/// ([`degraded_note`]). Empty + non-degraded renders to an empty string.
 pub fn render_plain(output: &BriefOutput) -> String {
     let body = output
         .chunks
@@ -249,10 +292,10 @@ pub fn render_plain(output: &BriefOutput) -> String {
         })
         .collect::<Vec<_>>()
         .join("\n---\n");
-    match (output.degraded, body.is_empty()) {
-        (true, true) => DEGRADED_NOTE.to_owned(),
-        (true, false) => format!("{DEGRADED_NOTE}\n{body}"),
-        (false, _) => body,
+    match (degraded_note(&output.degraded_causes), body.is_empty()) {
+        (Some(note), true) => note,
+        (Some(note), false) => format!("{note}\n{body}"),
+        (None, _) => body,
     }
 }
 
@@ -262,7 +305,7 @@ pub fn expand_plan(conn: &Connection, task: &TaskBrief) -> Result<BriefOutput, S
         tracing::warn!("expand_plan called with empty seeds; returning empty");
         return Ok(BriefOutput {
             chunks: Vec::new(),
-            degraded: true,
+            degraded_causes: vec![DegradedCause::EmptySeeds],
             total_chunks: 0,
             total_bytes: 0,
             reachable_files: Vec::new(),
@@ -333,7 +376,7 @@ pub fn expand_plan(conn: &Connection, task: &TaskBrief) -> Result<BriefOutput, S
 
     Ok(BriefOutput {
         chunks: ordered,
-        degraded: false,
+        degraded_causes: Vec::new(),
         total_chunks,
         total_bytes,
         reachable_files,

--- a/src/brief/tests.rs
+++ b/src/brief/tests.rs
@@ -20,9 +20,10 @@ fn expand_plan_empty_seeds_returns_empty_degraded() {
     let task = task_with_seeds(vec![], 1);
     let output = expand_plan(&conn, &task).unwrap();
     assert!(output.chunks.is_empty(), "empty seeds yield empty chunks");
-    assert!(
-        output.degraded,
-        "empty seeds must mark degraded as invariant violation"
+    assert_eq!(
+        output.degraded_causes,
+        vec![DegradedCause::EmptySeeds],
+        "empty seeds must record the EmptySeeds cause (#238)"
     );
     assert_eq!(output.total_chunks, 0);
     assert_eq!(output.total_bytes, 0);
@@ -281,7 +282,7 @@ fn render_json_emits_spec_shape() {
             source_kind: None,
             injection_flags: None,
         }],
-        degraded: true,
+        degraded_causes: vec![DegradedCause::SeedFtsFallback],
         total_chunks: 1,
         total_bytes: 11,
         reachable_files: Vec::new(),
@@ -317,7 +318,7 @@ fn render_json_includes_seed_and_modkinds() {
             chunk(ChunkInclusionReason::Sibling),
             chunk(ChunkInclusionReason::ModDecl),
         ],
-        degraded: false,
+        degraded_causes: Vec::new(),
         total_chunks: 3,
         total_bytes: 0,
         reachable_files: Vec::new(),
@@ -326,6 +327,10 @@ fn render_json_includes_seed_and_modkinds() {
     assert_eq!(parsed["chunks"][0]["included_reason"], "seed");
     assert_eq!(parsed["chunks"][1]["included_reason"], "sibling");
     assert_eq!(parsed["chunks"][2]["included_reason"], "mod-decl");
+    assert_eq!(
+        parsed["degraded"], false,
+        "empty degraded_causes must derive to false in JSON"
+    );
 }
 
 // T-604: render_plain_outputs_separator_and_header
@@ -346,7 +351,7 @@ fn render_plain_outputs_separator_and_header() {
             chunk("src/foo.rs", "fn foo() {}", 10, 12),
             chunk("src/bar.rs", "fn bar() {}", 20, 22),
         ],
-        degraded: false,
+        degraded_causes: Vec::new(),
         total_chunks: 2,
         total_bytes: 0,
         reachable_files: Vec::new(),
@@ -364,7 +369,7 @@ fn render_plain_outputs_separator_and_header() {
 fn render_plain_returns_empty_string_for_empty_output() {
     let output = BriefOutput {
         chunks: vec![],
-        degraded: false,
+        degraded_causes: Vec::new(),
         total_chunks: 0,
         total_bytes: 0,
         reachable_files: Vec::new(),
@@ -386,7 +391,7 @@ fn render_plain_prepends_degraded_note() {
             source_kind: None,
             injection_flags: None,
         }],
-        degraded: true,
+        degraded_causes: vec![DegradedCause::SeedFtsFallback],
         total_chunks: 1,
         total_bytes: 11,
         reachable_files: Vec::new(),
@@ -407,7 +412,7 @@ fn render_plain_prepends_degraded_note() {
 fn render_plain_empty_degraded_returns_only_note() {
     let output = BriefOutput {
         chunks: vec![],
-        degraded: true,
+        degraded_causes: vec![DegradedCause::SeedFtsFallback],
         total_chunks: 0,
         total_bytes: 0,
         reachable_files: Vec::new(),
@@ -415,6 +420,66 @@ fn render_plain_empty_degraded_returns_only_note() {
     assert_eq!(
         render_plain(&output),
         "Note: degraded mode — FTS-only seed selection"
+    );
+}
+
+// T-732: render_plain_empty_closure_names_its_own_cause [#238]
+// An empty closure (seed not in index / no dependencies) must not be
+// misattributed to the FTS seed fallback — the pre-fix note always read
+// "FTS-only seed selection" whatever the cause.
+#[test]
+fn render_plain_empty_closure_names_its_own_cause() {
+    let output = BriefOutput {
+        chunks: vec![],
+        degraded_causes: vec![DegradedCause::EmptyClosure],
+        total_chunks: 0,
+        total_bytes: 0,
+        reachable_files: Vec::new(),
+    };
+    let rendered = render_plain(&output);
+    assert_eq!(
+        rendered,
+        "Note: degraded mode — seeds expanded to zero chunks (not in index or no dependencies)"
+    );
+    assert!(
+        !rendered.contains("FTS-only"),
+        "empty closure must not be attributed to the FTS fallback: {rendered}"
+    );
+}
+
+// T-735: render_plain_empty_seeds_names_its_own_cause [#238]
+// Seed-less run whose inference resolved nothing: the note names the missing
+// seeds, not the FTS fallback.
+#[test]
+fn render_plain_empty_seeds_names_its_own_cause() {
+    let output = BriefOutput {
+        chunks: vec![],
+        degraded_causes: vec![DegradedCause::EmptySeeds],
+        total_chunks: 0,
+        total_bytes: 0,
+        reachable_files: Vec::new(),
+    };
+    assert_eq!(
+        render_plain(&output),
+        "Note: degraded mode — no file seeds resolved"
+    );
+}
+
+// T-733: render_plain_joins_multiple_causes_in_stage_order [#238]
+// Seed inference fell back to FTS *and* the resulting closure was empty:
+// both causes are real, so the note names both, seed stage first.
+#[test]
+fn render_plain_joins_multiple_causes_in_stage_order() {
+    let output = BriefOutput {
+        chunks: vec![],
+        degraded_causes: vec![DegradedCause::SeedFtsFallback, DegradedCause::EmptyClosure],
+        total_chunks: 0,
+        total_bytes: 0,
+        reachable_files: Vec::new(),
+    };
+    assert_eq!(
+        render_plain(&output),
+        "Note: degraded mode — FTS-only seed selection; seeds expanded to zero chunks (not in index or no dependencies)"
     );
 }
 
@@ -490,7 +555,7 @@ fn expand_plan_returns_seed_and_forward_chunks() {
     let output = expand_plan(&conn, &task).unwrap();
 
     assert_eq!(output.chunks.len(), 2);
-    assert!(!output.degraded);
+    assert!(!output.degraded());
 
     let by_path: HashMap<&str, &BriefChunk> = output
         .chunks
@@ -606,7 +671,7 @@ fn render_json_emits_per_chunk_injection_flags() {
             source_kind: None,
             injection_flags: Some(vec!["y".to_owned()]),
         }],
-        degraded: false,
+        degraded_causes: Vec::new(),
         total_chunks: 1,
         total_bytes: 11,
         reachable_files: Vec::new(),
@@ -643,7 +708,7 @@ fn render_json_emits_per_chunk_source_kind() {
             source_kind: Some(SourceKind::Src),
             injection_flags: None,
         }],
-        degraded: false,
+        degraded_causes: Vec::new(),
         total_chunks: 1,
         total_bytes: 11,
         reachable_files: Vec::new(),
@@ -672,7 +737,7 @@ fn render_json_skips_source_kind_when_none() {
             source_kind: None,
             injection_flags: None,
         }],
-        degraded: false,
+        degraded_causes: Vec::new(),
         total_chunks: 1,
         total_bytes: 11,
         reachable_files: Vec::new(),
@@ -690,7 +755,7 @@ fn render_json_skips_source_kind_when_none() {
 fn render_json_emits_injection_check_even_with_empty_chunks() {
     let output = BriefOutput {
         chunks: vec![],
-        degraded: false,
+        degraded_causes: Vec::new(),
         total_chunks: 0,
         total_bytes: 0,
         reachable_files: Vec::new(),
@@ -759,7 +824,7 @@ fn expand_plan_queries_import_counts_when_over_cap() {
         "BR-001: max_chunks=1 must drop the 3 seed chunks down to a single survivor"
     );
     assert_eq!(output.total_chunks, 1);
-    assert!(!output.degraded, "a satisfiable seed must not degrade");
+    assert!(!output.degraded(), "a satisfiable seed must not degrade");
 }
 
 // T-615: expand_plan_keeps_explicit_test_seed [#236]
@@ -788,7 +853,7 @@ fn expand_plan_keeps_explicit_test_seed() {
     );
     assert_eq!(output.chunks[0].file_path, "src/feature/tests.rs");
     assert!(
-        !output.degraded,
+        !output.degraded(),
         "a satisfiable explicit seed must not degrade"
     );
 }

--- a/src/tools/briefing.rs
+++ b/src/tools/briefing.rs
@@ -84,12 +84,13 @@ impl Yomu {
     }
 
     /// Runs `brief` over `task`, inferring file seeds from `task.task` when none
-    /// are given (seed-less), and returns the closure output with `degraded` set
-    /// when seed inference fell back or the closure was empty. Shared by `brief`
-    /// (renders) and `recall` (measures); callers validate `task` first.
+    /// are given (seed-less), and returns the closure output with a degradation
+    /// cause recorded when seed inference fell back or the closure was empty.
+    /// Shared by `brief` (renders) and `recall` (measures); callers validate
+    /// `task` first.
     fn brief_output(&self, task: &brief::TaskBrief) -> Result<brief::BriefOutput, YomuError> {
         let mut effective = task.clone();
-        let mut degraded = false;
+        let mut seed_fallback = false;
         if effective.seeds.is_empty() {
             let (paths, seed_degraded) =
                 self.infer_seed_paths(&effective.task, BRIEF_MAX_INFERRED_SEEDS);
@@ -100,19 +101,35 @@ impl Yomu {
                     value,
                 })
                 .collect();
-            degraded |= seed_degraded;
+            seed_fallback |= seed_degraded;
         }
 
         let mut output = self.with_db(|conn| brief::expand_plan(conn, &effective))?;
-        output.degraded |= degraded;
+        if seed_fallback {
+            // Front insert, not push: expand_plan may already have recorded
+            // EmptySeeds, but seed inference is the earlier stage, so its
+            // cause must lead the note (DegradedCause stage-order contract).
+            output
+                .degraded_causes
+                .insert(0, brief::DegradedCause::SeedFtsFallback);
+        }
 
         if output.chunks.is_empty() {
             tracing::warn!(
                 seeds = effective.seeds.len(),
-                degraded = output.degraded,
+                degraded = output.degraded(),
                 "brief produced zero chunks"
             );
-            output.degraded = true;
+            // EmptySeeds already explains a zero-chunk closure; recording
+            // EmptyClosure on top would just restate it.
+            if !output
+                .degraded_causes
+                .contains(&brief::DegradedCause::EmptySeeds)
+            {
+                output
+                    .degraded_causes
+                    .push(brief::DegradedCause::EmptyClosure);
+            }
         }
         Ok(output)
     }
@@ -183,7 +200,7 @@ impl Yomu {
                 output.chunks.iter().map(|c| c.file_path.clone()).collect();
             let reachable: HashSet<String> = output.reachable_files.iter().cloned().collect();
             let mut report = recall::measure(&entry.must_include, &out_files, &reachable);
-            report.degraded |= output.degraded;
+            report.degraded |= output.degraded();
             entries.push(recall::EntryReport {
                 id: entry.id.clone(),
                 report,

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -2418,6 +2418,54 @@ fn brief_task(seed_file: &str) -> brief::TaskBrief {
     }
 }
 
+// T-734: brief_out_of_index_seed_reports_empty_closure_not_fts [#238]
+// Reproduces the issue: an explicit seed that is not in the index yields an
+// empty closure. The note must name the empty closure, not the FTS seed
+// fallback — no seed inference ran because seeds were given explicitly.
+#[test]
+fn brief_out_of_index_seed_reports_empty_closure_not_fts() {
+    let (conn, dir) = test_db();
+    seed_brief_chunks(&conn);
+    let yomu = Yomu::for_test(conn, dir.path().to_path_buf(), None);
+
+    let output = yomu
+        .brief(&brief_task("src/nonexistent.rs"), false)
+        .unwrap();
+
+    assert_eq!(
+        output,
+        "Note: degraded mode — seeds expanded to zero chunks (not in index or no dependencies)",
+        "empty closure must be the sole named cause — naming the FTS fallback was the #238 misattribution"
+    );
+}
+
+// T-739: brief_seedless_fts_zero_hit_names_fallback_before_empty_seeds [#238]
+// Same scenario as T-014c rendered plain: no embedder forces the FTS fallback
+// AND the fallback finds nothing, so both causes co-occur. The note must lead
+// with the seed-inference stage (FTS-only) before its outcome (no seeds), and
+// EmptySeeds suppresses the EmptyClosure restatement.
+#[test]
+fn brief_seedless_fts_zero_hit_names_fallback_before_empty_seeds() {
+    let (conn, dir) = test_db();
+    seed_brief_chunks(&conn);
+    let yomu = Yomu::for_test(conn, dir.path().to_path_buf(), None);
+
+    let task = brief::TaskBrief {
+        task: "infer something".to_owned(),
+        seeds: vec![],
+        depth: 1,
+        max_chunks: 80,
+        max_bytes: 80_000,
+        include_tests: false,
+    };
+
+    let output = yomu.brief(&task, false).unwrap();
+    assert_eq!(
+        output, "Note: degraded mode — FTS-only seed selection; no file seeds resolved",
+        "stage order pins inference mechanism before its outcome, with no EmptyClosure restatement"
+    );
+}
+
 // T-568: yomu_brief_returns_plain_format
 #[test]
 fn yomu_brief_returns_plain_format() {


### PR DESCRIPTION
## 概要と目的

brief の degraded note が一律 "FTS-only seed selection" で、seed 指定が index 外だった場合 (FTS fallback は走っていない) も FTS に誤帰属していた。原因別の DegradedCause を導入し、note を実際の原因で出す。

## 変更内容

- `DegradedCause { SeedFtsFallback, EmptySeeds, EmptyClosure }` (#[non_exhaustive]) + 原因別の文言
- BriefOutput.degraded: bool → degraded_causes: Vec<DegradedCause>、bool は degraded() で導出 (flag と原因の drift を構造的に排除)
- note は stage 順 join ("; "): seed_fallback は insert(0) で inference 段階を常に先頭に — FTS 0 件で EmptySeeds と共起するケースで順序が逆転していたのを audit で検出し修正
- EmptySeeds 存在時は EmptyClosure を抑制 (zero-chunk の同語反復回避)
- T-732〜T-735 + T-739 (共起順序と抑制の exact assert)

## 設計判断

- amici の DegradedReason は不流用 — embedder 専用の意味論で brief の劣化原因とは別物
- render_json は degraded bool のまま (JSON スキーマ互換維持、causes は plain note にのみ展開)

## テスト方法

1. `cargo nextest run --features test-support` → 760 passed
2. 実機: `yomu brief "fix something" --seed-file src/nonexistent.rs` の note が "seeds expanded to zero chunks (not in index or no dependencies)" になる (旧: FTS-only seed selection)
3. audit 済 (silence reviewer: 旧 degraded 設定 4 箇所すべての cause 対応を検証、findings 0)

## 関連

- Closes #238