### PR TITLE
docs(verify): 削除済み verify_standalone への dangling doc 参照を除去

### DIFF
--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,8 +1,8 @@
 //! Precision/recall measurement for the injection matcher.
 //!
-//! Pure (no I/O). The caller (`tools::Yomu::verify_standalone` for CLI,
-//! `tests/verification.rs` for the gate) is responsible for loading the
-//! bundled corpora and assembling `PositiveCase` / `NegativeCase` lists.
+//! Pure (no I/O). The caller (`tests/verification.rs`, the gate) is
+//! responsible for loading the bundled corpora and assembling
+//! `PositiveCase` / `NegativeCase` lists.
 //!
 //! ADR-0069 contract: `precision >= 0.90 && recall >= 0.95 && !degraded`.
 //! Both denominators are kept structurally non-zero (BR-401):
@@ -15,9 +15,9 @@ use serde::Serialize;
 use crate::indexer::injection::{Corpus, CorpusEntry, NegativeEntry};
 use crate::injection_check::InjectionCheck;
 
-/// Single source for the corpus fixture path. Imported by `Yomu::verify_standalone`,
-/// `tests/verification.rs`, and `src/indexer/injection/tests.rs` so a future
-/// fixture move requires a single edit.
+/// Single source for the corpus fixture path. Imported by `tests/verification.rs`
+/// and `src/indexer/injection/tests.rs` so a future fixture move requires a
+/// single edit.
 pub const BUNDLED_CORPUS_YAML: &str = include_str!("../tests/fixtures/injection/corpus.yaml");
 pub const BUNDLED_NEGATIVE_YAML: &str =
     include_str!("../tests/fixtures/injection/corpus.negative.yaml");


### PR DESCRIPTION
## 概要

ADR-0005 (PR #249) で削除した `Yomu::verify_standalone` への dangling doc 参照を `src/verify.rs` から除去する。/audit-adr-drift (2026-06-08) の L finding。

## 変更

- module doc (`:3`) と `BUNDLED_CORPUS_YAML` の doc (`:18`) が `verify_standalone` を現存するかのように参照していた箇所を、実際の caller (gate = `tests/verification.rs`) / importer (`tests/verification.rs`, `src/indexer/injection/tests.rs`) に合わせる
- `ADR-0069` / `BR-401` / `FR-403f` / `T-425` の参照は実在する local artifact のため不変 (reviewer-rust 確認済み)
- 振る舞い変化なし (doc コメントのみ)。`cargo check` 緑

## 関連: /audit-adr-drift の他 findings

`docs/` は gitignored のため、ADR への drift correction はローカル `docs/adr/` に追記済み (git/PR には乗らない)。記録として列挙する。

- H (別 issue #316): ADR-0003 parent-heading lineage 未実装 + Confirmation falsified (tests T-576〜T-580 / e2e / 695 tests green が現実と不一致)
- M: ADR-0001 FTS base score 式の記録誤り (実装 `abs/(1+abs)` が正、bm25 negative-better)、ADR-0002 stale embedding 検知が #230/#309 で解消済み (帰結の陳腐化、前提は真)
- L: ADR-0004 Amended-by 逆リンク、ADR-0005 ADR-0069 dangling 記述の陳腐化 + thin wrapper 単数記述、ADR-0006 from-file FTS intersection 拡張、ADR-0007 read-only scope (query log / migration-on-open) 明確化

監査レポート: ローカル `docs/audit/2026-06-07-174230-adr-drift.md` (reviewer-rust + reviewer-design 反証パス済み、findings 全 13 件 H2/M2/L9)
