### PR TITLE
docs: yomu 開発撤退を README に明記

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,6 +2,8 @@
 
 # yomu
 
+> **⚠️ アーカイブ済み (2026-06-08)** — yomu の grep+LLM エージェントに対する優位性は、検証可能な範囲 (整理された repo) で実証できませんでした (precision/recall/necessity いずれも同点または directional 止まり)。開発は撤退します。検証史 (#250 → #291 → #321 → necessity) と結論は [#291](https://github.com/thkt/yomu/issues/291) を参照。
+
 AIエージェント向けフロントエンドコード検索。名前がわからなくても、概念でコードを見つけられます。
 
 ## 課題

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # yomu
 
+> **⚠️ Archived (2026-06-08)** — yomu's advantage over a grep+LLM agent could not be demonstrated within the testable range (well-structured repos): precision/recall/necessity all came out at parity or directional-only. Development is retired. See the validation history (#250 → #291 → #321 → necessity) and conclusion in [#291](https://github.com/thkt/yomu/issues/291).
+
 Frontend code search for AI agents. Find code by concept when you don't know the name.
 
 ## The problem


### PR DESCRIPTION
## 変更

README.md / README.ja.md の冒頭に開発撤退バナーを追加。

## 背景

yomu の対 agent 価値 (grep+LLM エージェントに対する優位) は検証可能な範囲 (整理された repo) で実証できず、開発撤退を決定。

検証史: #250 (内部で embedding 必須) → #291 (near recall +0.05 directional・コスト減なし) → #321 (規模で precision 優位開かず) → necessity 追試 (整理 repo で grep を救えず、recall G=Y 同点)。

検証可能な全範囲で対 agent 価値 (precision/recall/necessity) を示せず、データに基づく合理的撤退。詳細は #291 の検証結論コメント参照。