### PR TITLE
feat(resolver): TS path 解決の残ギャップ 3 件を解消 (baseUrl-only / multi-target / 絶対 baseUrl) (#233)

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -14,20 +14,35 @@ pub struct PathAlias {
     pub target: String,
 }
 
+/// tsconfig path-resolution inputs: `paths` aliases plus the explicit
+/// `baseUrl` (None when tsconfig omits it — bare specifiers then stay npm
+/// packages; `paths` target composition separately defaults to ".").
+#[derive(Debug, Default, PartialEq)]
+pub struct TsPathConfig {
+    pub aliases: Vec<PathAlias>,
+    pub base_url: Option<String>,
+}
+
 pub struct Resolver {
     root: PathBuf,
     canonical_root: Option<PathBuf>,
     aliases: Vec<PathAlias>,
+    base_url: Option<String>,
 }
 
 impl Resolver {
-    fn apply_alias(&self, source: &str) -> Option<String> {
-        for alias in &self.aliases {
-            if let Some(rest) = source.strip_prefix(&alias.prefix) {
-                return Some(format!("./{}{}", alias.target, rest));
-            }
-        }
-        None
+    /// All alias rewrites whose prefix matches `source`, in declaration order.
+    /// Multiple candidates arise from multi-target `paths` values (#233) and
+    /// from distinct alias keys sharing a matching prefix.
+    fn alias_candidates(&self, source: &str) -> Vec<String> {
+        self.aliases
+            .iter()
+            .filter_map(|alias| {
+                source
+                    .strip_prefix(&alias.prefix)
+                    .map(|rest| format!("./{}{}", alias.target, rest))
+            })
+            .collect()
     }
 
     fn to_relative(&self, abs: &Path) -> Option<String> {
@@ -63,31 +78,39 @@ impl Resolver {
 
     pub fn new(root: &Path) -> Self {
         let canonical_root = fs_optional::canonicalize_optional(root);
+        let config = load_path_config(root);
         Self {
             root: root.to_path_buf(),
             canonical_root,
-            aliases: load_aliases(root),
+            aliases: config.aliases,
+            base_url: config.base_url,
         }
     }
 
     /// Returns None for bare specifiers (npm packages) or unresolvable paths.
     pub fn resolve(&self, source: &str, from_file: &str) -> Option<String> {
-        let resolved_source = self.apply_alias(source);
-        let source = resolved_source.as_deref().unwrap_or(source);
-
-        if !source.starts_with('.') && !source.starts_with('/') && resolved_source.is_none() {
-            return None;
+        // tsconfig `paths` first: probe each matching alias target in
+        // declaration order, first existing file wins (TypeScript tries the
+        // substitutions in order). A matched prefix whose targets all miss
+        // resolves to None without falling through to baseUrl below.
+        let alias_candidates = self.alias_candidates(source);
+        if !alias_candidates.is_empty() {
+            return alias_candidates
+                .iter()
+                .find_map(|candidate| self.probe_path(&self.root.join(candidate)));
         }
 
-        let base_dir = if resolved_source.is_some() {
-            self.root.clone()
-        } else {
+        if source.starts_with('.') || source.starts_with('/') {
             let from_abs = self.root.join(from_file);
-            from_abs.parent()?.to_path_buf()
-        };
+            let base_dir = from_abs.parent()?;
+            return self.probe_path(&base_dir.join(source));
+        }
 
-        let candidate = base_dir.join(source);
-        self.probe_path(&candidate)
+        // Bare specifier: with an explicit `baseUrl`, TypeScript resolves
+        // non-relative imports against it before node_modules (#233). No
+        // explicit baseUrl (or no file there) → npm package, not ours.
+        let base_url = self.base_url.as_deref()?;
+        self.probe_path(&self.root.join(base_url).join(source))
     }
 }
 
@@ -127,14 +150,14 @@ pub fn to_relative_path(abs: &Path, root: &Path, canonical_root: Option<&Path>) 
     })
 }
 
-pub fn load_aliases(root: &Path) -> Vec<PathAlias> {
+pub fn load_path_config(root: &Path) -> TsPathConfig {
     let tsconfig_path = root.join("tsconfig.json");
     let content = match fs::read_to_string(&tsconfig_path) {
         Ok(c) => c,
-        Err(e) if e.kind() == io::ErrorKind::NotFound => return vec![],
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return TsPathConfig::default(),
         Err(e) => {
             tracing::warn!(path = %tsconfig_path.display(), error = %e, "Failed to read tsconfig.json");
-            return vec![];
+            return TsPathConfig::default();
         }
     };
 
@@ -142,43 +165,65 @@ pub fn load_aliases(root: &Path) -> Vec<PathAlias> {
         Ok(v) => v,
         Err(e) => {
             tracing::warn!(path = %tsconfig_path.display(), error = %e, "Failed to parse tsconfig.json");
-            return vec![];
+            return TsPathConfig::default();
         }
     };
 
     let compiler_options = match json.get("compilerOptions") {
         Some(co) => co,
-        None => return vec![],
+        None => return TsPathConfig::default(),
+    };
+
+    let explicit_base_url = compiler_options.get("baseUrl").and_then(|b| b.as_str());
+
+    // An absolute baseUrl either escapes the project root (never indexed) or
+    // would fold into a bogus root-relative path via compose_alias_target
+    // (`/abs` → `.//abs`). Disable tsconfig path resolution entirely (#233).
+    if let Some(base) = explicit_base_url
+        && base.starts_with('/')
+    {
+        tracing::warn!(base_url = base, path = %tsconfig_path.display(), "absolute baseUrl is unsupported; ignoring tsconfig paths/baseUrl");
+        return TsPathConfig::default();
+    }
+
+    let base_url_owned = explicit_base_url.map(str::to_owned);
+
+    let Some(paths) = compiler_options.get("paths").and_then(|p| p.as_object()) else {
+        return TsPathConfig {
+            aliases: Vec::new(),
+            base_url: base_url_owned,
+        };
     };
 
     // TypeScript resolves `paths` targets relative to `baseUrl` (which defaults
     // to "." when omitted). Without folding `baseUrl` in, an alias like
     // `{ "baseUrl": "src", "paths": { "@/*": ["*"] } }` resolves to the repo root
     // instead of `src/`, dropping the target from the forward closure.
-    let base_url = compiler_options
-        .get("baseUrl")
-        .and_then(|b| b.as_str())
-        .unwrap_or(".");
+    let base_url = explicit_base_url.unwrap_or(".");
 
-    let paths = match compiler_options.get("paths").and_then(|p| p.as_object()) {
-        Some(p) => p,
-        None => return vec![],
-    };
-
-    paths
+    let aliases = paths
         .iter()
         .filter_map(|(key, value)| {
-            // key: "@/*", value: ["*"] (relative to baseUrl) or ["src/*"]
-            let prefix = key.strip_suffix('*')?;
-            let target_arr = value.as_array()?;
-            let target_str = target_arr.first()?.as_str()?;
-            let raw_target = target_str.strip_suffix('*')?;
-            Some(PathAlias {
-                prefix: prefix.to_owned(),
-                target: compose_alias_target(base_url, raw_target),
+            // key: "@/*", value: ["*"] (relative to baseUrl) or ["src/*", "lib/*"]
+            Some((key.strip_suffix('*')?, value.as_array()?))
+        })
+        .flat_map(|(prefix, targets)| {
+            // Keep every wildcard target: TypeScript probes the substitutions
+            // in order until one exists (#233).
+            targets.iter().filter_map(move |target| {
+                let raw_target = target.as_str()?.strip_suffix('*')?;
+                Some(PathAlias {
+                    prefix: prefix.to_owned(),
+                    target: compose_alias_target(base_url, raw_target),
+                })
             })
         })
-        .collect()
+        .collect();
+
+    TsPathConfig {
+        aliases,
+        base_url: base_url_owned,
+    }
 }
 
 /// Prefix a tsconfig `paths` target with `base_url` (TypeScript resolves `paths`

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -114,7 +114,7 @@ fn load_aliases_from_tsconfig() {
         }"#;
     fs::write(tmp.path().join("tsconfig.json"), tsconfig).unwrap();
 
-    let aliases = load_aliases(tmp.path());
+    let aliases = load_path_config(tmp.path()).aliases;
     assert_eq!(
         aliases,
         vec![PathAlias {
@@ -141,7 +141,7 @@ fn load_aliases_with_baseurl() {
         }"#;
     fs::write(tmp.path().join("tsconfig.json"), tsconfig).unwrap();
 
-    let aliases = load_aliases(tmp.path());
+    let aliases = load_path_config(tmp.path()).aliases;
     assert_eq!(
         aliases,
         vec![PathAlias {
@@ -180,7 +180,7 @@ fn compose_alias_target_variants() {
 fn load_aliases_no_compiler_options() {
     let tmp = tempdir().unwrap();
     fs::write(tmp.path().join("tsconfig.json"), "{}").unwrap();
-    assert!(load_aliases(tmp.path()).is_empty());
+    assert!(load_path_config(tmp.path()).aliases.is_empty());
 }
 
 // T-332: load_aliases_no_tsconfig
@@ -188,7 +188,7 @@ fn load_aliases_no_compiler_options() {
 fn load_aliases_no_tsconfig() {
     let tmp = tempdir().unwrap();
 
-    let aliases = load_aliases(tmp.path());
+    let aliases = load_path_config(tmp.path()).aliases;
     assert!(aliases.is_empty());
 }
 
@@ -296,7 +296,7 @@ fn load_aliases_multiple() {
         }"#;
     fs::write(tmp.path().join("tsconfig.json"), tsconfig).unwrap();
 
-    let aliases = load_aliases(tmp.path());
+    let aliases = load_path_config(tmp.path()).aliases;
     assert_eq!(aliases.len(), 2);
     assert!(aliases.contains(&PathAlias {
         prefix: "@/".to_owned(),
@@ -407,4 +407,233 @@ fn resolve_html_file() {
     let resolver = Resolver::new(tmp.path());
     let result = resolver.resolve("./template.html", "src/App.tsx");
     assert_eq!(result, Some("src/template.html".to_owned()));
+}
+
+// T-755: load_path_config_multi_target_paths
+// A multi-target `paths` value (`["src/*", "lib/*"]`) yields one PathAlias per
+// target in declaration order (#233: previously only `first()` was kept).
+#[test]
+fn load_path_config_multi_target_paths() {
+    let tmp = tempdir().unwrap();
+    let tsconfig = r#"{
+            "compilerOptions": {
+                "paths": {
+                    "@/*": ["src/*", "lib/*"]
+                }
+            }
+        }"#;
+    fs::write(tmp.path().join("tsconfig.json"), tsconfig).unwrap();
+
+    let config = load_path_config(tmp.path());
+    assert_eq!(
+        config.aliases,
+        vec![
+            PathAlias {
+                prefix: "@/".to_owned(),
+                target: "src/".to_owned(),
+            },
+            PathAlias {
+                prefix: "@/".to_owned(),
+                target: "lib/".to_owned(),
+            },
+        ]
+    );
+}
+
+// T-756: resolve_alias_second_target_wins_when_first_missing
+// TypeScript probes `paths` substitutions in order: a file absent under the
+// first target but present under the second resolves via the second.
+#[test]
+fn resolve_alias_second_target_wins_when_first_missing() {
+    let tmp = tempdir().unwrap();
+    let lib = tmp.path().join("lib");
+    fs::create_dir_all(&lib).unwrap();
+    fs::write(lib.join("auth.ts"), "").unwrap();
+
+    let tsconfig = r#"{
+            "compilerOptions": {
+                "paths": {
+                    "@/*": ["src/*", "lib/*"]
+                }
+            }
+        }"#;
+    fs::write(tmp.path().join("tsconfig.json"), tsconfig).unwrap();
+
+    let resolver = Resolver::new(tmp.path());
+    let result = resolver.resolve("@/auth", "src/App.tsx");
+    assert_eq!(result, Some("lib/auth.ts".to_owned()));
+}
+
+// T-757: resolve_alias_first_target_wins_when_both_exist
+// When a file exists under both targets, declaration order decides.
+#[test]
+fn resolve_alias_first_target_wins_when_both_exist() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let lib = tmp.path().join("lib");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&lib).unwrap();
+    fs::write(src.join("auth.ts"), "").unwrap();
+    fs::write(lib.join("auth.ts"), "").unwrap();
+
+    let tsconfig = r#"{
+            "compilerOptions": {
+                "paths": {
+                    "@/*": ["src/*", "lib/*"]
+                }
+            }
+        }"#;
+    fs::write(tmp.path().join("tsconfig.json"), tsconfig).unwrap();
+
+    let resolver = Resolver::new(tmp.path());
+    let result = resolver.resolve("@/auth", "src/App.tsx");
+    assert_eq!(result, Some("src/auth.ts".to_owned()));
+}
+
+// T-758: resolve_bare_specifier_with_baseurl
+// `{ "baseUrl": "src" }` without `paths`: a bare specifier resolves relative
+// to baseUrl (#233: previously dropped as an npm package).
+#[test]
+fn resolve_bare_specifier_with_baseurl() {
+    let tmp = tempdir().unwrap();
+    let util = tmp.path().join("src").join("util");
+    fs::create_dir_all(&util).unwrap();
+    fs::write(util.join("format.ts"), "").unwrap();
+
+    let tsconfig = r#"{
+            "compilerOptions": {
+                "baseUrl": "src"
+            }
+        }"#;
+    fs::write(tmp.path().join("tsconfig.json"), tsconfig).unwrap();
+
+    let resolver = Resolver::new(tmp.path());
+    let result = resolver.resolve("util/format", "src/App.tsx");
+    assert_eq!(result, Some("src/util/format.ts".to_owned()));
+}
+
+// T-759: resolve_bare_specifier_with_dot_baseurl
+// An explicit `"baseUrl": "."` (the CRA / Next.js absolute-import form)
+// resolves bare specifiers from the project root.
+#[test]
+fn resolve_bare_specifier_with_dot_baseurl() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("util.ts"), "").unwrap();
+
+    let tsconfig = r#"{
+            "compilerOptions": {
+                "baseUrl": "."
+            }
+        }"#;
+    fs::write(tmp.path().join("tsconfig.json"), tsconfig).unwrap();
+
+    let resolver = Resolver::new(tmp.path());
+    let result = resolver.resolve("src/util", "src/App.tsx");
+    assert_eq!(result, Some("src/util.ts".to_owned()));
+}
+
+// T-760: resolve_bare_specifier_missing_with_baseurl_returns_none
+// With baseUrl set, a bare specifier with no file underneath stays an npm
+// package (None) instead of misresolving.
+#[test]
+fn resolve_bare_specifier_missing_with_baseurl_returns_none() {
+    let tmp = tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("src")).unwrap();
+
+    let tsconfig = r#"{
+            "compilerOptions": {
+                "baseUrl": "src"
+            }
+        }"#;
+    fs::write(tmp.path().join("tsconfig.json"), tsconfig).unwrap();
+
+    let resolver = Resolver::new(tmp.path());
+    let result = resolver.resolve("react", "src/App.tsx");
+    assert_eq!(result, None);
+}
+
+// T-761: load_path_config_absolute_baseurl_disabled
+// An absolute baseUrl disables tsconfig path resolution entirely: targets
+// outside the root are never indexed, and folding `/abs` into a root-relative
+// path would misresolve (#233).
+#[test]
+fn load_path_config_absolute_baseurl_disabled() {
+    let tmp = tempdir().unwrap();
+    let tsconfig = r#"{
+            "compilerOptions": {
+                "baseUrl": "/abs",
+                "paths": {
+                    "@/*": ["*"]
+                }
+            }
+        }"#;
+    fs::write(tmp.path().join("tsconfig.json"), tsconfig).unwrap();
+
+    assert_eq!(load_path_config(tmp.path()), TsPathConfig::default());
+}
+
+// T-762: resolve_absolute_baseurl_does_not_misresolve_to_root_subdir
+// Guards the #233 misresolution: with `"baseUrl": "/abs"`, an alias must not
+// fold into the root-relative `abs/` directory even when a matching file
+// exists there.
+#[test]
+fn resolve_absolute_baseurl_does_not_misresolve_to_root_subdir() {
+    let tmp = tempdir().unwrap();
+    let abs_dir = tmp.path().join("abs").join("lib");
+    fs::create_dir_all(&abs_dir).unwrap();
+    fs::write(abs_dir.join("auth.ts"), "").unwrap();
+
+    let tsconfig = r#"{
+            "compilerOptions": {
+                "baseUrl": "/abs",
+                "paths": {
+                    "@/*": ["*"]
+                }
+            }
+        }"#;
+    fs::write(tmp.path().join("tsconfig.json"), tsconfig).unwrap();
+
+    let resolver = Resolver::new(tmp.path());
+    let result = resolver.resolve("@/lib/auth", "src/App.tsx");
+    assert_eq!(result, None);
+}
+
+// T-763: resolve_alias_all_targets_missing_returns_none
+// A matched alias prefix whose targets all miss resolves to None without
+// falling through to the baseUrl bare-specifier route.
+#[test]
+fn resolve_alias_all_targets_missing_returns_none() {
+    let tmp = tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("src")).unwrap();
+
+    let tsconfig = r#"{
+            "compilerOptions": {
+                "baseUrl": ".",
+                "paths": {
+                    "@/*": ["src/*", "lib/*"]
+                }
+            }
+        }"#;
+    fs::write(tmp.path().join("tsconfig.json"), tsconfig).unwrap();
+
+    let resolver = Resolver::new(tmp.path());
+    let result = resolver.resolve("@/missing", "src/App.tsx");
+    assert_eq!(result, None);
+}
+
+// T-764: load_path_config_malformed_json_returns_default
+// A tsconfig that serde_json cannot parse (e.g. the common JSONC comment
+// form) disables path resolution without panicking.
+#[test]
+fn load_path_config_malformed_json_returns_default() {
+    let tmp = tempdir().unwrap();
+    let tsconfig = r#"{
+            // JSONC comment: serde_json rejects this
+            "compilerOptions": { "baseUrl": "src" }
+        }"#;
+    fs::write(tmp.path().join("tsconfig.json"), tsconfig).unwrap();
+
+    assert_eq!(load_path_config(tmp.path()), TsPathConfig::default());
 }


