### PR TITLE
feat(indexer): 同次元モデル差し替え時の stale embedding を検知し全 re-embed する (#230)

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -14,7 +14,10 @@ use rurico::embed::EmbedError;
 use crate::storage::StorageError;
 
 pub use chunk_only::{dry_run_index, run_chunk_only_index, run_chunk_only_index_force};
-pub use embed::{EmbedResult, run_incremental_embed, run_incremental_embed_with_progress};
+pub use embed::{
+    EMBED_MODEL_META_KEY, EmbedResult, ModelSync, run_incremental_embed,
+    run_incremental_embed_with_progress, sync_embeddings_with_model,
+};
 #[cfg(test)]
 use embed::{MAX_CONSECUTIVE_EMBED_ERRORS, enrich_for_embedding, order_files_for_embedding};
 

--- a/src/indexer/embed.rs
+++ b/src/indexer/embed.rs
@@ -320,6 +320,63 @@ pub fn run_incremental_embed_with_progress(
     })
 }
 
+/// `index_meta` key recording which embedding model produced the stored vectors.
+pub const EMBED_MODEL_META_KEY: &str = "embed_model_id";
+
+/// Outcome of [`sync_embeddings_with_model`].
+pub enum ModelSync {
+    /// Stored model id matches (or was just recorded for the first time).
+    Aligned,
+    /// Stored id differed; all embeddings were cleared for re-embedding.
+    Reembedding { previous: String },
+}
+
+/// Aligns stored embeddings with the current embedding model (#230).
+///
+/// `embedded_chunk_ids` tracks chunk ids only, so a same-dimension model swap
+/// leaves every stale embedding looking fresh and incremental embed would do
+/// nothing. This records the model id in `index_meta` and, when the stored id
+/// differs from `current_model_id`, clears all embeddings so the next
+/// incremental embed re-embeds every chunk (no re-chunking).
+///
+/// `ensure_loadable` runs before any destructive step: when the replacement
+/// embedder cannot load, the mismatch is left in place (an unavailable model
+/// must never wipe valid embeddings) and the error propagates. The clear and
+/// the id update are separate statements; a crash between them leaves an
+/// empty-but-mismatched state that the next run re-detects and re-clears
+/// (idempotent), never a falsely-fresh one.
+pub fn sync_embeddings_with_model<E>(
+    conn: &Db,
+    current_model_id: &str,
+    ensure_loadable: impl FnOnce() -> Result<(), E>,
+) -> Result<ModelSync, E>
+where
+    E: From<IndexError>,
+{
+    let index_err = |e: StorageError| E::from(IndexError::from(e));
+    let stored = storage::get_index_meta(conn, EMBED_MODEL_META_KEY).map_err(index_err)?;
+    match stored {
+        Some(ref id) if id == current_model_id => Ok(ModelSync::Aligned),
+        Some(previous) => {
+            ensure_loadable()?;
+            tracing::warn!(
+                previous = %previous,
+                current = %current_model_id,
+                "Embedding model changed; clearing all embeddings for re-embed"
+            );
+            storage::clear_all_embeddings(conn).map_err(index_err)?;
+            storage::set_index_meta(conn, EMBED_MODEL_META_KEY, current_model_id)
+                .map_err(index_err)?;
+            Ok(ModelSync::Reembedding { previous })
+        }
+        None => {
+            storage::set_index_meta(conn, EMBED_MODEL_META_KEY, current_model_id)
+                .map_err(index_err)?;
+            Ok(ModelSync::Aligned)
+        }
+    }
+}
+
 /// `chunks_embedded / elapsed_seconds`, truncated to an integer.
 /// Returns `0` when `elapsed_ms == 0` (sub-millisecond runs from empty / mock paths).
 fn chunks_per_sec(chunks_embedded: u32, elapsed_ms: u128) -> u128 {

--- a/src/indexer/tests.rs
+++ b/src/indexer/tests.rs
@@ -1373,3 +1373,171 @@ fn prepare_chunks_source_kind_classification_per_rel_path() {
         );
     }
 }
