### PR TITLE
fix(release): homebrew formula の sha256 を release asset から計算し fail-fast 化 (#307)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,11 +112,6 @@ jobs:
           repository: thkt/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
-      - name: Download artifacts for checksums
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          path: artifacts
-
       - name: Update Formula
         env:
           VERSION: ${{ needs.release.outputs.version }}
@@ -127,7 +122,19 @@ jobs:
             exit 1
           fi
 
-          SHA_AARCH64_DARWIN=$(sha256sum artifacts/yomu-aarch64-apple-darwin/yomu-aarch64-apple-darwin.tar.gz | cut -d' ' -f1)
+          # Compute the checksum from the released asset itself — the same URL
+          # the formula points at. Computing from CI artifacts broke silently
+          # when upload/download-artifact major bumps changed their on-disk
+          # layout: sha256sum failed on a missing path, the trailing `cut`
+          # masked the failure under `bash -e`, and an empty sha256 shipped
+          # for six releases (#307).
+          curl -fsSL --retry 3 -o /tmp/yomu-aarch64-apple-darwin.tar.gz \
+            "https://github.com/thkt/yomu/releases/download/${TAG}/yomu-aarch64-apple-darwin.tar.gz"
+          SHA_AARCH64_DARWIN=$(sha256sum /tmp/yomu-aarch64-apple-darwin.tar.gz | cut -d' ' -f1)
+          if [[ ! "$SHA_AARCH64_DARWIN" =~ ^[a-f0-9]{64}$ ]]; then
+            echo "::error::sha256 computation failed for ${TAG}: '${SHA_AARCH64_DARWIN}'"
+            exit 1
+          fi
 
           mkdir -p Formula
           cat > Formula/yomu.rb << FORMULA


### PR DESCRIPTION
## 概要

#307 の修正。v0.13.0 以降 6 リリース連続で homebrew formula の `sha256` が空文字列のままリリースされていた silent failure を根絶する。

Closes #307

## 根因 (詳細は #307)

- a66e6f3 の artifact actions major bump (upload v4→v7 / download v4→v8) で download 後のファイル配置が `update-homebrew` の決め打ちパスと不一致になり、`sha256sum` が `No such file or directory` で失敗
- `SHA=$(sha256sum <missing> | cut -d' ' -f1)` は pipe 末尾の `cut` が exit 0 のため `bash -e` をすり抜け、空文字が formula に書かれ workflow は緑で完走

## 変更内容

1. sha256 計算を **formula が指す release asset URL そのもの**からの `curl` 取得に変更 — actions の on-disk layout への依存を除去。検証対象 (release asset) と hash 計算対象が同一物になり意味的にも正しい
2. **64 hex の形式検証で fail-fast 化** — sha が取れなければ workflow が赤になる (silent → loud)
3. 不要になった `download-artifact` ステップを `update-homebrew` から削除

## 検証

- actionlint / zizmor: clean (`No findings to report. 3 ignored, 7 suppressed`)
- `curl --retry` は 404 を retry しない (man 確認: timeout/408/429/5xx のみ) が、`needs: release` で asset upload 完了後に走るため 404 は通常起きない。起きた場合は `-f` で即 fail = 赤くなり `gh run rerun` で回復可能 — fail-fast 設計として意図どおり
- 再実行安全性: `cat >` による formula 全置換は冪等、Commit and push は無変更時 no-op (既存設計のまま)
- release.yml はタグ push でしか実行されないため、実機確認は次回リリース時に update-homebrew ジョブの緑と formula の 64 hex sha256 で行う

## 関連

- v0.16.0 formula の backfill (sha256 `f39bcc614a695871fcbad350f93d922065c32d15eb7bd37e4bdf8fb1d49cd069`、release asset と CI artifact の両方から計算し一致確認済み) は tap 側で別途実施