### PR TITLE
feat(yomu): brief の seed 推論に reranker を RRF 融合で配線 (#290)

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -10,6 +10,7 @@ mod keywords;
 mod rank;
 
 pub use keywords::{extract_keywords, extract_type_hints};
+pub(crate) use rank::cross_encoder_rrf_rerank;
 pub use rank::{RerankContext, rerank};
 
 #[derive(Debug, thiserror::Error)]

--- a/src/query/rank.rs
+++ b/src/query/rank.rs
@@ -75,6 +75,49 @@ pub(super) fn cross_encoder_rerank(
     }
 }
 
+/// RRF blend of the incoming (vec) order and the cross-encoder order, for
+/// brief seed inference (#290). Unlike [`cross_encoder_rerank`] (search path,
+/// cross score replaces the order outright), the vec rank stays in the sum as
+/// a prior: one low cross score cannot demote a high-confidence vec hit to
+/// the tail — the failure mode measured on the amici semantic-far arm.
+/// Mirror-symmetric ties and scoring failure keep the incoming order (warn,
+/// not degraded).
+pub(crate) fn cross_encoder_rrf_rerank(
+    results: &mut [SearchResult],
+    query: &str,
+    reranker: &dyn Rerank,
+) {
+    /// Standard RRF damping constant (Cormack et al.): rank differences
+    /// contribute smoothly without letting either list dominate.
+    const RRF_K: f32 = 60.0;
+    if results.is_empty() {
+        return;
+    }
+    let pairs: Vec<(&str, &str)> = results
+        .iter()
+        .map(|r| (query, r.chunk.content.as_str()))
+        .collect();
+    match reranker.score_batch(&pairs) {
+        Ok(scores) => {
+            let mut by_cross: Vec<usize> = (0..results.len()).collect();
+            by_cross.sort_by(|&a, &b| scores[b].total_cmp(&scores[a]));
+            let mut cross_rank = vec![0_usize; results.len()];
+            for (rank, &i) in by_cross.iter().enumerate() {
+                cross_rank[i] = rank;
+            }
+            #[allow(clippy::cast_precision_loss)]
+            for (vec_rank, result) in results.iter_mut().enumerate() {
+                result.score = (RRF_K + vec_rank as f32).recip()
+                    + (RRF_K + cross_rank[vec_rank] as f32).recip();
+            }
+            results.sort_by(|a, b| b.score.total_cmp(&a.score));
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "cross-encoder reranking failed, keeping vec order");
+        }
+    }
+}
+
 pub(super) fn cap_per_file(results: &mut Vec<storage::SearchResult>, max: usize) {
     let mut counts: HashMap<String, usize> = HashMap::new();
     results.retain(|r| {

--- a/src/tools/briefing.rs
+++ b/src/tools/briefing.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 
 use amici::model::{degrade_with_warn, record_degraded};
+use rurico::reranker::Rerank;
 
 use crate::{brief, query, storage};
 
@@ -19,7 +20,7 @@ use crate::recall::{self, corpus};
 
 impl Yomu {
     fn infer_seed_paths(&self, task: &str, max_seeds: u32) -> (Vec<String>, bool) {
-        match self.embedder_seed_paths(task, max_seeds) {
+        match self.embedder_seed_paths(task, max_seeds, self.get_reranker()) {
             Ok(paths) => (paths, false),
             Err(reason) => {
                 record_degraded(reason, "brief: seed inference");
@@ -28,27 +29,39 @@ impl Yomu {
         }
     }
 
-    fn embedder_seed_paths(
+    pub(super) fn embedder_seed_paths(
         &self,
         task: &str,
         max_seeds: u32,
+        reranker: Option<&dyn Rerank>,
     ) -> Result<Vec<String>, DegradedReason> {
         let embedder = self.try_embedder_arc()?;
         let task_emb = embedder.embed_query(task).map_err(degrade_with_warn(
             "brief seed inference: embed_query",
             DegradedReason::ProbeFailed,
         ))?;
+        // Oversample when a cross-encoder is available so it can promote
+        // candidates the vec top-N would cut off; the RRF blend keeps the vec
+        // rank as a prior and rerank failure keeps the vec order outright
+        // (warn, not degraded) (#290).
+        let fetch = if reranker.is_some() {
+            max_seeds.saturating_mul(3)
+        } else {
+            max_seeds
+        };
         let conn = self
             .conn
             .lock()
             .expect("DB lock poisoned (embedder_seed_paths)");
-        let results = storage::vec_search(&conn, &task_emb, max_seeds, None, &[]).map_err(
-            degrade_with_warn(
+        let mut results =
+            storage::vec_search(&conn, &task_emb, fetch, None, &[]).map_err(degrade_with_warn(
                 "brief seed inference: vec_search",
                 DegradedReason::ProbeFailed,
-            ),
-        )?;
+            ))?;
         drop(conn);
+        if let Some(ranker) = reranker {
+            query::cross_encoder_rrf_rerank(&mut results, task, ranker);
+        }
 
         Ok(dedupe_seed_paths(results, max_seeds as usize))
     }
@@ -299,7 +312,11 @@ impl Yomu {
             let must_set: HashSet<String> =
                 entry.must_include.iter().map(|f| f.path.clone()).collect();
 
-            let emb_ranked = match self.embedder_seed_paths(&entry.task, depth) {
+            // Direct call (not infer_seed_paths) because this arm controls
+            // `depth` and isolates the embedding stage; it still passes the
+            // reranker so the bench measures the production inference path (#290).
+            let emb_ranked = match self.embedder_seed_paths(&entry.task, depth, self.get_reranker())
+            {
                 Ok(paths) => paths,
                 Err(reason) => {
                     record_degraded(reason, "recall arms: embedding");

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::fs;
 
 use rurico::embed::{Embed, FailingEmbedder, MockEmbedder};
+use rurico::reranker::{RankedResult, Rerank, RerankerError};
 use tempfile::{TempDir, tempdir};
 use tracing_test::traced_test;
 
@@ -2905,6 +2906,344 @@ fn yomu_brief_rejects_symbol_seed() {
             YomuError::InvalidInput(InvalidInputKind::SeedSymbolUnimplemented)
         ),
         "Symbol seed must be rejected with SeedSymbolUnimplemented, got: {err:?}"
+    );
+}
+
+// --- Seed-inference reranker wiring: oversample lets the cross-encoder surface vec-invisible candidates (#290) ---
+
+/// Reranker that scores a document by substring match on its content.
+///
+/// First matching `(substr, score)` entry wins; non-matching documents
+/// score 0.0. `rerank` sorts by score descending (ties broken by ascending
+/// input index, matching the production `Rerank` contract). All three trait
+/// methods derive from the same `score_doc`, so the produced order is
+/// identical whether production calls `rerank` or `score_batch` + sort.
+struct ScriptedReranker {
+    scores: Vec<(&'static str, f32)>,
+}
+
+impl ScriptedReranker {
+    fn new(scores: Vec<(&'static str, f32)>) -> Self {
+        Self { scores }
+    }
+
+    fn score_doc(&self, doc: &str) -> f32 {
+        self.scores
+            .iter()
+            .find(|(substr, _)| doc.contains(substr))
+            .map(|(_, s)| *s)
+            .unwrap_or(0.0)
+    }
+}
+
+impl Rerank for ScriptedReranker {
+    fn score(&self, _query: &str, document: &str) -> Result<f32, RerankerError> {
+        Ok(self.score_doc(document))
+    }
+
+    fn score_batch(&self, pairs: &[(&str, &str)]) -> Result<Vec<f32>, RerankerError> {
+        Ok(pairs.iter().map(|(_, doc)| self.score_doc(doc)).collect())
+    }
+
+    fn rerank(&self, _query: &str, documents: &[&str]) -> Result<Vec<RankedResult>, RerankerError> {
+        let mut results: Vec<RankedResult> = documents
+            .iter()
+            .enumerate()
+            .map(|(index, doc)| RankedResult {
+                index,
+                score: self.score_doc(doc),
+            })
+            .collect();
+        results.sort_by(|a, b| b.score.total_cmp(&a.score).then(a.index.cmp(&b.index)));
+        Ok(results)
+    }
+}
+
+/// Reranker whose every method returns an inference error, exercising the
+/// rerank-failure fallback path.
+struct FailingReranker;
+
+impl Rerank for FailingReranker {
+    fn score(&self, _query: &str, _document: &str) -> Result<f32, RerankerError> {
+        Err(RerankerError::Inference("scripted failure".into()))
+    }
+
+    fn score_batch(&self, _pairs: &[(&str, &str)]) -> Result<Vec<f32>, RerankerError> {
+        Err(RerankerError::Inference("scripted failure".into()))
+    }
+
+    fn rerank(
+        &self,
+        _query: &str,
+        _documents: &[&str],
+    ) -> Result<Vec<RankedResult>, RerankerError> {
+        Err(RerankerError::Inference("scripted failure".into()))
+    }
+}
+
+/// Inserts four embedded chunks with strictly increasing L2 distance to the
+/// MockEmbedder query vector (unit vectors; dist² = 2 - 2·e[0]): `src/a.rs`
+/// (dist 0, vec-nearest), `src/b.rs` (≈0.894), `src/c.rs` (≈1.183),
+/// `src/d.rs` (≈1.414). Contents carry distinct substrings the
+/// `ScriptedReranker` keys on.
+fn seed_rerank_chunks(conn: &storage::Db) {
+    let chunk = |name: &'static str, content: &'static str| storage::NewChunk {
+        chunk_type: &storage::ChunkType::RustFn,
+        name: Some(name),
+        content,
+        start_line: 1,
+        end_line: 3,
+        parent_index: None,
+        source_kind: None,
+        injection_flags: None,
+    };
+    let unit_emb = |e0: f32, e1: f32| {
+        let mut emb = vec![0.0_f32; storage::EMBEDDING_DIMS];
+        emb[0] = e0;
+        emb[1] = e1;
+        emb
+    };
+    let fixtures = [
+        (
+            "src/a.rs",
+            "alpha_handler",
+            "fn alpha_handler() {}",
+            1.0,
+            0.0,
+        ),
+        ("src/b.rs", "beta_handler", "fn beta_handler() {}", 0.6, 0.8),
+        (
+            "src/c.rs",
+            "gamma_handler",
+            "fn gamma_handler() {}",
+            0.3,
+            0.9539,
+        ),
+        (
+            "src/d.rs",
+            "delta_handler",
+            "fn delta_handler() {}",
+            0.0,
+            1.0,
+        ),
+    ];
+    for (path, name, content, e0, e1) in fixtures {
+        storage::insert_chunk(
+            conn,
+            path,
+            &chunk(name, content),
+            name,
+            &storage::ce(unit_emb(e0, e1)),
+            None,
+        )
+        .unwrap();
+    }
+}
+
+// T-740: embedder_seed_paths_reranker_promotes_oversampled_candidate [#290]
+// max_seeds=1: fetch=1 alone would return only A (vec-nearest). With
+// Some(reranker), oversample fetches max_seeds*3=3 candidates (A, B, C) and
+// RRF blends vec rank with cross rank (B: vec1+cross0 = 0.03306 beats
+// A: vec0+cross2 = 0.03280 and C: vec2+cross1 = 0.03252), promoting B to
+// rank 1. This pins BOTH oversample (B must be fetched) and the RRF blend
+// (B's cross win must outweigh A's vec win, asymmetrically).
+#[test]
+fn embedder_seed_paths_reranker_promotes_oversampled_candidate() {
+    let (conn, dir) = test_db();
+    seed_rerank_chunks(&conn);
+    let y = Yomu::for_test(
+        conn,
+        dir.path().to_path_buf(),
+        Some(Arc::new(MockEmbedder::default()) as Arc<dyn Embed>),
+    );
+    let scripted = ScriptedReranker::new(vec![
+        ("fn beta_handler", 0.9),
+        ("fn gamma_handler", 0.5),
+        ("fn alpha_handler", 0.1),
+    ]);
+
+    let paths = y
+        .embedder_seed_paths("task text", 1, Some(&scripted))
+        .unwrap();
+
+    assert_eq!(
+        paths,
+        vec!["src/b.rs".to_owned()],
+        "RRF must promote the oversampled candidate B over the vec-nearest A"
+    );
+}
+
+// T-745: embedder_seed_paths_rrf_keeps_vec_top_despite_low_cross_score [#290]
+// The discriminator between RRF blending and cross-score-only sorting: A is
+// vec rank 0 but cross rank 3 (last), B..D fill cross ranks 0..2. RRF keeps
+// A second (1/60 + 1/63 = 0.03254 beats C's 1/62 + 1/61 = 0.03253), while
+// cross-only sorting would bury A at the tail ([b, c] for max_seeds=2). This
+// is the amici semantic-far failure mode measured on the cross-only wiring:
+// one low cross score must not demote a high-confidence vec hit.
+#[test]
+fn embedder_seed_paths_rrf_keeps_vec_top_despite_low_cross_score() {
+    let (conn, dir) = test_db();
+    seed_rerank_chunks(&conn);
+    let y = Yomu::for_test(
+        conn,
+        dir.path().to_path_buf(),
+        Some(Arc::new(MockEmbedder::default()) as Arc<dyn Embed>),
+    );
+    let scripted = ScriptedReranker::new(vec![
+        ("fn beta_handler", 0.9),
+        ("fn gamma_handler", 0.7),
+        ("fn delta_handler", 0.5),
+        ("fn alpha_handler", 0.1),
+    ]);
+
+    let paths = y
+        .embedder_seed_paths("task text", 2, Some(&scripted))
+        .unwrap();
+
+    assert_eq!(
+        paths,
+        vec!["src/b.rs".to_owned(), "src/a.rs".to_owned()],
+        "RRF must keep the vec-nearest A in the top results even when the cross-encoder scores it last"
+    );
+}
+
+// T-741: embedder_seed_paths_without_reranker_keeps_vec_order [#290]
+// Same fixture, reranker=None, max_seeds=2: legacy behavior returns files in
+// ascending-distance (vec) order, A then B, unaffected by any cross-encoder.
+#[test]
+fn embedder_seed_paths_without_reranker_keeps_vec_order() {
+    let (conn, dir) = test_db();
+    seed_rerank_chunks(&conn);
+    let y = Yomu::for_test(
+        conn,
+        dir.path().to_path_buf(),
+        Some(Arc::new(MockEmbedder::default()) as Arc<dyn Embed>),
+    );
+
+    let paths = y.embedder_seed_paths("task text", 2, None).unwrap();
+
+    assert_eq!(
+        paths,
+        vec!["src/a.rs".to_owned(), "src/b.rs".to_owned()],
+        "without a reranker the result must keep vec (ascending-distance) order"
+    );
+}
+
+// T-742: embedder_seed_paths_reranker_failure_falls_back_to_vec_order [#290]
+// A reranker whose every method errors must not surface as a DegradedReason:
+// production falls back to vec order and still returns Ok. max_seeds=2 →
+// the full Ok vec is exactly the vec-order pair A, B.
+#[test]
+fn embedder_seed_paths_reranker_failure_falls_back_to_vec_order() {
+    let (conn, dir) = test_db();
+    seed_rerank_chunks(&conn);
+    let y = Yomu::for_test(
+        conn,
+        dir.path().to_path_buf(),
+        Some(Arc::new(MockEmbedder::default()) as Arc<dyn Embed>),
+    );
+    let failing = FailingReranker;
+
+    let result = y.embedder_seed_paths("task text", 2, Some(&failing));
+
+    assert_eq!(
+        result,
+        Ok(vec!["src/a.rs".to_owned(), "src/b.rs".to_owned()]),
+        "a reranker error must fall back to vec order and stay Ok, not become a DegradedReason"
+    );
+}
+
+// T-743: embedder_seed_paths_dedupes_files_after_rerank [#290]
+// Two chunks live in the SAME file src/a.rs (both high rerank score) plus one
+// chunk in src/b.rs (low score); max_seeds=2 with Some(reranker). After rerank
+// the order is [a-chunk, a-chunk, b-chunk]; file dedupe applies AFTER rerank,
+// so a.rs appears once and the result is [a, b] — not [a, a].
+#[test]
+fn embedder_seed_paths_dedupes_files_after_rerank() {
+    let (conn, dir) = test_db();
+    let mut emb_a = vec![0.0_f32; storage::EMBEDDING_DIMS];
+    emb_a[0] = 1.0;
+    let new_a = |name: &'static str, content: &'static str, start: u32| storage::NewChunk {
+        chunk_type: &storage::ChunkType::RustFn,
+        name: Some(name),
+        content,
+        start_line: start,
+        end_line: start + 2,
+        parent_index: None,
+        source_kind: None,
+        injection_flags: None,
+    };
+    storage::insert_chunk(
+        &conn,
+        "src/a.rs",
+        &new_a("alpha_one", "fn alpha_one() {}", 1),
+        "ha1",
+        &storage::ce(emb_a.clone()),
+        None,
+    )
+    .unwrap();
+    storage::insert_chunk(
+        &conn,
+        "src/a.rs",
+        &new_a("alpha_two", "fn alpha_two() {}", 10),
+        "ha2",
+        &storage::ce(emb_a),
+        None,
+    )
+    .unwrap();
+    let mut emb_b = vec![0.0_f32; storage::EMBEDDING_DIMS];
+    emb_b[0] = 0.6;
+    emb_b[1] = 0.8;
+    storage::insert_chunk(
+        &conn,
+        "src/b.rs",
+        &new_a("beta_low", "fn beta_low() {}", 1),
+        "hb",
+        &storage::ce(emb_b),
+        None,
+    )
+    .unwrap();
+    let y = Yomu::for_test(
+        conn,
+        dir.path().to_path_buf(),
+        Some(Arc::new(MockEmbedder::default()) as Arc<dyn Embed>),
+    );
+    let scripted = ScriptedReranker::new(vec![
+        ("fn alpha_one", 0.9),
+        ("fn alpha_two", 0.8),
+        ("fn beta_low", 0.1),
+    ]);
+
+    let paths = y
+        .embedder_seed_paths("task text", 2, Some(&scripted))
+        .unwrap();
+
+    assert_eq!(
+        paths,
+        vec!["src/a.rs".to_owned(), "src/b.rs".to_owned()],
+        "file dedupe must apply after rerank — a.rs collapses to one entry, not [a, a]"
+    );
+}
+
+// T-744: embedder_seed_paths_vec_search_failure_degrades [#290]
+#[test]
+fn embedder_seed_paths_vec_search_failure_degrades() {
+    let (conn, dir) = test_db();
+    seed_rerank_chunks(&conn);
+    // 8-dim query embedding against the 768-dim vec0 table: vec_search errors,
+    // which must surface as ProbeFailed (the seed-inference degrade contract).
+    let y = Yomu::for_test(
+        conn,
+        dir.path().to_path_buf(),
+        Some(Arc::new(MockEmbedder::with_dims(8)) as Arc<dyn Embed>),
+    );
+
+    let err = y.embedder_seed_paths("task text", 2, None).unwrap_err();
+
+    assert_eq!(
+        err,
+        DegradedReason::ProbeFailed,
+        "a vec_search failure must degrade as ProbeFailed, not panic or pass through"
     );
 }
 


### PR DESCRIPTION
## 概要と目的

Closes #290

brief の seed 推論 (`embedder_seed_paths`) に search と同じ `get_reranker()` を配線する。reranker が居る環境では vec 候補を 3× oversample し、vec rank と cross-encoder rank の RRF 融合 (k=60) で並べ替えてから dedupe する。semantic-far combined Hit@1 が 0.33→0.50 (n=6 directional)。**+0.17 は rurico-downloaded-weights-integrity 1 task の rank1→0 flip が全て** (n=6 なので 1 件 = 0.167)。

測定の全記録 (same-index 3 列比較、per-entry、トレードオフ) は #290 のコメント参照。

## 変更内容

- `tools/briefing.rs`: `embedder_seed_paths` が `Option<&dyn Rerank>` を受け取り、存在時に fetch = 3×max_seeds で oversample → `cross_encoder_rrf_rerank` → `dedupe_seed_paths`。不在時は旧パス (oversample なし・rerank なし) のまま
- `query/rank.rs`: `cross_encoder_rrf_rerank` を新設 (`pub(crate)`)。search 用 `cross_encoder_rerank` (cross スコアで順位置換) とは別関数で、vec rank を prior として和に残す。スコアリング失敗時は warn + vec 順維持 (degraded にしない)
- `query.rs`: re-export 調整 (`cross_encoder_rerank` は `pub(super)` に戻し search 専用化)

## スコープ

- brief の seed 推論経路のみ。search の rerank 経路 (`cross_encoder_rerank`) は不変
- reranker 不在環境では brief の挙動完全不変 (AC②)
- RRF k=60 は Cormack et al. の標準値のまま未チューニング (n=6 directional にチューニングの解像度がない)

## 設計判断

- **cross スコア単独置換 (search と同形) を先に試して却下**: amici far の vec rank0 2 件が cross の一票で rank3 に降格し combined far Hit@1 0.33→0.17 (AC① 違反)。RRF は vec rank が和に残るため高確信 vec ヒットが転落しない
- **トレードオフは認識済み**: cross 単独は combined near Hit@1 0.60 (RRF 0.40)、must_recall 全体 0.792 (RRF 0.776) で優位。AC が semantic-far Hit@1 を指名するため RRF を採用した (詳細は #290 コメント)
- RRF の鏡像対称同点は stable sort で vec 順優先 = far 破壊防止の意味論をテストで pin (T-745 が RRF と cross 単独を判別)
- 採用判断は同一バイナリ・同一 index の `YOMU_RERANK` off/on 比較に依拠。rerank-off baseline は f105f88 期の far 確定値 (PR #287) を完全再現

## テスト方法

- `cargo nextest run --features test-support` — 776 passed
- `cargo clippy --all-targets --all-features -p yomu -- -D warnings` / `cargo fmt --check` — green
- diff-cover 97% (gate ≥95)
- 新規テスト T-740〜T-745: RRF 昇格 / reranker None で vec 順 / scoring 失敗で vec 順 (Ok のまま) / dedupe / vec_search 失敗の DegradedReason / RRF と cross 置換の判別
- 測定: `recall-bench --repo {rurico,amici} --compare` same-index 3 列比較 → #290 コメント

## 関連

- Closes #290
- #291: Y arm は `YOMU_RERANK` on/off で seed 経路が変わるため、測定時の固定を #290 コメントに注記済み