+
+// --- #230: sync_embeddings_with_model ---
+
+/// One embeddable chunk per file, embedded via MockEmbedder. Returns the conn.
+fn db_with_embedded_chunks(dir: &TempDir, files: u32) -> Arc<Mutex<storage::Db>> {
+    let db_path = dir.path().join(".yomu").join("index.db");
+    let conn = storage::open_db(&db_path).unwrap();
+    for i in 0..files {
+        storage::replace_file_chunks_only(
+            &conn,
+            &format!("src/M{i}.tsx"),
+            &[storage::NewChunk {
+                chunk_type: &storage::ChunkType::Component,
+                name: Some(&format!("M{i}")),
+                content: &format!("function M{i}() {{}}"),
+                start_line: 1,
+                end_line: 1,
+                parent_index: None,
+                source_kind: None,
+                injection_flags: None,
+            }],
+            &format!("m{i}"),
+            "",
+            &[],
+            None,
+        )
+        .unwrap();
+    }
+    let conn = Arc::new(Mutex::new(conn));
+    run_incremental_embed(&conn, &MockEmbedder::default(), u32::MAX, None).unwrap();
+    conn
+}
+
+fn embedded_rows(conn: &Arc<Mutex<storage::Db>>) -> i64 {
+    conn.lock()
+        .unwrap()
+        .query_row("SELECT COUNT(*) FROM embedded_chunk_ids", [], |r| r.get(0))
+        .unwrap()
+}
+
+// T-749: sync_embeddings_with_model_records_id_on_first_run
+#[test]
+fn sync_embeddings_with_model_records_id_on_first_run() {
+    let dir = tempdir().unwrap();
+    let conn = db_with_embedded_chunks(&dir, 2);
+
+    let outcome = {
+        let guard = conn.lock().unwrap();
+        sync_embeddings_with_model::<IndexError>(&guard, "model-a", || {
+            panic!("ensure_loadable must not run when nothing is stored")
+        })
+        .unwrap()
+    };
+
+    assert!(matches!(outcome, ModelSync::Aligned));
+    let guard = conn.lock().unwrap();
+    assert_eq!(
+        storage::get_index_meta(&guard, EMBED_MODEL_META_KEY)
+            .unwrap()
+            .as_deref(),
+        Some("model-a"),
+        "first run records the current model id"
+    );
+    drop(guard);
+    assert_eq!(embedded_rows(&conn), 2, "existing embeddings survive");
+}
+
+// T-750: sync_embeddings_with_model_noop_on_match
+#[test]
+fn sync_embeddings_with_model_noop_on_match() {
+    let dir = tempdir().unwrap();
+    let conn = db_with_embedded_chunks(&dir, 2);
+    {
+        let guard = conn.lock().unwrap();
+        storage::set_index_meta(&guard, EMBED_MODEL_META_KEY, "model-a").unwrap();
+    }
+
+    let outcome = {
+        let guard = conn.lock().unwrap();
+        sync_embeddings_with_model::<IndexError>(&guard, "model-a", || {
+            panic!("ensure_loadable must not run on a match")
+        })
+        .unwrap()
+    };
+
+    assert!(matches!(outcome, ModelSync::Aligned));
+    assert_eq!(embedded_rows(&conn), 2, "embeddings untouched on match");
+}
+
+// T-751: sync_embeddings_with_model_keeps_embeddings_when_model_unavailable
+// #230 safety property: a mismatch must never wipe embeddings unless the
+// replacement embedder is confirmed loadable.
+#[test]
+fn sync_embeddings_with_model_keeps_embeddings_when_model_unavailable() {
+    let dir = tempdir().unwrap();
+    let conn = db_with_embedded_chunks(&dir, 2);
+    {
+        let guard = conn.lock().unwrap();
+        storage::set_index_meta(&guard, EMBED_MODEL_META_KEY, "model-a").unwrap();
+    }
+
+    let result = {
+        let guard = conn.lock().unwrap();
+        sync_embeddings_with_model::<IndexError>(&guard, "model-b", || {
+            Err(IndexError::Internal("model unavailable".into()))
+        })
+    };
+
+    assert!(result.is_err(), "loader failure must propagate");
+    assert_eq!(
+        embedded_rows(&conn),
+        2,
+        "embeddings must be untouched when the new model cannot load"
+    );
+    let guard = conn.lock().unwrap();
+    assert_eq!(
+        storage::get_index_meta(&guard, EMBED_MODEL_META_KEY)
+            .unwrap()
+            .as_deref(),
+        Some("model-a"),
+        "stored id must stay on the old model so the next run re-detects the swap"
+    );
+}
+
+// T-752: sync_embeddings_with_model_clears_stale_and_reembeds_on_swap
+#[test]
+fn sync_embeddings_with_model_clears_stale_and_reembeds_on_swap() {
+    let dir = tempdir().unwrap();
+    let conn = db_with_embedded_chunks(&dir, 3);
+    {
+        let guard = conn.lock().unwrap();
+        storage::set_index_meta(&guard, EMBED_MODEL_META_KEY, "model-a").unwrap();
+    }
+
+    let outcome = {
+        let guard = conn.lock().unwrap();
+        sync_embeddings_with_model::<IndexError>(&guard, "model-b", || Ok(())).unwrap()
+    };
+
+    match outcome {
+        ModelSync::Reembedding { previous } => assert_eq!(previous, "model-a"),
+        ModelSync::Aligned => panic!("swap must report Reembedding"),
+    }
+    assert_eq!(embedded_rows(&conn), 0, "stale embeddings cleared");
+    {
+        let guard = conn.lock().unwrap();
+        assert_eq!(
+            storage::get_index_meta(&guard, EMBED_MODEL_META_KEY)
+                .unwrap()
+                .as_deref(),
+            Some("model-b"),
+            "stored id moves to the new model"
+        );
+        assert_eq!(
+            storage::embed_gap_count(&guard).unwrap(),
+            3,
+            "every chunk is pending again"
+        );
+    }
+
+    // The normal incremental embed then refills everything without re-chunking.
+    let result = run_incremental_embed(&conn, &MockEmbedder::default(), u32::MAX, None).unwrap();
+    assert_eq!(
+        result.chunks_embedded, 3,
+        "all chunks re-embed after the swap"
+    );
+    assert_eq!(embedded_rows(&conn), 3);
+}

