### PR TITLE
docs(deps): amici/rurico の rev lockstep 制約を Cargo.toml コメントに明文化

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,14 @@ repository = "https://github.com/thkt/yomu"
 test-support = ["rurico/test-support"]
 
 [dependencies]
+# amici pins its own rurico rev; a git source resolves to one rev across the
+# dependency graph, so the rurico rev below must match the one amici pins or
+# the build breaks on the rev conflict. When bumping amici, align rurico to it.
 amici = { git = "https://github.com/thkt/amici", rev = "5f4ee12" }
 bytemuck = "1"
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4"
+# Keep in lockstep with the rurico rev amici pins (see the amici note above).
 rurico = { git = "https://github.com/thkt/rurico", rev = "adbe3a8" }
 regex = "1"
 rusqlite = { version = "0.40", features = ["bundled"] }


### PR DESCRIPTION
## 概要

`/audit-adr-gaps` (report: docs/audit/2026-06-07-141921-adr-gaps.md、本 PR コメントに転記) の follow-up 4 件のうち、tracked 変更は本 PR の Cargo.toml コメント追加のみ。残り 3 件は gitignored な docs/ 配下のため、本 PR のコメントに本文を転記して永続化する。

| #   | Audit ID | 対応              | 成果物                                                                  |
| --- | -------- | ----------------- | ----------------------------------------------------------------------- |
| 1   | C2       | コメント強化      | **本 PR**: Cargo.toml amici 行上に lockstep 3 行 + rurico 行 cross-ref |
| 2   | C1+C5    | ADR 0007 起案     | docs/adr/0007 (gitignored) → PR コメント転記                            |
| 3   | C3       | ADR 0008 起案     | docs/adr/0008 (gitignored) → PR コメント転記                            |
| 4   | C4       | doc bug-fix       | docs/adr/README.md External ADRs 表に 0060 行追加 (gitignored)          |

## C2: なぜ ADR でなくコメントか

critic-design の challenge で downgrade 判定。lockstep は保存すべき invariant ではなく Cargo の同一 git source 制約 (1 rev に解決) から従う運用ノウハウで、ズレるとビルドが必ず止まるため silent でない。不足していたのは「なぜ壊れるか・どう直すか」の診断情報のみで、rev 値を ADR に書くと statement-of-fact の二重化で drift リスクになる。依存宣言の直上が正しい置き場 (crates/recall-bench/Cargo.toml:13 の同型コメントが precedent)。

## 検証

- [x] `cargo metadata` パース成功 (コメントが TOML を壊していない)
- [x] 変更はコメントのみ、依存解決に影響なし