### PR DESCRIPTION
## 概要

Closes #233

#127 (brief Phase 2) で分離された TS path 解決の残ギャップ 3 件を解消する。いずれも forward closure からの欠落・誤解決に直結する resolver の挙動。

## 修正したギャップ

| # | ギャップ | 修正 |
| --- | --- | --- |
| 1 | baseUrl-only 非相対 import: `{ "baseUrl": "src" }` のみの構成で `import "util/x"` が npm package 扱いになり closure から欠落 | bare specifier を明示 baseUrl 起点で probe する fallback を `resolve()` 末尾に追加。**tsconfig が baseUrl を明示した場合のみ**発火 (TS 仕様準拠)。`"baseUrl": "."` 明示 (CRA / Next.js の absolute import 形) も対象 |
| 2 | multi-target paths: `{ "@/*": ["src/*", "lib/*"] }` の 2 番目以降が無視 (`first()` のみ採用) | target ごとに PathAlias を展開し、`alias_candidates()` が宣言順の全候補を返して最初の存在解で確定 (TS の substitution probe 順序準拠) |
| 3 | 絶対パス baseUrl: `"baseUrl": "/abs"` が `trim_start_matches("./")` をすり抜け root-relative の `abs/` に誤畳み込み | `/` 始まりの baseUrl は warn して tsconfig path 解決を全無効化。root 外は index 対象外なので解決しても closure に入らず、誤解決の防止が正しい挙動 |

