### PR TITLE
docs(indexer): incremental embed の Abort 時 partial commit を resumable 設計として明文化 (#280)

### DIFF
--- a/src/indexer/embed.rs
+++ b/src/indexer/embed.rs
@@ -207,6 +207,18 @@ fn embed_file_chunks(
     Ok(Some((n, embed_dur, store_dur)))
 }
 
+/// Embeds pending chunks file-by-file until `max_chunks` is reached.
+///
+/// # Abort and resumability (#280)
+///
+/// Embedding commits per file: a file's embeddings are written in a single
+/// transaction only after its whole batch embedded successfully, so no file is
+/// ever half-embedded. When consecutive failures abort the run
+/// ([`MAX_CONSECUTIVE_EMBED_ERRORS`]), files committed before the abort stay
+/// committed by design: the next run resumes from the gap (the
+/// `embedded_chunk_ids` LEFT JOIN skips completed chunks) and
+/// [`storage::embed_gap_count`] exposes the remainder. Rolling back completed
+/// files on abort would discard finished work without improving correctness.
 #[allow(clippy::cast_possible_truncation)]
 pub fn run_incremental_embed(
     conn: &Arc<Mutex<Db>>,

--- a/src/indexer/embed.rs
+++ b/src/indexer/embed.rs
@@ -214,7 +214,7 @@ fn embed_file_chunks(
 /// Embedding commits per file: a file's embeddings are written in a single
 /// transaction only after its whole batch embedded successfully, so no file is
 /// ever half-embedded. When consecutive failures abort the run
-/// ([`MAX_CONSECUTIVE_EMBED_ERRORS`]), files committed before the abort stay
+/// (`MAX_CONSECUTIVE_EMBED_ERRORS`), files committed before the abort stay
 /// committed by design: the next run resumes from the gap (the
 /// `embedded_chunk_ids` LEFT JOIN skips completed chunks) and
 /// [`storage::embed_gap_count`] exposes the remainder. Rolling back completed

--- a/src/indexer/tests.rs
+++ b/src/indexer/tests.rs
@@ -676,6 +676,82 @@ fn run_incremental_embed_aborts_after_consecutive_failures() {
     assert!(err_msg.contains("mock failure"), "got: {err_msg}");
 }
 
+// T-746: run_incremental_embed_resumes_after_abort
+// #280: files committed before an abort stay committed (partial state), the
+// gap is detectable via embed_gap_count, and a re-run fills exactly the gap
+// without re-embedding completed files.
+#[test]
+fn run_incremental_embed_resumes_after_abort() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join(".yomu").join("index.db");
+    let conn = storage::open_db(&db_path).unwrap();
+
+    // 7 files, 1 chunk each: 2 commit in stage 1, leaving 5 pending so stage 2
+    // reaches MAX_CONSECUTIVE_EMBED_ERRORS (5) and aborts.
+    for i in 0..7 {
+        storage::replace_file_chunks_only(
+            &conn,
+            &format!("src/P{i}.tsx"),
+            &[storage::NewChunk {
+                chunk_type: &storage::ChunkType::Component,
+                name: Some(&format!("P{i}")),
+                content: &format!("function P{i}() {{}}"),
+                start_line: 1,
+                end_line: 1,
+                parent_index: None,
+                source_kind: None,
+                injection_flags: None,
+            }],
+            &format!("p{i}"),
+            "",
+            &[],
+            None,
+        )
+        .unwrap();
+    }
+
+    let conn = Arc::new(Mutex::new(conn));
+
+    // Stage 1: healthy embedder commits 2 files (max_chunks cap), then stops.
+    let first = run_incremental_embed(&conn, &MockEmbedder::default(), 2, None).unwrap();
+    assert_eq!(first.files_completed, 2, "precondition: 2 files committed");
+
+    // Stage 2: all failures -> abort. The 2 committed files stay committed.
+    let aborted =
+        run_incremental_embed(&conn, &FailingEmbedder::all_fail("mock failure"), 50, None);
+    assert!(aborted.is_err(), "stage 2 should abort");
+    {
+        let guard = conn.lock().unwrap();
+        assert_eq!(
+            storage::embed_gap_count(&guard).unwrap(),
+            5,
+            "abort leaves a detectable gap of unembedded chunks"
+        );
+    }
+
+    // Stage 3: re-run resumes from the gap and embeds only the remainder.
+    let resumed = run_incremental_embed(&conn, &MockEmbedder::default(), 50, None).unwrap();
+    assert_eq!(
+        resumed.files_completed, 5,
+        "re-run embeds exactly the files the abort left behind"
+    );
+    let guard = conn.lock().unwrap();
+    assert_eq!(
+        storage::embed_gap_count(&guard).unwrap(),
+        0,
+        "gap closes after re-run"
+    );
+    let vec_rows: i64 = guard
+        .query_row("SELECT COUNT(*) FROM embedded_chunk_ids", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(
+        vec_rows, 7,
+        "no duplicate embeddings for already-committed files"
+    );
+}
+
 // T-391: order_files_for_embedding_most_imported_first
 #[test]
 fn order_files_for_embedding_most_imported_first() {

--- a/src/indexer/tests.rs
+++ b/src/indexer/tests.rs
@@ -741,13 +741,13 @@ fn run_incremental_embed_resumes_after_abort() {
         0,
         "gap closes after re-run"
     );
-    let vec_rows: i64 = guard
+    let embedded_rows: i64 = guard
         .query_row("SELECT COUNT(*) FROM embedded_chunk_ids", [], |row| {
             row.get(0)
         })
         .unwrap();
     assert_eq!(
-        vec_rows, 7,
+        embedded_rows, 7,
         "no duplicate embeddings for already-committed files"
     );
 }


### PR DESCRIPTION
## 概要

#280 (incremental embed の Abort 時に partial commit が残留する問題) の調査結果。結論は**方針 1 (現状維持 + ドキュメント化)**: Abort 残留は実害を生まず、resumable 設計として意図的に許容する。

Closes #280

## 調査結論

| issue の論点 | 検証結果 |
|---|---|
| partial 状態が次回実行で正しく検出・再開される保証 | あり。再実行は `embedded_chunk_ids` LEFT JOIN (`get_unembedded_chunks_for_file`) で正確に差分再開する。#250 の訂正コメントでマシンクラッシュ (Abort より過酷な中断) からの incremental 復旧が sqlite3 突合で実証済み |
| 誤った embed 済判定 | 構造上不可能。`embedded_chunk_ids` と `vec_chunks` は `insert_sub_embeddings` で同一トランザクション内に書かれる (`add_chunked_embeddings` の tx 経由) |
| ファイル内 partial | 構造上不可能。embed 失敗 / count mismatch は書き込み前に return し、書き込みは単一 tx で all-or-nothing |
| Abort 状態の検出 | 既に可能。#288 の `embed_gap_count` + `yomu status` の Embedded n/m 表示 |

方針 2 (ロールバック) は完了済みファイルの作業を捨てるだけで正しさを増やさないため不採用。方針 3 (Abort メタデータ記録) は gap が DB 自体から導出できるため冗長で不採用。

## 変更内容

- `run_incremental_embed` に Abort/resumability 契約の doc comment を追加。#280 は audit (PR #278 関連) 由来であり、コードに設計意図が書かれていないことが指摘の root cause のため、コード側に明文化する
- T-746 `run_incremental_embed_resumes_after_abort`: 「2 ファイル commit 済み → Abort (5 連続失敗) → 残留 gap=5 を `embed_gap_count` で検出 → 再実行で gap=0、`embedded_chunk_ids` 7 行 (重複 embed なし)」を 3 段で固定

## テスト

- `cargo test --features test-support`: 682 + 95 全 pass (新規 T-746 含む)
- `cargo clippy --features test-support --all-targets`: clean