### PR TITLE
fix(ci): actions/checkout の pin を v6.0.3 に更新し version comment 不一致を解消

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           # Gate1 (tests/brief_recall.rs) measures recall against the pinned
@@ -111,7 +111,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -166,7 +166,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/label-from-issue.yml
+++ b/.github/workflows/label-from-issue.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - name: Checkout homebrew-tap
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: thkt/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -22,7 +22,7 @@ jobs:
       actions: read
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## 概要

Code scanning の open アラート 7 件 (zizmor `ref-version-mismatch`, alerts #4–#10) を解消する。

## 原因

4 ファイル 7 箇所の checkout 行がすべて同一パターンだった:

```yaml
actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
```

- pin の `de0fac2e` は **v6.0.2** のコミット
- comment が floating tag `# v6` のため、upstream で v6 タグが v6.0.3 (`df4cb1c`) に進んだ時点で全行が mismatch 判定になった
- floating 形式のままだと patch release のたびに再発する

## 変更

7 行を v6.0.3 の commit hash + immutable な完全バージョン comment に更新:

```yaml
actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
```

Dependabot は本リポジトリで完全バージョン comment を維持して bump する (`taiki-e/install-action # v2.79.14` の実績) ため、以降の bump で floating 形式に戻ることはない。

## 検証

- 旧 hash `de0fac2e` 0 件 / 新 hash `df4cb1c` 7 件を grep で確認
- zizmor 1.25.2 をローカル実行し **No findings to report** を確認
- merge 後、zizmor workflow の main 再スキャンで alerts #4–#10 が自動 close される見込み (手動 dismiss はしない)

## 対象外

- `dtolnay/rust-toolchain@... # stable` は branch ref でありアラート対象外のため変更しない
- fixed 済みの alerts #1–#3 は対応不要