## 設計

- `load_aliases` → `load_path_config`: 戻り値を `TsPathConfig { aliases, base_url }` に変更。`base_url` は明示時のみ `Some` (paths target 合成のデフォルト "." とは別概念として分離)
- `apply_alias` (最初の prefix マッチのみ) → `alias_candidates` (マッチ全候補) + `find_map` で probe
- alias マッチ + 全 target miss は **None のまま** (baseUrl への fallthrough をしない、T-763 で固定)

## 非対応 (意識的なスコープ外)

1. **jsconfig.json は読まない** — 既存から tsconfig.json のみ (pre-existing)
2. **Windows 絶対パス** (`C:\...`) は `starts_with('/')` で検知されない — darwin/Linux 前提のツールなので妥当
3. **競合する alias key は宣言順** — TS の longest-prefix-match とは異なる (pre-existing)。なお本 PR で「最初の prefix がマッチして miss した場合に 2 番目の prefix で解決する」ようになった (従来は None)。single-target alias では挙動同一で、multi-target の意図と整合する改善
4. **JSONC (コメント付き tsconfig)** は parse 失敗 → path 解決無効 (pre-existing、T-764 で panic しないことを固定)

## テスト

| T-ID | 検証内容 |
| --- | --- |
| T-755 | multi-target が宣言順に全展開される |
| T-756 | 1 番目の target に無く 2 番目に有る → 2 番目で解決 |
| T-757 | 両方に有る → 宣言順で 1 番目が優先 |
| T-758 | `{ baseUrl: "src" }` の bare specifier が解決される |
| T-759 | `{ baseUrl: "." }` 明示 (CRA/Next 形) で root 起点解決 |
| T-760 | baseUrl 配下に無い bare ("react") は None のまま |
| T-761 | 絶対 baseUrl は config 全体が default に落ちる |
| T-762 | 絶対 baseUrl で root 直下 `abs/` への誤解決が起きない |
| T-763 | alias 全 target miss は baseUrl に fallthrough せず None |
| T-764 | JSONC parse 失敗は panic せず default |

## 検証

- resolver 既存 23 テスト回帰なし + 新規 10 本 green
- 全テスト green: 697 lib + 60 cli_integration ほか (forward closure 統合 = chunk_only.rs 経由も exercised)
- clippy clean (両 cfg: default / test-support)
- diff-cover 98% (gate 95%): 未カバーは tsconfig read 失敗 (permission 系) の defensive arm 1 行のみ