### PR TITLE
chore(release): バージョンを 0.17.0 に更新

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "yomu"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "amici",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 
 [package]
 name = "yomu"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 rust-version = "1.96"
 description = "Frontend code search for AI agents"


### PR DESCRIPTION
## 概要

v0.17.0 リリースのための version bump (Cargo.toml / Cargo.lock)。

## v0.16.0 からの変更

| PR | 種別 | 内容 |
| --- | --- | --- |
| #309 | feat | 同次元モデル差し替え時の stale embedding を検知し全 re-embed (#230) |
| #310 | feat | TS path 解決の残ギャップ 3 件 (baseUrl-only / multi-target / 絶対 baseUrl) (#233) |
| #308 | fix | homebrew formula の sha256 を release asset から計算し fail-fast 化 (#307) |

feat ×2 のため minor bump。

## リリース手順 (merge 後)

1. main を pull し HEAD に `v0.17.0` タグを付与して push
2. release.yml (tag trigger) が build → release asset → update-homebrew を実行
3. **#307 修正の初実走**: update-homebrew job で formula の sha256 が 64hex で入ることを確認する