--- a/src/storage/embed.rs
+++ b/src/storage/embed.rs
@@ -209,3 +209,15 @@ pub fn needs_embedding(
         }
     }
 }
+
+/// Deletes every embedding row (`embedded_chunk_ids` + `vec_chunks`) in one
+/// transaction while leaving chunks and FTS intact. Used when a model swap
+/// makes all stored embeddings stale (#230): the next incremental embed then
+/// treats every chunk as unembedded and re-embeds without re-chunking.
+pub fn clear_all_embeddings(conn: &Connection) -> Result<(), StorageError> {
+    let tx = conn.unchecked_transaction()?;
+    tx.execute("DELETE FROM embedded_chunk_ids", [])?;
+    tx.execute("DELETE FROM vec_chunks", [])?;
+    tx.commit()?;
+    Ok(())
+}

--- a/src/storage/mutation.rs
+++ b/src/storage/mutation.rs
@@ -275,3 +275,25 @@ pub fn delete_file_chunks(conn: &Connection, file_path: &str) -> Result<(), Stor
     tx.commit()?;
     Ok(())
 }
+
+/// Reads one `index_meta` value by key. Returns `None` when the key is absent.
+pub fn get_index_meta(conn: &Connection, key: &str) -> Result<Option<String>, StorageError> {
+    match conn.query_row(
+        "SELECT value FROM index_meta WHERE key = ?1",
+        [key],
+        |row| row.get::<_, String>(0),
+    ) {
+        Ok(v) => Ok(Some(v)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Writes one `index_meta` value, overwriting any existing entry for `key`.
+pub fn set_index_meta(conn: &Connection, key: &str, value: &str) -> Result<(), StorageError> {
+    conn.execute(
+        "INSERT OR REPLACE INTO index_meta (key, value) VALUES (?1, ?2)",
+        [key, value],
+    )?;
+    Ok(())
+}

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -5255,3 +5255,72 @@ fn embed_gap_count_propagates_query_failure() {
         "a gap that cannot be measured must surface as Err, never as 0"
     );
 }
+
+// T-747: index_meta_get_set_roundtrip
+#[test]
+fn index_meta_get_set_roundtrip() {
+    let (conn, _dir) = test_db();
+
+    assert_eq!(get_index_meta(&conn, "embed_model_id").unwrap(), None);
+
+    set_index_meta(&conn, "embed_model_id", "cl-nagoya/ruri-v3-310m").unwrap();
+    assert_eq!(
+        get_index_meta(&conn, "embed_model_id").unwrap().as_deref(),
+        Some("cl-nagoya/ruri-v3-310m")
+    );
+
+    set_index_meta(&conn, "embed_model_id", "other/model").unwrap();
+    assert_eq!(
+        get_index_meta(&conn, "embed_model_id").unwrap().as_deref(),
+        Some("other/model"),
+        "set must overwrite the existing value"
+    );
+}
+
+// T-748: clear_all_embeddings_empties_vec_and_tracking_tables
+// #230: also proves DELETE works on the vec0 virtual table (prior schema
+// migrations only ever dropped and recreated it).
+#[test]
+fn clear_all_embeddings_empties_vec_and_tracking_tables() {
+    let (conn, _dir) = test_db();
+    let embedding = vec![0.0_f32; EMBEDDING_DIMS];
+
+    insert_chunk(
+        &conn,
+        "src/Nav.tsx",
+        &NewChunk {
+            chunk_type: &ChunkType::Component,
+            name: Some("Nav"),
+            content: "function Nav() {}",
+            start_line: 1,
+            end_line: 3,
+            parent_index: None,
+            source_kind: None,
+            injection_flags: None,
+        },
+        "h1",
+        &ce(embedding),
+        None,
+    )
+    .unwrap();
+
+    let vec_rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM vec_chunks", [], |r| r.get(0))
+        .unwrap();
+    assert!(vec_rows > 0, "precondition: vec_chunks populated");
+
+    clear_all_embeddings(&conn).unwrap();
+
+    let emb: i64 = conn
+        .query_row("SELECT COUNT(*) FROM embedded_chunk_ids", [], |r| r.get(0))
+        .unwrap();
+    let vec: i64 = conn
+        .query_row("SELECT COUNT(*) FROM vec_chunks", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!((emb, vec), (0, 0), "both tables must be empty after clear");
+
+    let chunks: i64 = conn
+        .query_row("SELECT COUNT(*) FROM chunks", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(chunks, 1, "chunk rows must survive the clear");
+}

--- a/src/tools/embedder.rs
+++ b/src/tools/embedder.rs
@@ -44,6 +44,23 @@ pub(super) fn get_recorded_warnings() -> Vec<(DegradedReason, String)> {
     RECORDED_WARNINGS.with(|w| w.borrow().clone())
 }
 
+/// Identifier of the embedding model this binary embeds with, recorded in
+/// `index_meta` to detect same-dimension model swaps (#230). Keyed on the
+/// `ModelId` variant name (rurico keeps the HF repo id behind a private
+/// trait), so it tracks any `DEFAULT` change automatically; a variant rename
+/// only causes one spurious full re-embed (safe direction). In-place weight
+/// updates under the same variant are not detected.
+#[cfg(not(feature = "test-support"))]
+pub(super) fn current_model_id() -> String {
+    format!("{:?}", ModelId::DEFAULT)
+}
+
+/// Test-support build: a fixed id matching the deterministic stub embedder.
+#[cfg(feature = "test-support")]
+pub(super) fn current_model_id() -> String {
+    "test-support/mock-embedder".to_owned()
+}
+
 #[cfg(not(feature = "test-support"))]
 fn try_load_embedder() -> Result<Arc<dyn Embed>, DegradedReason> {
     let result = try_load_embedder_with(

--- a/src/tools/indexing.rs
+++ b/src/tools/indexing.rs
@@ -5,11 +5,24 @@ use rurico::embed::Embed;
 
 use crate::{indexer, storage};
 
-use super::embedder::DegradedReason;
+use super::embedder::{DegradedReason, current_model_id};
 use super::format::{
     format_coverage_note, format_dry_run_json, format_index_json, format_rebuild_json,
 };
 use super::{IndexRunOptions, Yomu, YomuError, degraded_for_dry_run_errors, degraded_for_index};
+
+/// Maps an embedder load failure to the user-facing error. `Disabled` can no
+/// longer occur (yomu never disables embedding); it folds into the generic arm
+/// rather than an unreachable! that diff-coverage would flag as untested.
+fn embedder_unavailable(reason: DegradedReason) -> YomuError {
+    let msg = match reason {
+        DegradedReason::NotInstalled => {
+            "embedding model not installed; run `yomu model download` to enable semantic search"
+        }
+        _ => "embedding model unavailable",
+    };
+    YomuError::EmbedderUnavailable(msg.to_owned())
+}
 
 impl Yomu {
     pub fn index(&self, opts: IndexRunOptions, json: bool) -> Result<String, YomuError> {
@@ -85,6 +98,26 @@ impl Yomu {
     /// Embeds all pending chunks with progress spinners. Errors out when the
     /// model is unavailable so callers never silently leave a chunk-only index.
     fn embed_pending(&self) -> Result<(), YomuError> {
+        // #230: a same-dimension model swap leaves embedded_chunk_ids fully
+        // populated, so `pending` below would count 0 and the embed phase
+        // would silently keep every stale embedding. Align with the current
+        // model first; a confirmed swap clears all embeddings (only after the
+        // new model proved loadable) so `pending` counts every chunk again.
+        let model_id = current_model_id();
+        let sync = {
+            let conn = self.conn.lock().expect("DB lock poisoned (embed_pending)");
+            indexer::sync_embeddings_with_model(&conn, &model_id, || {
+                self.try_embedder_arc()
+                    .map(|_| ())
+                    .map_err(embedder_unavailable)
+            })?
+        };
+        if let indexer::ModelSync::Reembedding { previous } = sync {
+            eprintln!(
+                "Embedding model changed ({previous} -> {model_id}); re-embedding all chunks"
+            );
+        }
+
         let pending = self.with_db(|conn| {
             let stats = storage::get_stats(conn)?;
             Ok(stats
@@ -94,20 +127,7 @@ impl Yomu {
 
         embed_with_spinners(
             pending,
-            |_| {
-                self.try_embedder_arc().map_err(|reason| {
-                    // `Disabled` can no longer occur (yomu never disables
-                    // embedding); it folds into the generic arm rather than an
-                    // unreachable! that diff-coverage would flag as untested.
-                    let msg = match reason {
-                        DegradedReason::NotInstalled => {
-                            "embedding model not installed; run `yomu model download` to enable semantic search"
-                        }
-                        _ => "embedding model unavailable",
-                    };
-                    YomuError::EmbedderUnavailable(msg.to_owned())
-                })
-            },
+            |_| self.try_embedder_arc().map_err(embedder_unavailable),
             |r: &indexer::EmbedResult| format!("Embedded {} chunks", r.chunks_embedded),
             |model: Arc<dyn Embed>, update| {
                 indexer::run_incremental_embed_with_progress(

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -2057,3 +2057,141 @@ fn brief_json_emits_per_chunk_source_kind() {
         "FR-009a: at least one brief chunk must carry source_kind='src'",
     );
 }
+
+// T-753: index_reembeds_all_when_embed_model_changes
+// #230: a same-dimension model swap is invisible to embedded_chunk_ids, so
+// `yomu index` must detect the recorded model id mismatch, clear stale
+// embeddings, and re-embed every chunk.
+#[cfg(feature = "test-support")]
+#[test]
+fn index_reembeds_all_when_embed_model_changes() {
+    let dir = setup_project();
+
+    let output = yomu_cmd()
+        .args(["index"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "initial index failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let db_path = dir.path().join(".yomu").join("index.db");
+    let before: i64 = {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM embedded_chunk_ids", [], |r| r.get(0))
+            .unwrap();
+        assert!(count > 0, "precondition: embeddings exist");
+        let recorded: String = conn
+            .query_row(
+                "SELECT value FROM index_meta WHERE key = 'embed_model_id'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            recorded, "test-support/mock-embedder",
+            "first index records the model id"
+        );
+        // Simulate a model swap: pretend stored embeddings came from another model.
+        conn.execute(
+            "UPDATE index_meta SET value = 'older-model' WHERE key = 'embed_model_id'",
+            [],
+        )
+        .unwrap();
+        count
+    };
+
+    let output = yomu_cmd()
+        .args(["index"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "re-index failed: {stderr}");
+    assert!(
+        stderr.contains("Embedding model changed"),
+        "swap must be announced on stderr: {stderr}"
+    );
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let after: i64 = conn
+        .query_row("SELECT COUNT(*) FROM embedded_chunk_ids", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(after, before, "every chunk re-embeds after the swap");
+    let recorded: String = conn
+        .query_row(
+            "SELECT value FROM index_meta WHERE key = 'embed_model_id'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        recorded, "test-support/mock-embedder",
+        "stored id moves to the current model"
+    );
+}
+
+// T-754: index_keeps_embeddings_when_swapped_model_unavailable
+// #230 safety property at the process boundary: when a swap is detected but
+// the replacement model cannot load, `yomu index` must fail WITHOUT wiping
+// the existing embeddings (an unavailable model must never destroy data).
+#[cfg(feature = "test-support")]
+#[test]
+fn index_keeps_embeddings_when_swapped_model_unavailable() {
+    let dir = setup_project();
+
+    let output = yomu_cmd()
+        .args(["index"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let db_path = dir.path().join(".yomu").join("index.db");
+    let before: i64 = {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM embedded_chunk_ids", [], |r| r.get(0))
+            .unwrap();
+        assert!(count > 0, "precondition: embeddings exist");
+        conn.execute(
+            "UPDATE index_meta SET value = 'older-model' WHERE key = 'embed_model_id'",
+            [],
+        )
+        .unwrap();
+        count
+    };
+
+    let output = yomu_cmd()
+        .args(["index"])
+        .current_dir(dir.path())
+        .env("YOMU_TEST_EMBEDDER", "unavailable")
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "index must fail when the swapped-in model cannot load: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let after: i64 = conn
+        .query_row("SELECT COUNT(*) FROM embedded_chunk_ids", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(after, before, "embeddings must survive the failed swap");
+    let recorded: String = conn
+        .query_row(
+            "SELECT value FROM index_meta WHERE key = 'embed_model_id'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        recorded, "older-model",
+        "stored id stays on the old model so the next run re-detects the swap"
+    );
+}


### PR DESCRIPTION
## 概要

Closes #230

embedding モデルを同次元の別モデルへ差し替えた場合、`embedded_chunk_ids` は全件埋まったままなので pending=0 となり、`yomu index` が stale embedding を黙って保持し続ける。本 PR は index 時にモデル識別子を `index_meta` と照合し、不一致なら全 embedding を破棄して再 embed する。

## 設計

| 要素 | 内容 |
| --- | --- |
| 識別子 | `format!("{:?}", ModelId::DEFAULT)` = `"RuriV3_310m"` (variant 名)。rurico の HF repo id は private trait 配下で到達不能のため |
| 保存先 | 既存 `index_meta` (key/value) に `embed_model_id` キー。schema 変更なし |
| 検知位置 | `embed_pending()` 冒頭 — pending 計算より前 (後だと pending=0 で即 return し検知に到達しない) |
| swap 時 | `ensure_loadable` (新モデルのロード確認) が成功した場合のみ `clear_all_embeddings` → meta 更新。モデル不在なら既存 embedding を保持してエラー |
| 未記録 DB | 現 id を記録するのみ (既存ユーザーに re-embed を課さない寛容互換) |
| 冪等性 | clear → set は別文。間で中断しても次回再検知して継続 |

## 検出境界 (この PR が検知**しない**もの)

1. **同次元 swap は現行ラインナップに存在しない**: ModelId 各 variant の次元は全て異なるため、現時点では次元チェック (既存) で全 swap が検知できる。本 PR は将来の同次元モデル追加・`DEFAULT` 変更に備える forward-looking infra
2. **同名 weight 更新は非検知**: variant 名をキーにするため、同じ `RuriV3_310m` のまま weight が更新されるケースは検知しない (HF revision まで追う必要があり、rurico 側 API 拡張が前提)
3. **検知は index 時のみ**: swap 後 `yomu index` を実行するまで、search/brief は stale embedding を返し続ける。search 時検知は query path への DB write 混入となるため見送り

## テスト

| T-ID | 検証内容 |
| --- | --- |
| T-747 | `index_meta` get/set roundtrip |
| T-748 | `clear_all_embeddings` が vec_chunks (vec0) と embedded_chunk_ids を空にする |
| T-749 | 初回 run で現 id を記録 (re-embed なし) |
| T-750 | id 一致時は no-op |
| T-751 | **swap + モデル不在時は embedding/meta を不変に保つ** (advisor must-fix) |
| T-752 | swap 時に stale を clear し meta を更新 |
| T-753 | (cli_integration) 実バイナリで swap 検知 → stderr 通知 → 全 re-embed → meta 復帰 |
| T-754 | (cli_integration) swap + `YOMU_TEST_EMBEDDER=unavailable` で失敗し embedding/meta 不変 |

## 検証

- 全テスト green: 688 lib + 60 cli_integration ほか
- clippy clean (両 cfg: default / test-support)
- diff-cover 97% (gate 95%): 未カバーは `index_meta` SQL エラー伝播 arm 2 行のみ
- 実機 e2e: vendor/amici で fake id 注入 → `Embedding model changed (fake-old-model -> RuriV3_310m)` → 378 chunks 実 re-embed → 再実行 no-op (0.05s) → status 100% 復元